### PR TITLE
Audio fixes

### DIFF
--- a/xml/exiftool/exiftool_xslt_map.xml
+++ b/xml/exiftool/exiftool_xslt_map.xml
@@ -109,6 +109,7 @@
 	<map format="LA" transform="exiftool_audio_to_fits.xslt"/>
 	<map format="M4A" transform="exiftool_audio_to_fits.xslt"/>
 	<map format="MP3" transform="exiftool_audio_to_fits.xslt"/>
+	<map format="M4A" transform="exiftool_audio_to_fits.xslt"/>
 	<map format="MPC" transform="exiftool_audio_to_fits.xslt"/>
 	<map format="OFR" transform="exiftool_audio_to_fits.xslt"/>
 	<map format="OGG" transform="exiftool_audio_to_fits.xslt"/>
@@ -138,7 +139,6 @@
 	<map format="M2T" transform="exiftool_video_to_fits.xslt"/>
 	<map format="M2TS" transform="exiftool_video_to_fits.xslt"/>
 	<map format="M2V" transform="exiftool_video_to_fits.xslt"/>
-	<map format="M4A" transform="exiftool_video_to_fits.xslt"/>
 	<map format="M4P" transform="exiftool_video_to_fits.xslt"/>
 	<map format="M4V" transform="exiftool_video_to_fits.xslt"/>
 	<map format="MKA" transform="exiftool_video_to_fits.xslt"/>

--- a/xml/fits_format_tree.xml
+++ b/xml/fits_format_tree.xml
@@ -35,7 +35,10 @@
 	</branch>
 	<branch format="ISO Media, MPEG v4 system, version 2">
 		<branch format="MPEG-4"/>
-	</branch>	
+	</branch>
+	<branch format="MXF">
+		<branch format="Material Exchange Format"/>
+	</branch>
 	<branch format="ZIP Format">
 		<branch format="OpenDocument"/>
 		<branch format="OpenDocument Text"/>


### PR DESCRIPTION
Fixes for the following tickets:

FITS-116 - FITS doesn't produce standard output for audio m4a files.
FITS-118 - Identification CONFLICT on processing .mxf file