### PR TITLE
Avoid instantiating Fits class until necessary

### DIFF
--- a/src/edu/harvard/hul/ois/fits/Fits.java
+++ b/src/edu/harvard/hul/ois/fits/Fits.java
@@ -161,8 +161,6 @@ public class Fits {
 	}
 	
 	public static void main(String[] args) throws FitsException, IOException, ParseException, XMLStreamException {
-		Fits fits = new Fits();
-		
 		Options options = new Options();
 		options.addOption("i",true, "input file or directory");
 		options.addOption("r",false,"process directories recursively when -i is a directory ");
@@ -180,7 +178,7 @@ public class Fits {
 		CommandLine cmd = parser.parse(options, args);
 		
 		if(cmd.hasOption("h")) {
-			fits.printHelp(options);
+			printHelp(options);
 			System.exit(0);
 		}
 		if(cmd.hasOption("v")) {
@@ -203,16 +201,18 @@ public class Fits {
 				if(outputDir == null || !(new File(outputDir).isDirectory())) {
 					throw new FitsException("When FITS is run in directory processing mode the output location must be a diretory");
 				}
+				Fits fits = new Fits();
 				fits.doDirectory(inputFile,new File(outputDir),cmd.hasOption("x"),cmd.hasOption("xc"));
 			}
 			else {
+				Fits fits = new Fits();
 				FitsOutput result = fits.doSingleFile(inputFile);
 				fits.outputResults(result,cmd.getOptionValue("o"),cmd.hasOption("x"),cmd.hasOption("xc"),false);
 			}
 		}
 		else {
 			System.err.println("Invalid CLI options");
-			fits.printHelp(options);
+			printHelp(options);
 			System.exit(-1);
 		}
 	    
@@ -376,7 +376,7 @@ public class Fits {
 		}
 	}
 	
-	private void printHelp(Options opts) {
+	private static void printHelp(Options opts) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.printHelp("fits", opts );
 	}


### PR DESCRIPTION
The Fits class is relatively slow to load, and depending on the speed of the computer can take between 0.5s and 1s to instantiate. (It looks like most of this is happening in DROID's signature loading - upgrading to a new version of DROID would probably cut down a lot of startup time.)

On the other hand, this class isn't actually necessary until FITS needs to start processing. It looks like it was only being instantiated earlier for the sake of the printHelp() method, which didn't actually need access to the internal state of the Fits class.

This converts printHelp into a static function, then moves instantiation of the Fits class as late as possible. This ensures that the Fits class doesn't get instantiated when it's not being used, for instance if FITS is exiting without running any tools via the -h help option, or due to invalid commandline usage.

The difference is quite significant. With JVM lag removed (e.g., via a Nailgun server), `fits -h` can take as long as 10 seconds(!) to display its help text, with typical times at between 0.5s and 1s. With this patch, typical time to display help text is 0.08s - providing a much better user experience.
