### PR TITLE
LIBDRS-4878 MIX metadata fix; small JHOVE output fix.

### DIFF
--- a/src/edu/harvard/hul/ois/fits/mapping/FitsXmlMapper.java
+++ b/src/edu/harvard/hul/ois/fits/mapping/FitsXmlMapper.java
@@ -26,6 +26,10 @@ import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.tools.Tool;
 import edu.harvard.hul.ois.fits.tools.ToolInfo;
 
+/**
+ * Transform FITS output as configured in fits_xml_map.xml. Transformations will happen only
+ * if configured in the XML file. Otherwise, the output will pass directly through without transformation.
+ */
 public class FitsXmlMapper {
 
 	public static final String FITS_XML_MAP_PATH = Fits.FITS_XML_DIR+"fits_xml_map.xml";
@@ -54,7 +58,7 @@ public class FitsXmlMapper {
 		try {
 			Element e = (Element)XPath.selectSingleNode(doc,"//identity");
 			if(e != null) {
-				mime = e.getAttributeValue("mimetype");
+				mime = e.getAttributeValue("mimetype"); // (This code is never accessed from any of the unit tests. Is it ever?)
 			}
 		} catch (JDOMException e) {
 			logger.error("Error parsing XML with XPath expression.", e);

--- a/src/edu/harvard/hul/ois/fits/tools/ToolOutput.java
+++ b/src/edu/harvard/hul/ois/fits/tools/ToolOutput.java
@@ -79,7 +79,7 @@ public class ToolOutput {
 		//map values and get identities from fitsXML if not null
 		if(fitsXml != null) {
 			//fitsxml doc is mapped here before identities are extracted
-			this.fitsXml = Fits.mapper.applyMap(tool,fitsXml);
+			this.fitsXml = Fits.mapper.applyMap(tool,fitsXml); // Perform any last-chance transformations/normalizations of FITS output.
 			identity = createFileIdentities(fitsXml,tool.getToolInfo());
 		}
 	}

--- a/src/edu/harvard/hul/ois/fits/tools/droid/DroidToolOutputter.java
+++ b/src/edu/harvard/hul/ois/fits/tools/droid/DroidToolOutputter.java
@@ -125,10 +125,10 @@ public class DroidToolOutputter {
     		return "JPEG 2000 JP2";
     	}
     	else if(formatName.startsWith("Exchangeable Image File Format (Compressed)")) {
-    		return "Exchangeable Image File Format";
+    		return "JPEG EXIF";
     	}
     	else if(formatName.startsWith("Exchangeable Image File Format (Uncompressed)")) {
-    		return "Exchangeable Image File Format";
+    		return "TIFF EXIF";
     	}
     	else if(formatName.contains("PDF/A")) {
     		return "PDF/A";

--- a/tests/edu/harvard/hul/ois/fits/junit/MixTest.java
+++ b/tests/edu/harvard/hul/ois/fits/junit/MixTest.java
@@ -48,8 +48,10 @@ public class MixTest {
 		// Set up XMLUnit and FITS for entire class.
 		XMLUnit.setIgnoreWhitespace(true);
 		XMLUnit.setNormalizeWhitespace(true);
-		fits = new Fits();
-	}
+		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
+		fits = new Fits(null, fitsConfigFile);
+//		fits = new Fits();	// Use this instead to turn off tool output.
+		}
 	
 	@AfterClass
 	public static void afterClass() {
@@ -102,8 +104,8 @@ public class MixTest {
     
 	@Test
 	public void testMixJpg() throws Exception {	
-    	Fits fits = new Fits("");
-    	String filename = "3426592.jpg";
+
+		String filename = "3426592.jpg";
     	File input = new File("testfiles/" + filename);
     	
     	FitsOutput fitsOut = fits.examine(input);

--- a/xml/fits_format_tree.xml
+++ b/xml/fits_format_tree.xml
@@ -9,7 +9,7 @@
 	<branch format="Raw JPEG Stream">
 		<branch format="jpeg">
 			<branch format="JPEG File Interchange Format"/>
-			<branch format="Exchangeable Image File Format"/>
+			<branch format="JPEG EXIF"/>
 		</branch>
 	</branch>
 	<branch format="JPEG 2000">

--- a/xml/fits_xml_map.xml
+++ b/xml/fits_xml_map.xml
@@ -1,9 +1,12 @@
 <fitsXmlMap>
-
+    <!-- Case of tool name and element name does not matter; case of 'from' attribute value DOES matter. -->
 	<tool name="jhove">
 		<mime type="all">
 			<element name="colorSpace">
 				<map from="Greyscale" to="Grayscale"/>
+			</element>
+			<element name="meteringMode">
+				<map from="pattern" to="Pattern"/>
 			</element>
 		</mime>
 	</tool>

--- a/xml/format_map.txt
+++ b/xml/format_map.txt
@@ -17,7 +17,6 @@ Windows bitmap=Windows Bitmap
 PPT=Microsoft Powerpoint Presentation
 Plain Text File=Plain text
 Scalable Vector Graphics=Scalable Vector Graphics (SVG)
-Tagged Image File Format for Internet Fax (TIFF-FX)=Tagged Image File Format
 Microsoft Excel Spreadsheet=Microsoft Excel
 Audio Video Interleave File=Audio/Video Interleaved Format
 Photoshop Image=Adobe Photoshop


### PR DESCRIPTION
Earlier upgrade to DROID 6.1.5 improved accuracy of file analysis and metadata. Corrections needed to be made in FITS to accommodate these improvements.