### PR TITLE
update tika code to include filename in input

### DIFF
--- a/src/main/java/edu/harvard/hul/ois/fits/tools/tika/TikaTool.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/tika/TikaTool.java
@@ -455,7 +455,7 @@ public class TikaTool extends ToolBase {
         } finally {
             try {
                 instrm.close();
-            } catch (IOException e) {
+            } catch (Exception e) {
                 logger.debug("Failed to close input stream for file " + file.getAbsolutePath());
             }
         }

--- a/src/test/java/edu/harvard/hul/ois/fits/tools/tika/TikaToolTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/tools/tika/TikaToolTest.java
@@ -1,0 +1,37 @@
+package edu.harvard.hul.ois.fits.tools.tika;
+
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import edu.harvard.hul.ois.fits.identity.ToolIdentity;
+import edu.harvard.hul.ois.fits.tools.ToolOutput;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+public class TikaToolTest {
+
+    private static final String RESOURCE_DIR = "src/test/resources/test-files/";
+
+    private TikaTool tool;
+
+    @Before
+    public void setup() throws Exception {
+        tool = new TikaTool(new Fits());
+    }
+
+    @Test
+    public void shouldDetectFormatBasedOnFileName() throws FitsToolException {
+        File file = new File(RESOURCE_DIR + "example.kml");
+        ToolOutput output = tool.extractInfo(file);
+
+        assertEquals(1, output.getFileIdentity().size());
+
+        ToolIdentity identity = output.getFileIdentity().get(0);
+        assertEquals("application/vnd.google-earth.kml+xml", identity.getMime());
+        assertEquals("Keyhole Markup Language", identity.getFormat());
+    }
+
+}

--- a/src/test/resources/test-files/example.kml
+++ b/src/test/resources/test-files/example.kml
@@ -1,0 +1,11 @@
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Document>
+        <Placemark>
+            <name>New York City</name>
+            <description>New York City</description>
+            <Point>
+                <coordinates>-74.006393,40.714172,0</coordinates>
+            </Point>
+        </Placemark>
+    </Document>
+</kml>

--- a/testfiles/output/32044020597662.zip_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/32044020597662.zip_XmlUnitExpectedOutput.xml
@@ -14,7 +14,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/32044020597662.zip</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">32044020597662.zip</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">95270</size>
+    <size toolname="OIS File Information" toolversion="0.2">95270</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">7c64750915af83a39c35f0e836d3690f</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117982000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/40415587.zip_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/40415587.zip_XmlUnitExpectedOutput.xml
@@ -14,7 +14,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/40415587.zip</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">40415587.zip</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">12716562</size>
+    <size toolname="OIS File Information" toolversion="0.2">12716562</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">f91dd3fdf89cc68860029b0ee785ad96</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117982000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/Calibre_hasTable_of_Contents.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Calibre_hasTable_of_Contents.epub_XmlUnitExpectedOutput.xml
@@ -11,7 +11,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Calibre_hasTable_of_Contents.epub</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Calibre_hasTable_of_Contents.epub</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">465875</size>
+    <size toolname="OIS File Information" toolversion="0.2">465875</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1e107d085c284806cd32029021152478</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117982000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/Doc2.rtf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Doc2.rtf_XmlUnitExpectedOutput.xml
@@ -15,7 +15,7 @@
     <created toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2015:09:24 12:16:00</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Doc2.rtf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Doc2.rtf</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">26328</size>
+    <size toolname="OIS File Information" toolversion="0.2">26328</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">26301ff11c920c4e32f9fa7d706390a6</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117982000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/Document_Has_Form_Controls.docm_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Document_Has_Form_Controls.docm_XmlUnitExpectedOutput.xml
@@ -14,7 +14,7 @@
     <creatingApplicationVersion toolname="Exiftool" toolversion="10.00">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Document_Has_Form_Controls.docm</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Document_Has_Form_Controls.docm</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">117650</size>
