### PR TITLE
LIBDRS-5209 - Latest FITS failing to generate MIX for some TIFF's

### DIFF
--- a/src/edu/harvard/hul/ois/fits/tools/droid/DroidToolOutputter.java
+++ b/src/edu/harvard/hul/ois/fits/tools/droid/DroidToolOutputter.java
@@ -73,6 +73,7 @@ public class DroidToolOutputter {
             	mimeType = FitsMetadataValues.getInstance().normalizeMimeType(mimeType);
             }
 
+            // maybe this block should be moved to mapFormatName() ???
             if(formatName.equals("Digital Negative (DNG)")) {
             	mimeType="image/x-adobe-dng";
             } else if (formatName.equals("Office Open XML Document")) {

--- a/tests/edu/harvard/hul/ois/fits/junit/MixTest.java
+++ b/tests/edu/harvard/hul/ois/fits/junit/MixTest.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.FitsOutput;
 import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
-import edu.harvard.hul.ois.ots.schemas.DocumentMD.DocumentMD;
 import edu.harvard.hul.ois.ots.schemas.MIX.Mix;
 
 public class MixTest extends AbstractLoggingTest {
@@ -50,7 +49,7 @@ public class MixTest extends AbstractLoggingTest {
 		XMLUnit.setIgnoreWhitespace(true);
 		XMLUnit.setNormalizeWhitespace(true);
 		fits = new Fits();
-		// Use this instead to turn on tool output.
+		// Use this instead of above line to turn on tool output.
 //		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
 //		fits = new Fits(null, fitsConfigFile);
 	}
@@ -92,14 +91,14 @@ public class MixTest extends AbstractLoggingTest {
 		fitsOut.addStandardCombinedFormat();
 		serializer.output(fitsOut.getFitsXml(), System.out);
 		
-		DocumentMD docmd = (DocumentMD)fitsOut.getStandardXmlContent();
+		Mix mix = (Mix)fitsOut.getStandardXmlContent();
 		
-		if(docmd != null) {
-			docmd.setRoot(true);
+		if(mix != null) {
+			mix.setRoot(true);
 			XMLOutputFactory xmlof = XMLOutputFactory.newInstance();
 			XMLStreamWriter writer = xmlof.createXMLStreamWriter(System.out); 
 			
-			docmd.output(writer);
+			mix.output(writer);
 		}
     	fitsOut.saveToDisk("test-generated-output/" + inputFilename + "_Output.xml");
 	}

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-build.version=1.0.3
+build.version=1.0.4

--- a/xml/exiftool/exiftool_common_to_fits.xslt
+++ b/xml/exiftool/exiftool_common_to_fits.xslt
@@ -100,9 +100,6 @@
 				<xsl:when test="$format='TIFF'">
 					<xsl:value-of select="string('Tagged Image File Format')"/>						
 				</xsl:when>
-				<xsl:when test="$format='TIFF EXIF'">
-					<xsl:value-of select="string('Tagged Image File Format')"/>						
-				</xsl:when>
 				<xsl:when test="$format='AVI'">
 					<xsl:value-of select="string('Audio/Video Interleaved Format')"/>		
 				</xsl:when>


### PR DESCRIPTION
Need to adjust XSLT for the format in Exiftool so that certain TIFF files are properly identified as "TIFF EXIF" and the tool's metadata is propagated to FITS output and subsequently to MIX standard output.