### PR TITLE
file utility to fits: XML format detection bug

### DIFF
--- a/xml/fileutility/fileutility_to_fits.xslt
+++ b/xml/fileutility/fileutility_to_fits.xslt
@@ -213,12 +213,29 @@
 					</xsl:when>						
 					<!--  XML -->
 					<xsl:when test="$mime='application/xml'">
-						<xsl:attribute name="format">
-						  	<xsl:if test="$format='XML  document text'">
+						<!-- test if format contains: XML VERSION* SOMETHING,* ELSE* -->
+						<!-- whereas: * is optional --> 
+						<!-- version <= file-5.24 example: XML document text -->
+						<!-- version >= file-5.25 example: XML 1.0 document, ASCII text -->
+						<xsl:analyze-string select="$format" regex="XML ([\d\.]*).*">
+						    <xsl:matching-substring>
+							<xsl:attribute name="format">
 								<xsl:value-of select="string('Extensible Markup Language')"/>
+							</xsl:attribute>
+							<!-- test if there is a version string -->
+							<xsl:if test="regex-group(1) != ''">
+								<version>
+									<xsl:value-of select="regex-group(1)"/>
+								</version>
 							</xsl:if>
-						</xsl:attribute>				
-					</xsl:when>	
+						    </xsl:matching-substring>
+						    <xsl:non-matching-substring>
+							<xsl:attribute name="format">
+								<xsl:value-of select="$format" />
+							</xsl:attribute>
+						    </xsl:non-matching-substring>
+						</xsl:analyze-string>
+					</xsl:when>
 					<!--  HTML -->
 					<xsl:when test="$mime='text/html'">
 						<xsl:attribute name="format">


### PR DESCRIPTION
proposed fix for file utility XML bug https://github.com/harvard-lts/fits/issues/103

There are two problems:
1.) There is a typo within fileutility_to_fits.xslt (two spaces, therefore
    'XML  document text' isn't the same as 'XML document text' => format is empty)
2.) As of file utility version 5.25 the reported output has changed (now with version string)
    file <= 5.24: XML document text
    file => 5.25: XML 1.0 document text, ASCII text

fix:
Use regex in order to identify XML documents and to find XML version.
This works even if no version is provided.