+    <size toolname="OIS File Information" toolversion="0.2">117650</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">acd68a6f5ba25303486add10a62a673e</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1455050482000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/GeographyofBliss_oneChapter.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/GeographyofBliss_oneChapter.epub_XmlUnitExpectedOutput.xml
@@ -11,7 +11,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/GeographyofBliss_oneChapter.epub</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">GeographyofBliss_oneChapter.epub</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">198197</size>
+    <size toolname="OIS File Information" toolversion="0.2">198197</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">52c6dedc6e49c0e8bdd3ac85016640e3</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/Jess26676_Pugua.mp3_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Jess26676_Pugua.mp3_XmlUnitExpectedOutput.xml
@@ -14,7 +14,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/Documents/FITS-WP-test/input/Jess26676_Pugua.mp3</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Jess26676_Pugua.mp3</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1720048</size>
+    <size toolname="OIS File Information" toolversion="0.2">1720048</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">50ed497b874395b36be63cbe1f82bcc2</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1242226524000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/LibreODT-Ur-doc.odt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/LibreODT-Ur-doc.odt_XmlUnitExpectedOutput.xml
@@ -15,7 +15,7 @@
     <creatingApplicationName toolname="Exiftool" toolversion="11.01">LibreOffice/5.0.1.2$Windows_x86 LibreOffice_project/81898c9f5c0d43f3473ba111d7b351050be20261</creatingApplicationName>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/LibreODT-Ur-doc.odt</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">LibreODT-Ur-doc.odt</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">25372</size>
+    <size toolname="OIS File Information" toolversion="0.2">25372</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">a7054b796a98100e06028cd69d163581</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1453908574000</fslastmodified>
     <lastmodified toolname="Tika" toolversion="1.18" status="SINGLE_RESULT">2015-09-21T12:27:51.129000000</lastmodified>

--- a/testfiles/output/LibreODT-hasTables.odt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/LibreODT-hasTables.odt_XmlUnitExpectedOutput.xml
@@ -15,7 +15,7 @@
     <creatingApplicationName toolname="Exiftool" toolversion="11.01">LibreOffice/5.0.1.2$Windows_x86 LibreOffice_project/81898c9f5c0d43f3473ba111d7b351050be20261</creatingApplicationName>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/LibreODT-hasTables.odt</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">LibreODT-hasTables.odt</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">24346</size>
+    <size toolname="OIS File Information" toolversion="0.2">24346</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">e1ac7119f6590ad1a11c6aa341c6dfbe</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
     <lastmodified toolname="Tika" toolversion="1.18" status="SINGLE_RESULT">2015-09-21T12:11:26.720000000</lastmodified>

--- a/testfiles/output/LibreODTwFormulas.odt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/LibreODTwFormulas.odt_XmlUnitExpectedOutput.xml
@@ -15,7 +15,7 @@
     <creatingApplicationName toolname="Exiftool" toolversion="11.01">LibreOffice/5.0.1.2$Windows_x86 LibreOffice_project/81898c9f5c0d43f3473ba111d7b351050be20261</creatingApplicationName>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/LibreODTwFormulas.odt</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">LibreODTwFormulas.odt</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">20133</size>
+    <size toolname="OIS File Information" toolversion="0.2">20133</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">fed4921e096db80dcaab1dd5cb490915</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
     <lastmodified toolname="Tika" toolversion="1.18" status="SINGLE_RESULT">2015-09-21T11:44:36.875000000</lastmodified>

--- a/testfiles/output/LibreOffice.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/LibreOffice.doc_XmlUnitExpectedOutput.xml
@@ -20,7 +20,7 @@
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-12-14 11:12:58</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/LibreOffice.doc</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">LibreOffice.doc</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">10240</size>
+    <size toolname="OIS File Information" toolversion="0.2">10240</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">2520885e1d9e43b13d8dab9009393b56</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/MacMSWORD_4-5.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/MacMSWORD_4-5.doc_XmlUnitExpectedOutput.xml
@@ -12,7 +12,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/MacMSWORD_4-5.doc</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">MacMSWORD_4-5.doc</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">2047</size>
+    <size toolname="OIS File Information" toolversion="0.2">2047</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">edc1036fd68b60ba62af22aa269fc0a8</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/NEWSSLID_Word2_0.DOC_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/NEWSSLID_Word2_0.DOC_XmlUnitExpectedOutput.xml
@@ -15,7 +15,7 @@
     <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">Word 2.0</creatingApplicationName>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/NEWSSLID_Word2_0.DOC</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">NEWSSLID_Word2_0.DOC</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">10405</size>
