### PR TITLE
Update JHOVE processing of fonts from PDF files.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xml/nlnz"/>
 	<classpathentry kind="src" path="tests"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/Java SE 7 [1.7.0_80]"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="lib-ant/junit-4.11.jar"/>
 	<classpathentry kind="lib" path="lib-ant/xmlunit-1.6.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>

--- a/src/edu/harvard/hul/ois/fits/Fits.java
+++ b/src/edu/harvard/hul/ois/fits/Fits.java
@@ -474,7 +474,7 @@ public class Fits {
     Transformer transformer = null;
 
     // initialize transformer for pretty print xslt
-    TransformerFactory tFactory = TransformerFactory.newInstance();
+    TransformerFactory tFactory = TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", null);
     String prettyPrintXslt = FITS_XML_DIR + "prettyprint.xslt";
     try {
       Templates template = tFactory.newTemplates( new StreamSource( prettyPrintXslt ) );

--- a/testfiles/output/Book_pdfx1a.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Book_pdfx1a.pdf_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/3/16 11:41 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/8/16 1:32 PM">
   <identification status="SINGLE_RESULT">
     <identity format="PDF/A" mimetype="application/pdf" toolname="FITS" toolversion="1.0.0">
       <tool toolname="Jhove" toolversion="1.11" />
@@ -15,7 +15,7 @@
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Book_pdfx1a.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Book_pdfx1a.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">2d4fc60b4498c7cb63a95d7d247f6160</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1456242101000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">true</well-formed>
@@ -29,43 +29,39 @@
       <hasAnnotations toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasAnnotations>
       <graphicsCount toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">21</graphicsCount>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>ANGADD+Verdana</fontName>
+        <fontName>MyriadPro-Regular</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>JYRCZL+MyriadPro-Regular-SC700</fontName>
+        <fontName>MyriadPro-Regular-SC700</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>OIJGRB+MyriadPro-Regular</fontName>
-      </font>
-      <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>OQHBRB+Verdana</fontName>
+        <fontName>Verdana</fontName>
       </font>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>8</docmd:PageCount>
           <docmd:GraphicsCount>21</docmd:GraphicsCount>
-          <docmd:Font FontName="ANGADD+Verdana" />
-          <docmd:Font FontName="JYRCZL+MyriadPro-Regular-SC700" />
-          <docmd:Font FontName="OIJGRB+MyriadPro-Regular" />
-          <docmd:Font FontName="OQHBRB+Verdana" />
+          <docmd:Font FontName="MyriadPro-Regular" />
+          <docmd:Font FontName="MyriadPro-Regular-SC700" />
+          <docmd:Font FontName="Verdana" />
         </docmd:document>
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="545">
+  <statistics fitsExecutionTime="763">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="19" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="541" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="48" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="183" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="58" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="5" />
+    <tool toolname="Droid" toolversion="6.1.5" executionTime="55" />
+    <tool toolname="Jhove" toolversion="1.11" executionTime="742" />
+    <tool toolname="file utility" toolversion="5.04" executionTime="115" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="254" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="97" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="13" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="5" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="53" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="26" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="293" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFA_Document with tables.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFA_Document with tables.pdf_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/3/16 11:37 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/8/16 1:29 PM">
   <identification>
     <identity format="PDF/A" mimetype="application/pdf" toolname="FITS" toolversion="1.0.0">
       <tool toolname="Droid" toolversion="6.1.5" />
@@ -19,7 +19,7 @@
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDFA_Document with tables.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFA_Document with tables.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">fd8c309140462d55d6a76e5e3ec709ee</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1460584552000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">true</well-formed>
@@ -27,7 +27,6 @@
   </filestatus>
   <metadata>
     <document>
-      <title toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">Zakuta, Vitaly</title>
       <author toolname="Jhove" toolversion="1.11">Zakuta, Vitaly</author>
       <language toolname="Jhove" toolversion="1.11">EN-US</language>
       <pageCount toolname="Jhove" toolversion="1.11">3</pageCount>
@@ -35,61 +34,61 @@
       <hasOutline toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasOutline>
       <hasAnnotations toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">yes</hasAnnotations>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>CERSLK+Calibri-Bold</fontName>
+        <fontName>ArialMT</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>CWOXLK+ArialUnicodeMS</fontName>
+        <fontName>ArialUnicodeMS</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>CWOXLK+Wingdings2</fontName>
+        <fontName>Calibri</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>JEFNFW+TimesNewRomanPSMT</fontName>
+        <fontName>Calibri-Bold</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>MLOFVQ+ArialMT</fontName>
+        <fontName>TimesNewRomanPS-BoldMT</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>NKDLJO+Wingdings-Regular</fontName>
+        <fontName>TimesNewRomanPSMT</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>QRRDZI+TimesNewRomanPS-BoldMT</fontName>
+        <fontName>Wingdings-Regular</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>WATNFW+Calibri</fontName>
+        <fontName>Wingdings2</fontName>
       </font>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>3</docmd:PageCount>
           <docmd:Language>EN-US</docmd:Language>
-          <docmd:Font FontName="CERSLK+Calibri-Bold" />
-          <docmd:Font FontName="CWOXLK+ArialUnicodeMS" />
-          <docmd:Font FontName="CWOXLK+Wingdings2" />
-          <docmd:Font FontName="JEFNFW+TimesNewRomanPSMT" />
-          <docmd:Font FontName="MLOFVQ+ArialMT" />
-          <docmd:Font FontName="NKDLJO+Wingdings-Regular" />
-          <docmd:Font FontName="QRRDZI+TimesNewRomanPS-BoldMT" />
-          <docmd:Font FontName="WATNFW+Calibri" />
+          <docmd:Font FontName="ArialMT" />
+          <docmd:Font FontName="ArialUnicodeMS" />
+          <docmd:Font FontName="Calibri" />
+          <docmd:Font FontName="Calibri-Bold" />
+          <docmd:Font FontName="TimesNewRomanPS-BoldMT" />
+          <docmd:Font FontName="TimesNewRomanPSMT" />
+          <docmd:Font FontName="Wingdings-Regular" />
+          <docmd:Font FontName="Wingdings2" />
           <docmd:Features>isTagged</docmd:Features>
           <docmd:Features>hasAnnotations</docmd:Features>
         </docmd:document>
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="155">
+  <statistics fitsExecutionTime="231">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="5" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="56" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="33" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="151" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="24" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="2" />
+    <tool toolname="Droid" toolversion="6.1.5" executionTime="24" />
+    <tool toolname="Jhove" toolversion="1.11" executionTime="152" />
+    <tool toolname="file utility" toolversion="5.04" executionTime="86" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="191" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="65" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="12" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="3" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="24" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="16" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="113" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDF_eng.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDF_eng.pdf_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/3/16 11:46 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/7/16 2:58 PM">
   <identification>
     <identity format="Portable Document Format" mimetype="application/pdf" toolname="FITS" toolversion="1.0.0">
       <tool toolname="Droid" toolversion="6.1.5" />
@@ -22,7 +22,7 @@
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDF_eng.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDF_eng.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">4ef7c6dd77d598fe8f60f84af8e4e7de</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1460584552000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">true</well-formed>
@@ -37,51 +37,51 @@
       <hasOutline toolname="Jhove" toolversion="1.11">no</hasOutline>
       <hasAnnotations toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasAnnotations>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>AODHFO+MetaNormal-Caps</fontName>
+        <fontName>HelveticaRounded-Bold</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>BINCNJ+MetaBold-Roman</fontName>
+        <fontName>MetaBold-Roman</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>BINCOL+MetaNormal-Roman</fontName>
+        <fontName>MetaNormal-Caps</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>BINCOM+MetaNormal-Italic</fontName>
+        <fontName>MetaNormal-Italic</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>BINDAO+HelveticaRounded-Bold</fontName>
+        <fontName>MetaNormal-Roman</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>BINDCB+MetaNormalLF-Italic</fontName>
+        <fontName>MetaNormalLF-Italic</fontName>
       </font>
       <hasForms toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">no</hasForms>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>32</docmd:PageCount>
-          <docmd:Font FontName="AODHFO+MetaNormal-Caps" />
-          <docmd:Font FontName="BINCNJ+MetaBold-Roman" />
-          <docmd:Font FontName="BINCOL+MetaNormal-Roman" />
-          <docmd:Font FontName="BINCOM+MetaNormal-Italic" />
-          <docmd:Font FontName="BINDAO+HelveticaRounded-Bold" />
-          <docmd:Font FontName="BINDCB+MetaNormalLF-Italic" />
+          <docmd:Font FontName="HelveticaRounded-Bold" />
+          <docmd:Font FontName="MetaBold-Roman" />
+          <docmd:Font FontName="MetaNormal-Caps" />
+          <docmd:Font FontName="MetaNormal-Italic" />
+          <docmd:Font FontName="MetaNormal-Roman" />
+          <docmd:Font FontName="MetaNormalLF-Italic" />
         </docmd:document>
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="183">
+  <statistics fitsExecutionTime="423">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="5" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="138" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="53" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="175" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="82" />
+    <tool toolname="Droid" toolversion="6.1.5" executionTime="8" />
+    <tool toolname="Jhove" toolversion="1.11" executionTime="391" />
+    <tool toolname="file utility" toolversion="5.04" executionTime="93" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="209" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="107" />
     <tool toolname="OIS File Information" toolversion="0.2" executionTime="1" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="5" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="67" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="13" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="98" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDF_equations.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDF_equations.pdf_XmlUnitExpectedOutput.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.11.0" timestamp="4/15/16 10:32 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/8/16 1:34 PM">
   <identification>
-    <identity format="Portable Document Format" mimetype="application/pdf" toolname="FITS" toolversion="0.11.0">
+    <identity format="Portable Document Format" mimetype="application/pdf" toolname="FITS" toolversion="1.0.0">
       <tool toolname="Droid" toolversion="6.1.5" />
       <tool toolname="Jhove" toolversion="1.11" />
       <tool toolname="file utility" toolversion="5.04" />
@@ -22,7 +22,7 @@
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDF_equations.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDF_equations.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1d359eacb0de890b2f36eec5224a923e</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1460584552000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">false</well-formed>
@@ -39,33 +39,33 @@
       <hasOutline toolname="Jhove" toolversion="1.11">no</hasOutline>
       <hasAnnotations toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasAnnotations>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>VYOESN+CambriaMath</fontName>
+        <fontName>CambriaMath</fontName>
       </font>
       <hasForms toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">no</hasForms>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>3</docmd:PageCount>
           <docmd:Language>EN-US</docmd:Language>
-          <docmd:Font FontName="VYOESN+CambriaMath" />
+          <docmd:Font FontName="CambriaMath" />
           <docmd:Features>isTagged</docmd:Features>
         </docmd:document>
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="238">
+  <statistics fitsExecutionTime="435">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="4" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="63" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="44" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="223" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="22" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="2" />
+    <tool toolname="Droid" toolversion="6.1.5" executionTime="16" />
+    <tool toolname="Jhove" toolversion="1.11" executionTime="213" />
+    <tool toolname="file utility" toolversion="5.04" executionTime="138" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="303" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="81" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="5" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="8" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="96" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="25" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="391" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFa_embedded_resources.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_embedded_resources.pdf_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/3/16 11:38 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/8/16 1:30 PM">
   <identification>
     <identity format="PDF/A" mimetype="application/pdf" toolname="FITS" toolversion="1.0.0">
       <tool toolname="Droid" toolversion="6.1.5" />
@@ -19,7 +19,7 @@
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDFa_embedded_resources.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_embedded_resources.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">12b6269615243b9a62cc9181796e76bd</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1460584552000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">true</well-formed>
@@ -34,22 +34,22 @@
       <hasAnnotations toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasAnnotations>
       <graphicsCount toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">433</graphicsCount>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>ILMKCK+Charlesworth-Normal</fontName>
+        <fontName>BauerBodoniBT-Bold</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>ILMKCL+BauerBodoniBT-Italic</fontName>
+        <fontName>BauerBodoniBT-BoldItalic</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>ILMKDM+BauerBodoniBT-Roman</fontName>
+        <fontName>BauerBodoniBT-Italic</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>ILMKFM+BauerBodoniBT-BoldItalic</fontName>
+        <fontName>BauerBodoniBT-Roman</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>ILMKFN+Charlesworth-Bold</fontName>
+        <fontName>Charlesworth-Bold</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>ILMKOK+BauerBodoniBT-Bold</fontName>
+        <fontName>Charlesworth-Normal</fontName>
       </font>
       <subject toolname="Exiftool" toolversion="10.00">booklet10</subject>
       <description toolname="Exiftool" toolversion="10.00">booklet10</description>
@@ -57,30 +57,30 @@
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>52</docmd:PageCount>
           <docmd:GraphicsCount>433</docmd:GraphicsCount>
-          <docmd:Font FontName="ILMKCK+Charlesworth-Normal" />
-          <docmd:Font FontName="ILMKCL+BauerBodoniBT-Italic" />
-          <docmd:Font FontName="ILMKDM+BauerBodoniBT-Roman" />
-          <docmd:Font FontName="ILMKFM+BauerBodoniBT-BoldItalic" />
-          <docmd:Font FontName="ILMKFN+Charlesworth-Bold" />
-          <docmd:Font FontName="ILMKOK+BauerBodoniBT-Bold" />
+          <docmd:Font FontName="BauerBodoniBT-Bold" />
+          <docmd:Font FontName="BauerBodoniBT-BoldItalic" />
+          <docmd:Font FontName="BauerBodoniBT-Italic" />
+          <docmd:Font FontName="BauerBodoniBT-Roman" />
+          <docmd:Font FontName="Charlesworth-Bold" />
+          <docmd:Font FontName="Charlesworth-Normal" />
         </docmd:document>
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="348">
+  <statistics fitsExecutionTime="764">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="22" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="344" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="31" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="186" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="97" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="6" />
+    <tool toolname="Droid" toolversion="6.1.5" executionTime="78" />
+    <tool toolname="Jhove" toolversion="1.11" executionTime="746" />
+    <tool toolname="file utility" toolversion="5.04" executionTime="111" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="265" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="279" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="43" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="2" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="87" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="40" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="437" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFa_equations.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_equations.pdf_XmlUnitExpectedOutput.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.11.0" timestamp="3/22/16 12:31 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/7/16 3:01 PM">
   <identification>
-    <identity format="PDF/A" mimetype="application/pdf" toolname="FITS" toolversion="0.11.0">
+    <identity format="PDF/A" mimetype="application/pdf" toolname="FITS" toolversion="1.0.0">
       <tool toolname="Droid" toolversion="6.1.5" />
       <tool toolname="Jhove" toolversion="1.11" />
       <tool toolname="Exiftool" toolversion="10.00" />
@@ -19,7 +19,7 @@
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDFa_equations.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_equations.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">83fa9407b0ddf13a38579a18fe9f7734</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1455736667000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1458852347000</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">true</well-formed>
@@ -27,7 +27,6 @@
   </filestatus>
   <metadata>
     <document>
-      <title toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">Zakuta, Vitaly</title>
       <author toolname="Jhove" toolversion="1.11">Zakuta, Vitaly</author>
       <language toolname="Jhove" toolversion="1.11">EN-US</language>
       <pageCount toolname="Jhove" toolversion="1.11">3</pageCount>
@@ -35,40 +34,36 @@
       <hasOutline toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasOutline>
       <hasAnnotations toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasAnnotations>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>AIBIKD+Calibri</fontName>
+        <fontName>Calibri</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>RSQGOV+CambriaMath</fontName>
-      </font>
-      <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>VYOESN+CambriaMath</fontName>
+        <fontName>CambriaMath</fontName>
       </font>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>3</docmd:PageCount>
           <docmd:Language>EN-US</docmd:Language>
-          <docmd:Font FontName="AIBIKD+Calibri" />
-          <docmd:Font FontName="RSQGOV+CambriaMath" />
-          <docmd:Font FontName="VYOESN+CambriaMath" />
+          <docmd:Font FontName="Calibri" />
+          <docmd:Font FontName="CambriaMath" />
           <docmd:Features>isTagged</docmd:Features>
         </docmd:document>
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="345">
+  <statistics fitsExecutionTime="2405">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="18" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="135" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="66" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="216" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="77" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="6" />
+    <tool toolname="Droid" toolversion="6.1.5" executionTime="140" />
+    <tool toolname="Jhove" toolversion="1.11" executionTime="1250" />
+    <tool toolname="file utility" toolversion="5.04" executionTime="1264" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="835" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="772" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="133" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="12" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="333" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="436" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="2283" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFa_has_form.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_form.pdf_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/3/16 11:30 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/8/16 1:25 PM">
   <identification>
     <identity format="PDF/A" mimetype="application/pdf" toolname="FITS" toolversion="1.0.0">
       <tool toolname="Droid" toolversion="6.1.5" />
@@ -20,7 +20,7 @@
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDFa_has_form.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_has_form.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">553682ae868f787654f5b2da6925861e</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1456259189000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">true</well-formed>
@@ -34,43 +34,43 @@
       <hasOutline toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasOutline>
       <hasAnnotations toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">yes</hasAnnotations>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>OCCMIG+Arial,Bold</fontName>
+        <fontName>Arial</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>OCCMJH+Arial</fontName>
+        <fontName>Arial,Bold</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>OCCMJI+Arimo</fontName>
+        <fontName>Arimo</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>OCCMJJ+Arimo-Bold</fontName>
+        <fontName>Arimo-Bold</fontName>
       </font>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>3</docmd:PageCount>
-          <docmd:Font FontName="OCCMIG+Arial,Bold" />
-          <docmd:Font FontName="OCCMJH+Arial" />
-          <docmd:Font FontName="OCCMJI+Arimo" />
-          <docmd:Font FontName="OCCMJJ+Arimo-Bold" />
+          <docmd:Font FontName="Arial" />
+          <docmd:Font FontName="Arial,Bold" />
+          <docmd:Font FontName="Arimo" />
+          <docmd:Font FontName="Arimo-Bold" />
           <docmd:Features>hasAnnotations</docmd:Features>
         </docmd:document>
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="154">
+  <statistics fitsExecutionTime="334">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="4" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="68" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="31" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="148" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="19" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="2" />
+    <tool toolname="Droid" toolversion="6.1.5" executionTime="19" />
+    <tool toolname="Jhove" toolversion="1.11" executionTime="189" />
+    <tool toolname="file utility" toolversion="5.04" executionTime="100" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="227" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="52" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="13" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="3" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="66" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="25" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="308" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFa_has_table_of_contents.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_table_of_contents.pdf_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/3/16 11:32 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/8/16 1:26 PM">
   <identification>
     <identity format="PDF/A" mimetype="application/pdf" toolname="FITS" toolversion="1.0.0">
       <tool toolname="Droid" toolversion="6.1.5" />
@@ -19,7 +19,7 @@
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDFa_has_table_of_contents.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_has_table_of_contents.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">537d5a41d854b5c03f8bb33041faf1aa</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1460584552000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">true</well-formed>
@@ -36,46 +36,46 @@
       <hasAnnotations toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">yes</hasAnnotations>
       <graphicsCount toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">1</graphicsCount>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>CJPZZP+Cambria</fontName>
+        <fontName>Arial</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>DOUTBX+TimesNewRoman,Bold</fontName>
+        <fontName>Arial,Bold</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>KBGJVJ+TimesNewRoman</fontName>
+        <fontName>Calibri</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>MEFVXF+CourierNew</fontName>
+        <fontName>Cambria</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>OGOYLR+Calibri</fontName>
+        <fontName>Cambria-Bold</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>QKITBX+Arial,Bold</fontName>
+        <fontName>CourierNew</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>SMRWPJ+Cambria-Bold</fontName>
+        <fontName>SymbolMT</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>TLBCDH+SymbolMT</fontName>
+        <fontName>TimesNewRoman</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>VUVXTN+Arial</fontName>
+        <fontName>TimesNewRoman,Bold</fontName>
       </font>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>5</docmd:PageCount>
           <docmd:GraphicsCount>1</docmd:GraphicsCount>
           <docmd:Language>EN-US</docmd:Language>
-          <docmd:Font FontName="CJPZZP+Cambria" />
-          <docmd:Font FontName="DOUTBX+TimesNewRoman,Bold" />
-          <docmd:Font FontName="KBGJVJ+TimesNewRoman" />
-          <docmd:Font FontName="MEFVXF+CourierNew" />
-          <docmd:Font FontName="OGOYLR+Calibri" />
-          <docmd:Font FontName="QKITBX+Arial,Bold" />
-          <docmd:Font FontName="SMRWPJ+Cambria-Bold" />
-          <docmd:Font FontName="TLBCDH+SymbolMT" />
-          <docmd:Font FontName="VUVXTN+Arial" />
+          <docmd:Font FontName="Arial" />
+          <docmd:Font FontName="Arial,Bold" />
+          <docmd:Font FontName="Calibri" />
+          <docmd:Font FontName="Cambria" />
+          <docmd:Font FontName="Cambria-Bold" />
+          <docmd:Font FontName="CourierNew" />
+          <docmd:Font FontName="SymbolMT" />
+          <docmd:Font FontName="TimesNewRoman" />
+          <docmd:Font FontName="TimesNewRoman,Bold" />
           <docmd:Features>isTagged</docmd:Features>
           <docmd:Features>hasOutline</docmd:Features>
           <docmd:Features>hasAnnotations</docmd:Features>
@@ -83,20 +83,20 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="214">
+  <statistics fitsExecutionTime="447">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="5" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="160" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="38" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="206" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="95" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="3" />
+    <tool toolname="Droid" toolversion="6.1.5" executionTime="20" />
+    <tool toolname="Jhove" toolversion="1.11" executionTime="420" />
+    <tool toolname="file utility" toolversion="5.04" executionTime="97" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="238" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="170" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="40" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="4" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="64" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="17" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="345" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFa_has_tables.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_tables.pdf_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/3/16 11:35 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/8/16 1:28 PM">
   <identification>
     <identity format="PDF/A" mimetype="application/pdf" toolname="FITS" toolversion="1.0.0">
       <tool toolname="Droid" toolversion="6.1.5" />
@@ -19,7 +19,7 @@
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDFa_has_tables.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_has_tables.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">fd321cedf56dec077704cfd5e0b6dbca</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1460584552000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">true</well-formed>
@@ -27,71 +27,66 @@
   </filestatus>
   <metadata>
     <document>
-      <title toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">XPP</title>
       <author toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">XPP</author>
       <pageCount toolname="Jhove" toolversion="1.11">4</pageCount>
       <hasOutline toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasOutline>
       <hasAnnotations toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">yes</hasAnnotations>
       <graphicsCount toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">5</graphicsCount>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>BBBCHQ+Helvetica-Bold</fontName>
+        <fontName>Helvetica</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>FHZEQJ+Times-Bold</fontName>
+        <fontName>Helvetica-Bold</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>NNWRWI+MathematicalPi-Three</fontName>
+        <fontName>MathematicalPi-One</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>RNDADQ+Times-Roman</fontName>
+        <fontName>MathematicalPi-Three</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>TAXUJQ+Helvetica</fontName>
+        <fontName>Times-Bold</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>XWLQSC+Helvetica-Bold</fontName>
+        <fontName>Times-Italic</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>ZDCITP+Times-Italic</fontName>
+        <fontName>Times-Roman</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>ZJVRWI+MathematicalPi-One</fontName>
-      </font>
-      <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>ZJVRWI+Universal-GreekwithMathPi</fontName>
+        <fontName>Universal-GreekwithMathPi</fontName>
       </font>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>4</docmd:PageCount>
           <docmd:GraphicsCount>5</docmd:GraphicsCount>
-          <docmd:Font FontName="BBBCHQ+Helvetica-Bold" />
-          <docmd:Font FontName="FHZEQJ+Times-Bold" />
-          <docmd:Font FontName="NNWRWI+MathematicalPi-Three" />
-          <docmd:Font FontName="RNDADQ+Times-Roman" />
-          <docmd:Font FontName="TAXUJQ+Helvetica" />
-          <docmd:Font FontName="XWLQSC+Helvetica-Bold" />
-          <docmd:Font FontName="ZDCITP+Times-Italic" />
-          <docmd:Font FontName="ZJVRWI+MathematicalPi-One" />
-          <docmd:Font FontName="ZJVRWI+Universal-GreekwithMathPi" />
+          <docmd:Font FontName="Helvetica" />
+          <docmd:Font FontName="Helvetica-Bold" />
+          <docmd:Font FontName="MathematicalPi-One" />
+          <docmd:Font FontName="MathematicalPi-Three" />
+          <docmd:Font FontName="Times-Bold" />
+          <docmd:Font FontName="Times-Italic" />
+          <docmd:Font FontName="Times-Roman" />
+          <docmd:Font FontName="Universal-GreekwithMathPi" />
           <docmd:Features>hasAnnotations</docmd:Features>
         </docmd:document>
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="166">
+  <statistics fitsExecutionTime="256">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="5" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="87" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="32" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="162" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="44" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="3" />
+    <tool toolname="Droid" toolversion="6.1.5" executionTime="20" />
+    <tool toolname="Jhove" toolversion="1.11" executionTime="194" />
+    <tool toolname="file utility" toolversion="5.04" executionTime="91" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="227" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="68" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="41" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="2" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="42" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="11" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="217" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFa_multiplefonts.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_multiplefonts.pdf_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/3/16 11:10 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/8/16 1:24 PM">
   <identification>
     <identity format="PDF/A" mimetype="application/pdf" toolname="FITS" toolversion="1.0.0">
       <tool toolname="Droid" toolversion="6.1.5" />
@@ -19,7 +19,7 @@
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDFa_multiplefonts.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_multiplefonts.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">ba84a24c8d09b76b1f02e359c36ebbda</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1456259123000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">true</well-formed>
@@ -33,50 +33,50 @@
       <hasOutline toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasOutline>
       <hasAnnotations toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasAnnotations>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>IMAFEJ+TimesNewRomanPS-BoldMT</fontName>
+        <fontName>CourierNewPSMT</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>IMAFFL+CourierNewPSMT</fontName>
+        <fontName>NiagaraEngraved-Reg</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>IMAFHM+TimesNewRomanPSMT</fontName>
+        <fontName>Raavi</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>IMAFNL+SymbolMT</fontName>
+        <fontName>SymbolMT</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>KCIWKT+Raavi</fontName>
+        <fontName>TimesNewRomanPS-BoldMT</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>OILUOL+NiagaraEngraved-Reg</fontName>
+        <fontName>TimesNewRomanPSMT</fontName>
       </font>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>3</docmd:PageCount>
-          <docmd:Font FontName="IMAFEJ+TimesNewRomanPS-BoldMT" />
-          <docmd:Font FontName="IMAFFL+CourierNewPSMT" />
-          <docmd:Font FontName="IMAFHM+TimesNewRomanPSMT" />
-          <docmd:Font FontName="IMAFNL+SymbolMT" />
-          <docmd:Font FontName="KCIWKT+Raavi" />
-          <docmd:Font FontName="OILUOL+NiagaraEngraved-Reg" />
+          <docmd:Font FontName="CourierNewPSMT" />
+          <docmd:Font FontName="NiagaraEngraved-Reg" />
+          <docmd:Font FontName="Raavi" />
+          <docmd:Font FontName="SymbolMT" />
+          <docmd:Font FontName="TimesNewRomanPS-BoldMT" />
+          <docmd:Font FontName="TimesNewRomanPSMT" />
         </docmd:document>
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="155">
+  <statistics fitsExecutionTime="307">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="4" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="62" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="28" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="149" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="20" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="1" />
+    <tool toolname="Droid" toolversion="6.1.5" executionTime="18" />
+    <tool toolname="Jhove" toolversion="1.11" executionTime="270" />
+    <tool toolname="file utility" toolversion="5.04" executionTime="115" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="232" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="67" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="17" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="3" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="25" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="29" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="110" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFx3.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFx3.pdf_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/3/16 11:42 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/8/16 1:33 PM">
   <identification status="SINGLE_RESULT">
     <identity format="PDF/A" mimetype="application/pdf" toolname="FITS" toolversion="1.0.0">
       <tool toolname="Jhove" toolversion="1.11" />
@@ -15,7 +15,7 @@
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDFx3.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFx3.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">745c9a202265d728d5cd21f86f1d411f</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1456242352000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">true</well-formed>
@@ -28,38 +28,38 @@
       <hasOutline toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasOutline>
       <hasAnnotations toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">no</hasAnnotations>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>BZOLYW+MyriadPro-Regular</fontName>
+        <fontName>MyriadPro-Regular</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>VQMBSI+OpenSans-Bold</fontName>
+        <fontName>OpenSans</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>WUBHGG+OpenSans</fontName>
+        <fontName>OpenSans-Bold</fontName>
       </font>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>16</docmd:PageCount>
-          <docmd:Font FontName="BZOLYW+MyriadPro-Regular" />
-          <docmd:Font FontName="VQMBSI+OpenSans-Bold" />
-          <docmd:Font FontName="WUBHGG+OpenSans" />
+          <docmd:Font FontName="MyriadPro-Regular" />
+          <docmd:Font FontName="OpenSans" />
+          <docmd:Font FontName="OpenSans-Bold" />
         </docmd:document>
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="159">
+  <statistics fitsExecutionTime="251">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="13" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="62" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="35" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="154" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="38" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="3" />
+    <tool toolname="Droid" toolversion="6.1.5" executionTime="32" />
+    <tool toolname="Jhove" toolversion="1.11" executionTime="133" />
+    <tool toolname="file utility" toolversion="5.04" executionTime="101" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="234" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="69" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="6" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="4" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="37" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="8" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="114" />
   </statistics>
 </fits>
 

--- a/testfiles/output/altona_technical_1v2_x3_has_annotations.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/altona_technical_1v2_x3_has_annotations.pdf_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/3/16 11:40 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.0" timestamp="6/8/16 1:21 PM">
   <identification>
     <identity format="PDF/X" mimetype="application/pdf" toolname="FITS" toolversion="1.0.0">
       <tool toolname="Droid" toolversion="6.1.5" />
@@ -19,7 +19,7 @@
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/altona_technical_1v2_x3_has_annotations.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">altona_technical_1v2_x3_has_annotations.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">c524ab2cd02240b12eab3ee9f8887a9f</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1456177705000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">true</well-formed>
@@ -37,16 +37,16 @@
         <fontName>Courier-Oblique</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>EMEICK+Helvetica</fontName>
+        <fontName>Helvetica</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>EMEIJA+Helvetica-Bold</fontName>
+        <fontName>Helvetica-Bold</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>EMFBGL+Metanormal01-Bold</fontName>
+        <fontName>Metabook01</fontName>
       </font>
       <font toolname="Jhove" toolversion="1.11" status="SINGLE_RESULT">
-        <fontName>EMFBIO+Metabook01</fontName>
+        <fontName>Metanormal01-Bold</fontName>
       </font>
       <subject toolname="Exiftool" toolversion="10.00">Altona Test Suite – Online Version</subject>
       <description toolname="Exiftool" toolversion="10.00">Altona Test Suite – Online Version</description>
@@ -55,29 +55,29 @@
           <docmd:PageCount>1</docmd:PageCount>
           <docmd:GraphicsCount>44</docmd:GraphicsCount>
           <docmd:Font FontName="Courier-Oblique" />
-          <docmd:Font FontName="EMEICK+Helvetica" />
-          <docmd:Font FontName="EMEIJA+Helvetica-Bold" />
-          <docmd:Font FontName="EMFBGL+Metanormal01-Bold" />
-          <docmd:Font FontName="EMFBIO+Metabook01" />
+          <docmd:Font FontName="Helvetica" />
+          <docmd:Font FontName="Helvetica-Bold" />
+          <docmd:Font FontName="Metabook01" />
+          <docmd:Font FontName="Metanormal01-Bold" />
           <docmd:Features>hasAnnotations</docmd:Features>
         </docmd:document>
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="687">
+  <statistics fitsExecutionTime="571">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="106" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="525" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="90" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="243" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="240" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="33" />
+    <tool toolname="Droid" toolversion="6.1.5" executionTime="131" />
+    <tool toolname="Jhove" toolversion="1.11" executionTime="257" />
+    <tool toolname="file utility" toolversion="5.04" executionTime="87" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="263" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="237" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="30" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="12" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="675" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="6" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="554" />
   </statistics>
 </fits>
 

--- a/xml/jhove/jhove_audio_to_fits.xslt
+++ b/xml/jhove/jhove_audio_to_fits.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<xsl:stylesheet version="1.0"
+<xsl:stylesheet version="2.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 xmlns:aes="http://www.aes.org/audioObject" 
 xmlns:tcf="http://www.aes.org/tcf">

--- a/xml/jhove/jhove_html_to_fits.xslt
+++ b/xml/jhove/jhove_html_to_fits.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<xsl:stylesheet version="1.0"
+<xsl:stylesheet version="2.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 xmlns:mix="http://www.loc.gov/mix/v20">
 

--- a/xml/jhove/jhove_text_to_fits.xslt
+++ b/xml/jhove/jhove_text_to_fits.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<xsl:stylesheet version="1.0"
+<xsl:stylesheet version="2.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 xmlns:mix="http://www.loc.gov/mix/v20">
 

--- a/xml/jhove/jhove_unknown_to_fits.xslt
+++ b/xml/jhove/jhove_unknown_to_fits.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<xsl:stylesheet version="1.0"
+<xsl:stylesheet version="2.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 xmlns:mix="http://www.loc.gov/mix/v20">
 

--- a/xml/jhove/jhove_xml_to_fits.xslt
+++ b/xml/jhove/jhove_xml_to_fits.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<xsl:stylesheet version="1.0"
+<xsl:stylesheet version="2.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 xmlns:mix="http://www.loc.gov/mix/v20">
 


### PR DESCRIPTION
Remove font tags from JHOVE output of PDF's; update corresponding tests; Bring all JHOVE XSLT up to 2.0