### PR TITLE
Fix unit test expected output files

### DIFF
--- a/testfiles/output/FITS-SAMPLE-26_mov_Combined.xml
+++ b/testfiles/output/FITS-SAMPLE-26_mov_Combined.xml
@@ -163,7 +163,7 @@
     <tool toolname="Jhove" toolversion="1.5" executionTime="8423" />
     <tool toolname="file utility" toolversion="5.04" executionTime="1748" />
     <tool toolname="Exiftool" toolversion="9.13" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.4GA" executionTime="814" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.4GA" status="did not run" />
     <tool toolname="OIS File Information" toolversion="0.2" executionTime="1211" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="782" />

--- a/testfiles/output/FITS-SAMPLE-26_mov_FITS.xml
+++ b/testfiles/output/FITS-SAMPLE-26_mov_FITS.xml
@@ -78,7 +78,7 @@
     <tool toolname="Jhove" toolversion="1.5" executionTime="4308" />
     <tool toolname="file utility" toolversion="5.04" executionTime="650" />
     <tool toolname="Exiftool" toolversion="9.13" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.4GA" executionTime="536" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.4GA" status="did not run" />
     <tool toolname="OIS File Information" toolversion="0.2" executionTime="279" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="552" />

--- a/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1_mp4_Combined.xml
+++ b/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1_mp4_Combined.xml
@@ -152,7 +152,7 @@
     <tool toolname="Jhove" toolversion="1.5" executionTime="4868" />
     <tool toolname="file utility" toolversion="5.04" executionTime="1017" />
     <tool toolname="Exiftool" toolversion="9.13" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.4GA" executionTime="679" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.4GA" status="did not run" />
     <tool toolname="OIS File Information" toolversion="0.2" executionTime="610" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="690" />

--- a/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1_mp4_FITS.xml
+++ b/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1_mp4_FITS.xml
@@ -72,7 +72,7 @@
     <tool toolname="Jhove" toolversion="1.5" executionTime="4659" />
     <tool toolname="file utility" toolversion="5.04" executionTime="1001" />
     <tool toolname="Exiftool" toolversion="9.13" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.4GA" executionTime="745" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.4GA" status="did not run" />
     <tool toolname="OIS File Information" toolversion="0.2" executionTime="587" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="753" />

--- a/tests/edu/harvard/hul/ois/fits/junit/AudioStdSchemaTest.java
+++ b/tests/edu/harvard/hul/ois/fits/junit/AudioStdSchemaTest.java
@@ -35,7 +35,7 @@ import edu.harvard.hul.ois.ots.schemas.XmlContent.XmlContent;
 
 import org.custommonkey.xmlunit.*;
 
-public class audioStdSchemaTest extends XMLTestCase {
+public class AudioStdSchemaTest extends XMLTestCase {
 
     @Test  
 	public void testAudioMD() throws Exception {   


### PR DESCRIPTION
Modify expected test results now that .mov and .mp4 have not been added to the MetadataExtrator tool's include list in fits.xml after changing that tool's element from and 'exclude' to and 'include' attribute.