### PR TITLE
Revise call to instantiate AudioObject

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -9,6 +9,7 @@ Version 0.10.2
 - Update AES31.jar
 - Revised logic to properly handle video aspect ratio in ebucore.
 - Add additional MXF codecs for video validation (ots).
+- Revise call to instantiate AudioObject for AES generation due to revision in ots.jar for handling xsi namespace declaration during parsing.
 
 Version 0.10.1
 ----------------------

--- a/src/edu/harvard/hul/ois/fits/AESModel.java
+++ b/src/edu/harvard/hul/ois/fits/AESModel.java
@@ -68,7 +68,7 @@ public class AESModel {
     protected AESModel () throws XmlContentException {
     	
     	//set up base AES object structure    	
-        aes = new AudioObject ();
+        aes = new AudioObject (true);
         aes.setSchemaVersion("1.0.0");
         aes.setID(audioObjectID);
         aes.setDisposition("");


### PR DESCRIPTION
Revise call to instantiate AudioObject for AES generation due to revision in ots.jar for handling xsi namespace declaration during parsing.