### PR TITLE
Separate out FITS env; add Nailgun helper

### DIFF
--- a/fits-env.sh
+++ b/fits-env.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Sets up the environment for launching a FITS instance via
+# either the fits.sh launcher, or the fits-ngserver.sh Nailgun server
+
+#FITS_HOME=`dirname "$0"`
+FITS_HOME=`echo "$0" | sed 's,/[^/]*$,,'`
+export FITS_HOME
+
+# Uncomment the following line if you want "file utility" to dereference and follow symlinks.
+# export POSIXLY_CORRECT=1
+
+# concatenate args and use eval/exec to preserve spaces in paths, options and args
+args=""
+for arg in "$@" ; do
+	args="$args \"$arg\""
+done
+
+JCPATH=${FITS_HOME}/lib
+# Add on extra jar files to APPCLASSPATH
+for i in "$JCPATH"/*.jar; do
+	APPCLASSPATH="$APPCLASSPATH":"$i"
+done
+
+JCPATH=${FITS_HOME}/lib/droid
+# Add on extra jar files to APPCLASSPATH
+for i in "$JCPATH"/*.jar; do
+	APPCLASSPATH="$APPCLASSPATH":"$i"
+done
+
+JCPATH=${FITS_HOME}/lib/jhove
+# Add on extra jar files to APPCLASSPATH
+for i in "$JCPATH"/*.jar; do
+	APPCLASSPATH="$APPCLASSPATH":"$i"
+done
+
+JCPATH=${FITS_HOME}/lib/nzmetool
+# Add on extra jar files to APPCLASSPATH
+for i in "$JCPATH"/*.jar; do
+	APPCLASSPATH="$APPCLASSPATH":"$i"
+done
+
+JCPATH=${FITS_HOME}/lib/nzmetool/adapters
+# Add on extra jar files to APPCLASSPATH
+for i in "$JCPATH"/*.jar; do
+	APPCLASSPATH="$APPCLASSPATH":"$i"
+done
+
+APPCLASSPATH="$APPCLASSPATH":"$FITS_HOME/xml/nlnz"

--- a/fits-ngserver.sh
+++ b/fits-ngserver.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# This helper script launches a nailgun server with the FITS
+# classpath, making it simple to launch a persistent JVM for FITS.
+# 
+# The one required parameter is the path to nailgun's jar; it can also be
+# specified via the NAILGUN_JAR environment variable.
+
+. "$(dirname $BASH_SOURCE)/fits-env.sh"
+
+if [[ ! $NAILGUN_JAR ]] && [[ ! $1 ]]; then
+	echo "Error: Path to Nailgun JAR must be specified!" >&2
+	echo "Usage: fits-ngserver.sh [path-to-nailgun.jar]" >&2
+	echo "The path may also be specified via the NAILGUN_JAR environment variable." >&2
+	exit 64
+else
+	NAILGUN_JAR=$1
+fi
+
+cmd="java -classpath \"$APPCLASSPATH:$NAILGUN_JAR\" com.martiansoftware.nailgun.NGServer"
+
+echo "You may now run FITS by typing: ng edu.harvard.hul.ois.fits.Fits [options]" >&2
+
+eval "exec $cmd"

--- a/fits.sh
+++ b/fits.sh
@@ -1,48 +1,7 @@
 #!/bin/bash
 
-#FITS_HOME=`dirname "$0"`
-FITS_HOME=`echo "$0" | sed 's,/[^/]*$,,'`
-export FITS_HOME
+. "$(dirname $BASH_SOURCE)/fits-env.sh"
 
-# Uncomment the following line if you want "file utility" to dereference and follow symlinks.
-# export POSIXLY_CORRECT=1
-
-# concatenate args and use eval/exec to preserve spaces in paths, options and args
-args=""
-for arg in "$@" ; do
-	args="$args \"$arg\""
-done
-
-JCPATH=${FITS_HOME}/lib
-# Add on extra jar files to APPCLASSPATH
-for i in "$JCPATH"/*.jar; do
-	APPCLASSPATH="$APPCLASSPATH":"$i"
-done
-
-JCPATH=${FITS_HOME}/lib/droid
-# Add on extra jar files to APPCLASSPATH
-for i in "$JCPATH"/*.jar; do
-	APPCLASSPATH="$APPCLASSPATH":"$i"
-done
-
-JCPATH=${FITS_HOME}/lib/jhove
-# Add on extra jar files to APPCLASSPATH
-for i in "$JCPATH"/*.jar; do
-	APPCLASSPATH="$APPCLASSPATH":"$i"
-done
-
-JCPATH=${FITS_HOME}/lib/nzmetool
-# Add on extra jar files to APPCLASSPATH
-for i in "$JCPATH"/*.jar; do
-	APPCLASSPATH="$APPCLASSPATH":"$i"
-done
-
-JCPATH=${FITS_HOME}/lib/nzmetool/adapters
-# Add on extra jar files to APPCLASSPATH
-for i in "$JCPATH"/*.jar; do
-	APPCLASSPATH="$APPCLASSPATH":"$i"
-done
-
-cmd="java -classpath \"$APPCLASSPATH:$FITS_HOME/xml/nlnz\" edu.harvard.hul.ois.fits.Fits $args"
+cmd="java -classpath \"$APPCLASSPATH\" edu.harvard.hul.ois.fits.Fits $args"
 
 eval "exec $cmd"


### PR DESCRIPTION
Separates out the FITS classpath setup, which is fairly complex, into its own script which can be included in other scripts to set up a compatible environment.

Additionally adds a new startup script, fits-ngserver.sh, which starts up a [Nailgun](http://www.martiansoftware.com/nailgun/) server with the FITS classpath instead of launching FITS itself. This produces a persistent JVM to which future FITS instances can connect, reducing startup lag over multiple iterations. For environments where FITS may be called repeatedly over thousands of files, saving even one or two seconds per launch can save a significant amount of time in total.
