### PR TITLE
fix for file utility html detection bug

### DIFF
--- a/src/edu/harvard/hul/ois/fits/tools/fileutility/FileUtility.java
+++ b/src/edu/harvard/hul/ois/fits/tools/fileutility/FileUtility.java
@@ -124,7 +124,7 @@ public class FileUtility extends ToolBase {
 		List<String> linebreaks = new ArrayList<String>();
 
 		//if mime indicates plain text (except if RTF files)
-		if(execMimeOut.startsWith("text/") && execMimeOut.contains("charset=") && !execOut.contains("Rich Text Format")) {
+		if(execMimeOut.startsWith("text/plain") && execMimeOut.contains("charset=") && !execOut.contains("Rich Text Format")) {
 			//mime = "text/plain";
 			mime = execMimeOut.substring(0,execMimeOut.indexOf("; charset="));
 			charset = execMimeOut.substring(execMimeOut.indexOf("=")+1);

--- a/xml/fileutility/fileutility_to_fits.xslt
+++ b/xml/fileutility/fileutility_to_fits.xslt
@@ -221,11 +221,18 @@
 					</xsl:when>	
 					<!--  HTML -->
 					<xsl:when test="$mime='text/html'">
-						<xsl:attribute name="format">
-						  	<xsl:if test="$format='HTML document text'">
+						<xsl:analyze-string select="$format" regex="HTML.*?document.*">
+						    <xsl:matching-substring>
+							<xsl:attribute name="format">
 								<xsl:value-of select="string('Hypertext Markup Language')"/>
-							</xsl:if>
-						</xsl:attribute>				
+							</xsl:attribute>
+						    </xsl:matching-substring>
+						    <xsl:non-matching-substring>
+							<xsl:attribute name="format">
+								<xsl:value-of select="$format" />
+							</xsl:attribute>
+						    </xsl:non-matching-substring>
+						</xsl:analyze-string>
 					</xsl:when>	
 					<!-- RTF -->
 					<xsl:when test="contains($rawoutput,'Rich Text Format')">


### PR DESCRIPTION
proposed fix for bug https://github.com/harvard-lts/fits/issues/95

Up until now if mime type starts with 'text/' the format gets hardcoded to 'Plain text'.
But according to fileutility_to_fits.xslt the format has to be 'HTML document text',
otherwise the format will be empty.

fix:
1.) don't hardcode everything that starts with 'text/' (if necessary, only for 'text/plain')
2.) write regex inside fileutility_to_fits.xslt for text/html, because different
file utility versions might output different output strings