+    <size toolname="OIS File Information" toolversion="0.2">10405</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">71649cd49b8cd0bc37f8643b2ee84c75</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/TestDoc.rtf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/TestDoc.rtf_XmlUnitExpectedOutput.xml
@@ -15,7 +15,7 @@
     <created toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2015:08:05 09:25:00</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/TestDoc.rtf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">TestDoc.rtf</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">29650</size>
+    <size toolname="OIS File Information" toolversion="0.2">29650</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">7ef9fd20c3545d3f29a79a9d77d85a03</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/UnparseableDate.odt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/UnparseableDate.odt_XmlUnitExpectedOutput.xml
@@ -15,7 +15,7 @@
     <creatingApplicationName toolname="Exiftool" toolversion="11.01">OpenOffice/4.1.1$Unix OpenOffice.org_project/411m6$Build-9775</creatingApplicationName>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/UnparseableDate.odt</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">UnparseableDate.odt</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">14422</size>
+    <size toolname="OIS File Information" toolversion="0.2">14422</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">2989e29ad588371b48a0eef61029d086</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1453908574000</fslastmodified>
     <lastmodified toolname="Tika" toolversion="1.18" status="SINGLE_RESULT">2015-08-05T08:25:00</lastmodified>

--- a/testfiles/output/Winnie-the-Pooh-protected.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Winnie-the-Pooh-protected.epub_XmlUnitExpectedOutput.xml
@@ -9,7 +9,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Winnie-the-Pooh-protected.epub</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Winnie-the-Pooh-protected.epub</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">15107043</size>
+    <size toolname="OIS File Information" toolversion="0.2">15107043</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">4ccb561ddebda70324926895899cd27c</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1453908574000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/Word2003PasswordProtected.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2003PasswordProtected.doc_XmlUnitExpectedOutput.xml
@@ -17,7 +17,7 @@
     <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2003PasswordProtected.doc</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Word2003PasswordProtected.doc</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">243712</size>
+    <size toolname="OIS File Information" toolversion="0.2">243712</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">e40cc3565482b4cef61a00c198e4e68b</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1453908574000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/Word2003_has_URLs_has_embedded_resources.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2003_has_URLs_has_embedded_resources.doc_XmlUnitExpectedOutput.xml
@@ -17,7 +17,7 @@
     <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">12.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2003_has_URLs_has_embedded_resources.doc</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Word2003_has_URLs_has_embedded_resources.doc</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1554944</size>
+    <size toolname="OIS File Information" toolversion="0.2">1554944</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">ebfe839dc828089505ec2490f5dfac63</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/Word2003_has_table_of_contents.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2003_has_table_of_contents.doc_XmlUnitExpectedOutput.xml
@@ -17,7 +17,7 @@
     <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2003_has_table_of_contents.doc</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Word2003_has_table_of_contents.doc</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">99328</size>
+    <size toolname="OIS File Information" toolversion="0.2">99328</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">afb707e78e777bebf7563534f2d51762</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/Word2003_many_graphics.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2003_many_graphics.doc_XmlUnitExpectedOutput.xml
@@ -17,7 +17,7 @@
     <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2003_many_graphics.doc</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Word2003_many_graphics.doc</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">528896</size>
+    <size toolname="OIS File Information" toolversion="0.2">528896</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">f2b172182cb10edc2c1d65dd44a7b9e0</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/Word2011_Has_Outline.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2011_Has_Outline.doc_XmlUnitExpectedOutput.xml
@@ -17,7 +17,7 @@
     <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2011_Has_Outline.doc</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Word2011_Has_Outline.doc</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">28672</size>
+    <size toolname="OIS File Information" toolversion="0.2">28672</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">c5dd4b2ac16c2d192ee36303f7b13ab6</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/WordPasswordProtected.docx_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPasswordProtected.docx_XmlUnitExpectedOutput.xml
@@ -14,7 +14,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/WordPasswordProtected.docx</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">WordPasswordProtected.docx</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">242176</size>
+    <size toolname="OIS File Information" toolversion="0.2">242176</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">bfc6125db60e834e6b9e7210970a6233</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1458055219000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/Word_has_index.docx_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word_has_index.docx_XmlUnitExpectedOutput.xml
@@ -18,7 +18,7 @@
     <creatingApplicationVersion toolname="Exiftool" toolversion="10.00">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Word_has_index.docx</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Word_has_index.docx</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">39310</size>
