### PR TITLE
fits scripts should resolve symlinks before loading relative paths

### DIFF
--- a/fits-env.sh
+++ b/fits-env.sh
@@ -3,8 +3,22 @@
 # Sets up the environment for launching a FITS instance via
 # either the fits.sh launcher, or the fits-ngserver.sh Nailgun server
 
-#FITS_HOME=`dirname "$0"`
-FITS_HOME=`echo "$0" | sed 's,/[^/]*$,,'`
+FITS_ENV_SCRIPT="$0"
+
+# Resolve symlinks to this script
+while [ -h "$FITS_ENV_SCRIPT" ] ; do
+  ls=`ls -ld "$FITS_ENV_SCRIPT"`
+  # Drop everything prior to ->
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    FITS_ENV_SCRIPT="$link"
+  else
+    FITS_ENV_SCRIPT=`dirname "$FITS_ENV_SCRIPT"`/"$link"
+  fi
+done
+
+FITS_HOME=`dirname $FITS_ENV_SCRIPT`
+
 export FITS_HOME
 
 # Uncomment the following line if you want "file utility" to dereference and follow symlinks.

--- a/fits.sh
+++ b/fits.sh
@@ -1,6 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-. "$(dirname $BASH_SOURCE)/fits-env.sh"
+FITS_SCRIPT="$0"
+
+# Resolve symlinks to this script
+while [ -h "$FITS_SCRIPT" ] ; do
+  ls=`ls -ld "$FITS_SCRIPT"`
+  # Drop everything prior to ->
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    FITS_SCRIPT="$link"
+  else
+    FITS_SCRIPT=`dirname "$FITS_SCRIPT"`/"$link"
+  fi
+done
+
+. "$(dirname $FITS_SCRIPT)/fits-env.sh"
 
 cmd="java -classpath \"$APPCLASSPATH\" edu.harvard.hul.ois.fits.Fits $args"
 


### PR DESCRIPTION
The current `fits.sh` and `fits-env.sh` scripts fail to correctly resolve relative paths when the scripts are behind a symlink. This patch resolves the symlink path to the file before setting e.g. `$FITS_HOME`.