### PR TITLE
fix mediainfo lib loading

### DIFF
--- a/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoNativeWrapper.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoNativeWrapper.java
@@ -60,7 +60,7 @@ class MediaInfoNativeWrapper
                final String LocalPath;
                if (loader!=null)
                {
-                   LocalPath=loader.getResource(MediaInfoNativeWrapper.class.getName().replace('.', '/')+ ".class").getPath().replace("MediaInfo.class", "");
+                   LocalPath=loader.getResource(MediaInfoNativeWrapper.class.getName().replace('.', '/')+ ".class").getPath().replace("MediaInfoNativeWrapper.class", "");
                    try
                    {
                        NativeLibrary.getInstance(LocalPath+"libzen.so.0"); // Local path
@@ -84,6 +84,7 @@ class MediaInfoNativeWrapper
                    }
                    catch (LinkageError e)
                    {
+                       NativeLibrary.getInstance("mediainfo");
                    }
                }
            }


### PR DESCRIPTION
This should resolve #198.

For me, the original error is extremely inconsistent. It happens perhaps 1 out of 10 runs. It's not clear to me exactly what the problem is. However, the existing code does load the libzen but it does not load libmediainfo correctly. This PR fixes the loading the of the library, and appears to resolve the issue. I have executed FITS repeatedly and am no longer seeing the problem.