+    <size toolname="OIS File Information" toolversion="0.2">39310</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">915d4914b6516586a4e05d32ccb27b35</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1455055714000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/Word_protected_encrypted.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word_protected_encrypted.doc_XmlUnitExpectedOutput.xml
@@ -17,7 +17,7 @@
     <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word_protected_encrypted.doc</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Word_protected_encrypted.doc</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">22528</size>
+    <size toolname="OIS File Information" toolversion="0.2">22528</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1a83eafb0583f1a719bfbe1b87c19df6</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/aliceDynamic_images_metadata_tableOfContents.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/aliceDynamic_images_metadata_tableOfContents.epub_XmlUnitExpectedOutput.xml
@@ -8,7 +8,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/aliceDynamic_images_metadata_tableOfContents.epub</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">aliceDynamic_images_metadata_tableOfContents.epub</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1135531</size>
+    <size toolname="OIS File Information" toolversion="0.2">1135531</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">4fce60e013fbb16c67514ae5bfd9b846</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1454956776000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/aliceDynamic_images_metadata_tableOfContents.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/aliceDynamic_images_metadata_tableOfContents.epub_XmlUnitExpectedOutput.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.11.0" timestamp="2/12/16 10:01 AM">
-  <identification status="SINGLE_RESULT">
+  <identification status="CONFLICT">
     <identity format="EPUB" mimetype="application/zip" toolname="FITS" toolversion="0.11.0">
       <tool toolname="Exiftool" toolversion="10.00" />
+    </identity>
+    <identity format="EPUB" mimetype="application/epub+zip" toolname="FITS" toolversion="0.11.0">
+      <tool toolname="Tika" toolversion="1.10" />
     </identity>
   </identification>
   <fileinfo>

--- a/testfiles/output/assorted-files.zip_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/assorted-files.zip_XmlUnitExpectedOutput.xml
@@ -14,7 +14,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/assorted-files.zip</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">assorted-files.zip</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">30400659</size>
+    <size toolname="OIS File Information" toolversion="0.2">30400659</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">381dd28336fef8e188ebec5c6c29c596</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/compressed-encrypted.zip_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/compressed-encrypted.zip_XmlUnitExpectedOutput.xml
@@ -14,7 +14,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/compressed-encrypted.zip</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">compressed-encrypted.zip</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">18284445</size>
+    <size toolname="OIS File Information" toolversion="0.2">18284445</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">3f3d6583101f3967ad285c8064bf746f</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/epub30-test-font-embedding-obfuscation.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/epub30-test-font-embedding-obfuscation.epub_XmlUnitExpectedOutput.xml
@@ -11,7 +11,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/epub30-test-font-embedding-obfuscation.epub</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">epub30-test-font-embedding-obfuscation.epub</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1176408</size>
+    <size toolname="OIS File Information" toolversion="0.2">1176408</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">8fcf4ac8f3ba4670ff204b200d1a910e</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1454956776000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/multiple-file-types-and-folders.zip_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/multiple-file-types-and-folders.zip_XmlUnitExpectedOutput.xml
@@ -14,7 +14,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/multiple-file-types-and-folders.zip</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">multiple-file-types-and-folders.zip</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">2210087</size>
+    <size toolname="OIS File Information" toolversion="0.2">2210087</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">48ab8c8077485276e99b7d0e58ccc2e8</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1554302812000</fslastmodified>
   </fileinfo>

--- a/testfiles/output/uncompressed-encrypted.zip_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/uncompressed-encrypted.zip_XmlUnitExpectedOutput.xml
@@ -14,7 +14,7 @@
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/uncompressed-encrypted.zip</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">uncompressed-encrypted.zip</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">18851920</size>
+    <size toolname="OIS File Information" toolversion="0.2">18851920</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">794d9bfc7a6743dbde2c04919136e152</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117984000</fslastmodified>
   </fileinfo>


### PR DESCRIPTION
Resolves #211 

In addition to fixing the Tika input stream, this PR also fixes a bug with how the file size was being set from the Tika code, which resulted in a large number of test expectations needing to be updated.