### PR TITLE
Add backward compatibility for Tool interface implementations.

### DIFF
--- a/src/edu/harvard/hul/ois/fits/tools/ToolBelt.java
+++ b/src/edu/harvard/hul/ois/fits/tools/ToolBelt.java
@@ -154,8 +154,17 @@ public class ToolBelt {
 	 * Note: All Tool class implementations MUST have a 1-argument constructor with Fits as the argument.
 	 */
 	private Tool createToolClassInstance(Class<?> toolClass, Fits fits) throws ReflectiveOperationException {
-		Constructor<?> ctor = toolClass.getConstructor(Fits.class);
-		Object instanceOfTheClass = ctor.newInstance(fits);
+		Object instanceOfTheClass = null;
+		try {
+			Constructor<?> ctor = toolClass.getConstructor(Fits.class);
+			instanceOfTheClass = ctor.newInstance(fits);
+			logger.debug("1-arg constructor for instantiating tool class: " + toolClass.getName());
+		} catch (ReflectiveOperationException e) {
+			// now try a no-arg constructor
+			logger.debug("No Fits 1-arg constructor for tool class: " + toolClass.getName() + " -- trying no-arg constructor...");
+			instanceOfTheClass = toolClass.newInstance();
+			logger.debug("no-arg constructor for instantiating tool class: " + toolClass.getName());
+		}
 		return (Tool)instanceOfTheClass;
 	}
 

--- a/testfiles/properties/fits_test_no_arg_tool.xml
+++ b/testfiles/properties/fits_test_no_arg_tool.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fits_configuration>
+	<!-- This file is for use by one of the test classes only. -->
+	<tools>
+        <tool class="edu.harvard.hul.ois.fits.tools.NoArgumentTestTool" />
+	</tools>
+	
+	<output>
+		<dataConsolidator class="edu.harvard.hul.ois.fits.consolidation.OISConsolidator"/>
+		<display-tool-output>false</display-tool-output>
+		<report-conflicts>true</report-conflicts>	
+		<validate-tool-output>false</validate-tool-output>
+		<internal-output-schema>xml/fits_output.xsd</internal-output-schema>
+		<external-output-schema>http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd</external-output-schema>
+		<fits-xml-namespace>http://hul.harvard.edu/ois/xml/ns/fits/fits_output</fits-xml-namespace>
+		<enable-statistics>true</enable-statistics>
+		<enable-checksum>true</enable-checksum>
+		<!-- The below controls the exclusion of the checksum for certain files, even if enable-checksum is true -->
+		<!-- Video Exclusions -->
+		<!-- <checksum-exclusions exclude-exts="avi,mov,mpg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv"/> -->
+		<!-- Audio Exclusions -->
+		<!-- <checksum-exclusions exclude-exts="wav,aif,mp3,mp4,m4a,ra,rm"/> -->
+	</output>
+	
+	<process>
+		<max-threads>20</max-threads>
+	</process>
+	
+	<!-- file name of the droid signature file to use in tools/droid/-->
+	<droid_sigfile>DROID_SignatureFile_V82.xml</droid_sigfile>
+	
+	<!-- the fits home is used by the MediaInfo tool to load the jna api libs  -->
+	<!-- in most cases you won't need to change -->
+	<!-- example for BB will be /fits -->
+	<fits_home>.</fits_home>	
+		
+</fits_configuration>

--- a/testfiles/properties/fits_test_one_arg_tool.xml
+++ b/testfiles/properties/fits_test_one_arg_tool.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fits_configuration>
+    <!-- This file is for use by one of the test classes only. -->
+	<tools>
+        <tool class="edu.harvard.hul.ois.fits.tools.OneArgumentTestTool" />
+	</tools>
+	
+	<output>
+		<dataConsolidator class="edu.harvard.hul.ois.fits.consolidation.OISConsolidator"/>
+		<display-tool-output>false</display-tool-output>
+		<report-conflicts>true</report-conflicts>	
+		<validate-tool-output>false</validate-tool-output>
+		<internal-output-schema>xml/fits_output.xsd</internal-output-schema>
+		<external-output-schema>http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd</external-output-schema>
+		<fits-xml-namespace>http://hul.harvard.edu/ois/xml/ns/fits/fits_output</fits-xml-namespace>
+		<enable-statistics>true</enable-statistics>
+		<enable-checksum>true</enable-checksum>
+		<!-- The below controls the exclusion of the checksum for certain files, even if enable-checksum is true -->
+		<!-- Video Exclusions -->
+		<!-- <checksum-exclusions exclude-exts="avi,mov,mpg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv"/> -->
+		<!-- Audio Exclusions -->
+		<!-- <checksum-exclusions exclude-exts="wav,aif,mp3,mp4,m4a,ra,rm"/> -->
+	</output>
+	
+	<process>
+		<max-threads>20</max-threads>
+	</process>
+	
+	<!-- file name of the droid signature file to use in tools/droid/-->
+	<droid_sigfile>DROID_SignatureFile_V82.xml</droid_sigfile>
+	
+	<!-- the fits home is used by the MediaInfo tool to load the jna api libs  -->
+	<!-- in most cases you won't need to change -->
+	<!-- example for BB will be /fits -->
+	<fits_home>.</fits_home>	
+		
+</fits_configuration>

--- a/tests/edu/harvard/hul/ois/fits/tools/NoArgumentTestTool.java
+++ b/tests/edu/harvard/hul/ois/fits/tools/NoArgumentTestTool.java
@@ -1,0 +1,54 @@
+/* 
+ * Copyright 2017 Harvard University Library
+ * 
+ * This file is part of FITS (File Information Tool Set).
+ * 
+ * FITS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * FITS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.harvard.hul.ois.fits.tools;
+
+import java.io.File;
+
+import edu.harvard.hul.ois.fits.exceptions.FitsConfigurationException;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+
+/**
+ * A no-argument trivial implementation of the Tool interface to test reflection in ToolBelt.
+ * 
+ * @see edu.harvard.hul.ois.fits.tools.ToolBeltTest#noArgumentConstructorToolTest()
+ */
+public class NoArgumentTestTool extends ToolBase implements Tool {
+
+	/**
+	 * @throws FitsConfigurationException
+	 */
+	public NoArgumentTestTool() throws FitsToolException {
+		super();
+	}
+
+	@Override
+	public ToolOutput extractInfo(File file) throws FitsToolException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isEnabled() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setEnabled(boolean value) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tests/edu/harvard/hul/ois/fits/tools/OneArgumentTestTool.java
+++ b/tests/edu/harvard/hul/ois/fits/tools/OneArgumentTestTool.java
@@ -1,0 +1,55 @@
+/* 
+ * Copyright 2017 Harvard University Library
+ * 
+ * This file is part of FITS (File Information Tool Set).
+ * 
+ * FITS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * FITS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.harvard.hul.ois.fits.tools;
+
+import java.io.File;
+
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+
+/**
+ * A one-argument trivial implementation of the Tool interface to test
+ * reflection in ToolBelt.
+ * 
+ * @see edu.harvard.hul.ois.fits.tools.ToolBeltTest#oneArgumentConstructorToolTest()
+ */
+public class OneArgumentTestTool extends ToolBase implements Tool {
+
+	/**
+	 * 
+	 */
+	public OneArgumentTestTool(Fits fits) throws FitsToolException {
+		super();
+	}
+
+	@Override
+	public ToolOutput extractInfo(File file) throws FitsToolException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isEnabled() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setEnabled(boolean value) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tests/edu/harvard/hul/ois/fits/tools/ToolBeltTest.java
+++ b/tests/edu/harvard/hul/ois/fits/tools/ToolBeltTest.java
@@ -1,0 +1,73 @@
+/* 
+ * Copyright 2017 Harvard University Library
+ * 
+ * This file is part of FITS (File Information Tool Set).
+ * 
+ * FITS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * FITS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.harvard.hul.ois.fits.tools;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.exceptions.FitsConfigurationException;
+import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
+
+public class ToolBeltTest extends AbstractLoggingTest {
+
+	/**
+	 * Tests reflection code in ToolBelt for instantiating a Tool implementation
+	 * which contains only (default) no-argument constructor.
+	 * 
+	 * @see edu.harvard.hul.ois.fits.tools.ToolBelt#createToolClassInstance(
+	 *      Class<?>, Fits)
+	 */
+	@Test
+	public void noArgumentConstructorToolTest() {
+		File fitsConfigFile = new File("testfiles/properties/fits_test_no_arg_tool.xml");
+		assertNotNull(fitsConfigFile);
+		try {
+			// Instantiating Fits will exercise the ToolBelt.
+			@SuppressWarnings("unused")
+			Fits fits = new Fits(null, fitsConfigFile);
+		} catch (FitsConfigurationException e) {
+			fail("Could not instantiate Fits or the XMLConfiguration: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * Tests reflection code in ToolBelt for instantiating a Tool implementation
+	 * which contains a 1-argument constructor with Fits as the argument.
+	 * 
+	 * @see edu.harvard.hul.ois.fits.tools.ToolBelt#createToolClassInstance(
+	 *      Class<?>, Fits)
+	 */
+	@Test
+	public void oneArgumentConstructorToolTest() {
+		File fitsConfigFile = new File("testfiles/properties/fits_test_one_arg_tool.xml");
+		assertNotNull(fitsConfigFile);
+		try {
+			// Instantiating Fits will exercise the ToolBelt.
+			@SuppressWarnings("unused")
+			Fits fits = new Fits(null, fitsConfigFile);
+		} catch (FitsConfigurationException e) {
+			fail("Could not instantiate Fits or the XMLConfiguration: " + e.getMessage());
+		}
+	}
+}


### PR DESCRIPTION
For backward compatibility, allow any Tool implementation to have either a no-arg constructor or a 1-arg Fits constructor. This way either the previous getInstance() method works or the recent 1-arg constructor (with a Fits argument) constructor via Reflection with work for a Tool implementation.