### PR TITLE
Remove deprecated VERSION from FitsOutput.java…

### DIFF
--- a/src/edu/harvard/hul/ois/fits/Fits.java
+++ b/src/edu/harvard/hul/ois/fits/Fits.java
@@ -332,7 +332,6 @@ public class Fits {
           String version = versionProps.getProperty("build.version");
           if (version != null && !version.isEmpty()) {
               Fits.VERSION = version;
-              FitsOutput.setFitsVersion(version);
           }
       } catch (IOException e) {
           System.err.println("Problem loading [" + VERSION_PROPERTIES_FILE + "]: " + "Cannot display FITS version information.");

--- a/src/edu/harvard/hul/ois/fits/FitsOutput.java
+++ b/src/edu/harvard/hul/ois/fits/FitsOutput.java
@@ -65,21 +65,7 @@ public class FitsOutput {
 	private Namespace ns = Namespace.getNamespace(Fits.XML_NAMESPACE);
 	private XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
 
-	/**
-	 * For backwards compatibility with older FITS clients.
-	 * @deprecated
-	 */
-	public static String VERSION = null;
     private static final Logger logger = Logger.getLogger(FitsOutput.class);
-    
-    /**
-     * Set from Fits.java initialization.
-     */
-    static void setFitsVersion(String fitsVersion) {
-    	if (fitsVersion != null) {
-    		FitsOutput.VERSION = new String(fitsVersion);
-    	}
-    }
 
 	public FitsOutput(String fitsXmlStr) throws JDOMException, IOException {
 		SAXBuilder builder = new SAXBuilder();
@@ -468,7 +454,18 @@ public class FitsOutput {
 
 	}
 	
+	/**
+	 * This is the version of FITS that created the input file of this instance.
+	 * @return The FITS version of the input file.
+	 */
 	public String getFitsVersion() {
-		return FitsOutput.VERSION;
+		
+		String fitsVersion = null;
+		Element root = fitsXml.getRootElement();
+		Attribute fitsVersionAttr = root.getAttribute("version");
+		if (fitsVersionAttr != null) {
+			fitsVersion = fitsVersionAttr.getValue();
+		}
+		return fitsVersion;
 	}
 }

--- a/src/edu/harvard/hul/ois/fits/tools/ToolBelt.java
+++ b/src/edu/harvard/hul/ois/fits/tools/ToolBelt.java
@@ -151,7 +151,8 @@ public class ToolBelt {
 	
 	/*
 	 * Instantiate a Tool class using Reflection by passing Fits into the constructor.
-	 * Note: All Tool class implementations MUST have a 1-argument constructor with Fits as the argument.
+	 * Note: All Tool class implementations can have a 1-argument constructor with Fits as the argument.
+	 * If it does not, then the standard newInstance() method fall-back will be used.
 	 */
 	private Tool createToolClassInstance(Class<?> toolClass, Fits fits) throws ReflectiveOperationException {
 		Object instanceOfTheClass = null;

--- a/testfiles/FitsOutputTest.xml
+++ b/testfiles/FitsOutputTest.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file is for use in testing FitsOutput.java -->
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.1.0" timestamp="4/24/17 12:01 PM">
+  <identification>
+    <identity format="Rich Text Format (RTF)" mimetype="application/rtf" toolname="FITS" toolversion="1.1.0">
+      <tool toolname="Droid" toolversion="6.1.5" />
+      <tool toolname="file utility" toolversion="5.04" />
+      <tool toolname="Exiftool" toolversion="10.00" />
+      <tool toolname="Tika" toolversion="1.10" />
+      <version toolname="Droid" toolversion="6.1.5">1.9</version>
+      <externalIdentifier toolname="Droid" toolversion="6.1.5" type="puid">fmt/355</externalIdentifier>
+    </identity>
+  </identification>
+  <fileinfo>
+    <lastmodified toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2015:09:24 12:17:00</lastmodified>
+    <created toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2015:09:24 12:16:00</created>
+    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Doc2.rtf</filepath>
+    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Doc2.rtf</filename>
+    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">26328</size>
+    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">26301ff11c920c4e32f9fa7d706390a6</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
+  </fileinfo>
+  <filestatus />
+  <metadata>
+    <document>
+      <pageCount toolname="Exiftool" toolversion="10.00">1</pageCount>
+      <wordCount toolname="Exiftool" toolversion="10.00">0</wordCount>
+      <characterCount toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">0</characterCount>
+      <author toolname="Tika" toolversion="1.10" status="SINGLE_RESULT">Aloisio, Paul G.</author>
+      <standard>
+        <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
+          <docmd:PageCount>1</docmd:PageCount>
+          <docmd:WordCount>0</docmd:WordCount>
+          <docmd:CharacterCount>0</docmd:CharacterCount>
+        </docmd:document>
+      </standard>
+    </document>
+  </metadata>
+</fits>
+

--- a/tests/edu/harvard/hul/ois/fits/FitsOutputVersionTest.java
+++ b/tests/edu/harvard/hul/ois/fits/FitsOutputVersionTest.java
@@ -4,14 +4,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
+import org.jdom.Document;
 import org.jdom.JDOMException;
+import org.jdom.input.SAXBuilder;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.exceptions.FitsConfigurationException;
 import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 
 public class FitsOutputVersionTest extends AbstractLoggingTest {
@@ -19,28 +23,23 @@ public class FitsOutputVersionTest extends AbstractLoggingTest {
 	private static Logger logger = LogManager.getLogger(FitsOutputVersionTest.class);
 
 	/**
-	 * Test to make sure Fits version initialization is passed along to FitsOutput class.
+	 * Test output of Fits version from the input file to FitsOutput.
 	 */
 	@Test
-	public void testFitsVersion() {
-		// Must instantiate class to initialize version number.
+	public void testFitsOutputVersion() {
+
 		try {
-			// Must instantiate class to initialize version number.
-			@SuppressWarnings("unused")
-			Fits fits = new Fits();
-		} catch (FitsConfigurationException e1) {
-			fail("Could not properly initialize Fits.java");
-		}
-		logger.info("Fits version: " + Fits.VERSION);
-		FitsOutput fitsOutput = null;
-		try {
-			fitsOutput = new FitsOutput("<test></test>");
+			Reader in = new FileReader(new File("testfiles/FitsOutputTest.xml"));
+			SAXBuilder builder = new SAXBuilder();
+			Document fitsXml = builder.build(in);
+			FitsOutput fitsOutput = new FitsOutput(fitsXml);
+			assertNotNull(fitsOutput);
+			String inputVersion = fitsOutput.getFitsVersion();
+			assertNotNull(inputVersion);
+			assertEquals("FitsOutput version not the same as input file version", "1.1.0", inputVersion);
 		} catch (JDOMException | IOException e) {
-			fail("Could not parse input document");
+			fail("Could not parse input document: " + e.getClass().getSimpleName() + " -- " + e.getMessage());
 		}
-		assertNotNull(Fits.VERSION);
-		assertNotNull(fitsOutput);
-		assertEquals("FitsOutput version not the same as Fits version", Fits.VERSION, fitsOutput.getFitsVersion());
 	}
 		
 }


### PR DESCRIPTION
FitsOutput now gives the FITS version number of the input file that created the instance of this class rather than redundantly providing the FITS version that is currently running, which is already provided by Fits.VERSION.