### PR TITLE
Make FileInfo checksum generation optional

### DIFF
--- a/src/edu/harvard/hul/ois/fits/tools/oisfileinfo/FileInfo.java
+++ b/src/edu/harvard/hul/ois/fits/tools/oisfileinfo/FileInfo.java
@@ -75,13 +75,15 @@ public class FileInfo extends ToolBase {
 		size.setText(String.valueOf(file.length()));
 		fileInfo.addContent(size);		
 		//Calculate the MD5 checksum
-		try {
-			String md5Hash = MD5.asHex(MD5.getHash(new File(file.getPath())));
-			Element signature = new Element("md5checksum",fitsNS);
-			signature.setText(md5Hash);
-			fileInfo.addContent(signature);
-		} catch (IOException e) {
-			throw new FitsToolException("Could not calculate the MD5 for "+file.getPath(),e);
+		if (Fits.config.getBoolean("output.enable-checksum")) {
+			try {
+				String md5Hash = MD5.asHex(MD5.getHash(new File(file.getPath())));
+				Element signature = new Element("md5checksum",fitsNS);
+				signature.setText(md5Hash);
+				fileInfo.addContent(signature);
+			} catch (IOException e) {
+				throw new FitsToolException("Could not calculate the MD5 for "+file.getPath(),e);
+			}
 		}
 		//fslastmodified
 		Element fslastmodified = new Element("fslastmodified",fitsNS);

--- a/xml/fits.xml
+++ b/xml/fits.xml
@@ -26,6 +26,7 @@
 		<external-output-schema>http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd</external-output-schema>
 		<fits-xml-namespace>http://hul.harvard.edu/ois/xml/ns/fits/fits_output</fits-xml-namespace>
 		<enable-statistics>false</enable-statistics>
+		<enable-checksum>true</enable-checksum>
 	</output>
 	
 	<process>


### PR DESCRIPTION
In some environments FITS is being called on files with known checksums, whose checksums are being checked in other parts of the workflow. Since MD5 hash generation is fairly computationally expensive, it's a significant amount of extra CPU time to spend on metadata that might not be used.

This commit makes MD5 checksum generation optional, controlled by the option.enable-checksum parameter in the fits.xml file.
