### PR TITLE
exif timestamp parsing should not infer timezone

### DIFF
--- a/testfiles/output/4072820.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/4072820.tif_XmlUnitExpectedOutput.xml
@@ -120,7 +120,7 @@
           </mix:BasicImageInformation>
           <mix:ImageCaptureMetadata>
             <mix:GeneralCaptureInformation>
-              <mix:dateTimeCreated>2005-12-15T15:56:19.0Z</mix:dateTimeCreated>
+              <mix:dateTimeCreated>2005-12-15T10:56:19</mix:dateTimeCreated>
               <mix:captureDevice>digital still camera</mix:captureDevice>
             </mix:GeneralCaptureInformation>
             <mix:ScannerCapture>

--- a/testfiles/output/ICFA.KC.BIA.1524-small.jpg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/ICFA.KC.BIA.1524-small.jpg_XmlUnitExpectedOutput.xml
@@ -99,7 +99,7 @@
           </mix:BasicImageInformation>
           <mix:ImageCaptureMetadata>
             <mix:GeneralCaptureInformation>
-              <mix:dateTimeCreated>2010-07-07T18:22:53.0Z</mix:dateTimeCreated>
+              <mix:dateTimeCreated>2010-07-07T14:22:53</mix:dateTimeCreated>
             </mix:GeneralCaptureInformation>
             <mix:ScannerCapture>
               <mix:ScanningSystemSoftware>

--- a/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
@@ -106,7 +106,7 @@
           </mix:BasicImageInformation>
           <mix:ImageCaptureMetadata>
             <mix:GeneralCaptureInformation>
-              <mix:dateTimeCreated>2014-10-27T16:34:43.0Z</mix:dateTimeCreated>
+              <mix:dateTimeCreated>2014-10-27T12:34:43</mix:dateTimeCreated>
               <mix:captureDevice>digital still camera</mix:captureDevice>
             </mix:GeneralCaptureInformation>
             <mix:ScannerCapture>

--- a/testfiles/output/gps.jpg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/gps.jpg_XmlUnitExpectedOutput.xml
@@ -107,7 +107,7 @@
           </mix:BasicImageInformation>
           <mix:ImageCaptureMetadata>
             <mix:GeneralCaptureInformation>
-              <mix:dateTimeCreated>2006-11-03T12:14:39.0Z</mix:dateTimeCreated>
+              <mix:dateTimeCreated>2006-11-03T07:14:39</mix:dateTimeCreated>
               <mix:captureDevice>digital still camera</mix:captureDevice>
             </mix:GeneralCaptureInformation>
             <mix:ScannerCapture>

--- a/testfiles/output/test.jp2_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/test.jp2_XmlUnitExpectedOutput.xml
@@ -77,7 +77,7 @@
           </mix:BasicImageInformation>
           <mix:ImageCaptureMetadata>
             <mix:GeneralCaptureInformation>
-              <mix:dateTimeCreated>2007-09-21T04:00:00.0Z</mix:dateTimeCreated>
+              <mix:dateTimeCreated>2007-09-21T00:00:00</mix:dateTimeCreated>
             </mix:GeneralCaptureInformation>
             <mix:ScannerCapture>
               <mix:scannerManufacturer>Google</mix:scannerManufacturer>

--- a/testfiles/output/topazscanner.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/topazscanner.tif_XmlUnitExpectedOutput.xml
@@ -101,7 +101,7 @@
           </mix:BasicImageInformation>
           <mix:ImageCaptureMetadata>
             <mix:GeneralCaptureInformation>
-              <mix:dateTimeCreated>2006-11-28T17:22:59.0Z</mix:dateTimeCreated>
+              <mix:dateTimeCreated>2006-11-28T12:22:59</mix:dateTimeCreated>
             </mix:GeneralCaptureInformation>
             <mix:ScannerCapture>
               <mix:scannerManufacturer>HDPPKIEL</mix:scannerManufacturer>


### PR DESCRIPTION
This PR resolves https://github.com/harvard-lts/fits/issues/216. It addresses two problems:

1. Exif timestamps are not recorded with a timezone and a timezone should not be inferred unless there is relevant GPS or XMP data. However, the code was parsing these timestamps in local time and then formatting them as UTC.
2. The timestamps were being written in the format `yyyy-MM-dd'T'HH:mm:ss.S'Z'` to a `mix:dateTimeCreated` element. However, the [Mix schema](https://www.loc.gov/standards/mix/mix.xsd) defines this tag as `xsd:dateTime` which must be formatted as `yyyy-MM-ddTHH:mm:ss[Z|(+|-)hh:mm]`. That is to say, it cannot include fractional seconds.