### PR TITLE
add created timestamp from tika

### DIFF
--- a/src/main/java/edu/harvard/hul/ois/fits/FitsMetadataValues.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/FitsMetadataValues.java
@@ -74,6 +74,7 @@ public class FitsMetadataValues {
     public final static String COLOR_SPACE = "colorSpace";
     public final static String COMPANY = "company";
     public final static String COMPRESSION_SCHEME = "compressionScheme";
+    public final static String CREATED = "created";
     public final static String CREATING_APPLICATION_NAME = "creatingApplicationName";
     public final static String CREATING_APPLICATION_VERSION = "creatingApplicationVersion";
     public final static String DATA_FORMAT_TYPE = "dataFormatType";

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/tika/TikaTool.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/tika/TikaTool.java
@@ -589,6 +589,12 @@ public class TikaTool extends ToolBase {
             fileInfoElem.addContent (lastModElem);
         }
 
+        if (created != null) {
+            Element createdElem = new Element (FitsMetadataValues.CREATED, fitsNS);
+            createdElem.addContent(created);
+            fileInfoElem.addContent(createdElem);
+        }
+
         if (appName != null) {
             Element appNameElem = new Element (FitsMetadataValues.CREATING_APPLICATION_NAME, fitsNS);
             appNameElem.addContent (appName);

--- a/testfiles/output/4072820.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/4072820.tif_XmlUnitExpectedOutput.xml
@@ -15,7 +15,8 @@
     <creatingApplicationName toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">Adobe Photoshop CS Macintosh</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="11.14" status="CONFLICT">2005:12:15 12:46:50</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.20" status="CONFLICT">2005-12-15T07:46:50</lastmodified>
-    <created toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">2005:12:15 10:56:19-05:00</created>
+    <created toolname="Exiftool" toolversion="11.14" status="CONFLICT">2005:12:15 10:56:19-05:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2005-12-15T04:56:19</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/4072820.tif</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">4072820.tif</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">4a333061a5619b94aa5afc3bb106eb54</md5checksum>

--- a/testfiles/output/Book_pdfx1a.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Book_pdfx1a.pdf_XmlUnitExpectedOutput.xml
@@ -11,7 +11,8 @@
     <creatingApplicationName toolname="Jhove" toolversion="1.11">Adobe PDF Library 10.0.1/Adobe InDesign CS6 (Windows)</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:08:20 18:29:04-04:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2015-08-20T22:29:04Z</lastmodified>
-    <created toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2015:08:20 18:29-04:00</created>
+    <created toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:08:20 18:29-04:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-08-20T22:29:00Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Book_pdfx1a.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Book_pdfx1a.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">2d4fc60b4498c7cb63a95d7d247f6160</md5checksum>

--- a/testfiles/output/Calibre_hasTable_of_Contents.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Calibre_hasTable_of_Contents.epub_XmlUnitExpectedOutput.xml
@@ -9,6 +9,7 @@
     </identity>
   </identification>
   <fileinfo>
+    <created toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">2015-08-01T08:34:26.276379+00:00</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Calibre_hasTable_of_Contents.epub</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Calibre_hasTable_of_Contents.epub</filename>
     <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">465875</size>

--- a/testfiles/output/Doc2.rtf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Doc2.rtf_XmlUnitExpectedOutput.xml
@@ -12,7 +12,8 @@
   </identification>
   <fileinfo>
     <lastmodified toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2015:09:24 12:17:00</lastmodified>
-    <created toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2015:09:24 12:16:00</created>
+    <created toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:09:24 12:16:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-09-24T17:16:00Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Doc2.rtf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Doc2.rtf</filename>
     <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">26328</size>

--- a/testfiles/output/Document_Has_Form_Controls.docm_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Document_Has_Form_Controls.docm_XmlUnitExpectedOutput.xml
@@ -9,7 +9,8 @@
   <fileinfo>
     <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:09:30 20:34:00Z</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2015-09-30T20:34:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2015:09:30 20:34:00Z</created>
+    <created toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:09:30 20:34:00Z</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-09-30T20:34:00Z</created>
     <creatingApplicationName toolname="Tika" toolversion="1.10" status="SINGLE_RESULT">Microsoft Office Word</creatingApplicationName>
     <creatingApplicationVersion toolname="Exiftool" toolversion="10.00">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Document_Has_Form_Controls.docm</filepath>

--- a/testfiles/output/GeographyofBliss_oneChapter.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/GeographyofBliss_oneChapter.epub_XmlUnitExpectedOutput.xml
@@ -9,6 +9,7 @@
     </identity>
   </identification>
   <fileinfo>
+    <created toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">2008-01-03</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/GeographyofBliss_oneChapter.epub</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">GeographyofBliss_oneChapter.epub</filename>
     <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">198197</size>

--- a/testfiles/output/HasChangeHistory.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/HasChangeHistory.pdf_XmlUnitExpectedOutput.xml
@@ -18,7 +18,8 @@
     <creatingApplicationName toolname="Exiftool" toolversion="10.00">Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:08:19 17:10:57-04:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2015-08-19T21:10:57Z</lastmodified>
-    <created toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2015:08:19 17:10:14-04:00</created>
+    <created toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:08:19 17:10:14-04:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-08-19T21:10:14Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/HasChangeHistory.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">HasChangeHistory.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">ad18d1a191b7ab53614f3d003fa60472</md5checksum>

--- a/testfiles/output/ICFA.KC.BIA.1524-small.jpg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/ICFA.KC.BIA.1524-small.jpg_XmlUnitExpectedOutput.xml
@@ -21,6 +21,7 @@
     <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2017-01-30T06:39:51</lastmodified>
     <created toolname="Exiftool" toolversion="11.01" status="CONFLICT">2010:07:07 14:22:53</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2017:01:30 11:39:51</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2010-07-07T09:22:53</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/ICFA.KC.BIA.1524-small.jpg</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">ICFA.KC.BIA.1524-small.jpg</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">0108175c9153da1d41278066a2e3c1a2</md5checksum>

--- a/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
@@ -20,6 +20,7 @@
     <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-06-25T07:03:38</lastmodified>
     <created toolname="Exiftool" toolversion="11.01" status="CONFLICT">2014:10:27 12:34:43</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015:06:25 11:03:38</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2014-10-27T07:34:43</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/JPEGTest_20170591--JPEGTest_20170591.jpeg</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">JPEGTest_20170591--JPEGTest_20170591.jpeg</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">3c5a86c471809d347e99d19c51bd1b94</md5checksum>

--- a/testfiles/output/LibreODT-Ur-doc.odt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/LibreODT-Ur-doc.odt_XmlUnitExpectedOutput.xml
@@ -12,6 +12,7 @@
     </identity>
   </identification>
   <fileinfo>
+    <created toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">2015-09-21T11:45:06.295000000</created>
     <creatingApplicationName toolname="Exiftool" toolversion="11.01">LibreOffice/5.0.1.2$Windows_x86 LibreOffice_project/81898c9f5c0d43f3473ba111d7b351050be20261</creatingApplicationName>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/LibreODT-Ur-doc.odt</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">LibreODT-Ur-doc.odt</filename>

--- a/testfiles/output/LibreODT-hasTables.odt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/LibreODT-hasTables.odt_XmlUnitExpectedOutput.xml
@@ -12,6 +12,7 @@
     </identity>
   </identification>
   <fileinfo>
+    <created toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">2015-09-21T11:45:06.295000000</created>
     <creatingApplicationName toolname="Exiftool" toolversion="11.01">LibreOffice/5.0.1.2$Windows_x86 LibreOffice_project/81898c9f5c0d43f3473ba111d7b351050be20261</creatingApplicationName>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/LibreODT-hasTables.odt</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">LibreODT-hasTables.odt</filename>

--- a/testfiles/output/LibreODTwFormulas.odt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/LibreODTwFormulas.odt_XmlUnitExpectedOutput.xml
@@ -12,6 +12,7 @@
     </identity>
   </identification>
   <fileinfo>
+    <created toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">2015-09-21T11:42:44.173000000</created>
     <creatingApplicationName toolname="Exiftool" toolversion="11.01">LibreOffice/5.0.1.2$Windows_x86 LibreOffice_project/81898c9f5c0d43f3473ba111d7b351050be20261</creatingApplicationName>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/LibreODTwFormulas.odt</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">LibreODTwFormulas.odt</filename>

--- a/testfiles/output/LibreOffice.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/LibreOffice.doc_XmlUnitExpectedOutput.xml
@@ -18,6 +18,7 @@
     <lastmodified toolname="Tika" toolversion="1.19.1" status="CONFLICT">2016-01-15T20:03:34Z</lastmodified>
     <created toolname="Exiftool" toolversion="11.14" status="CONFLICT">2015:12:14 16:12:58</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-12-14 11:12:58</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-12-14T16:12:58Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/LibreOffice.doc</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">LibreOffice.doc</filename>
     <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">10240</size>

--- a/testfiles/output/MMS-82A.08.12.02.ai_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/MMS-82A.08.12.02.ai_XmlUnitExpectedOutput.xml
@@ -11,7 +11,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.16">561633</size>
     <creatingApplicationName toolname="Jhove" toolversion="1.16">Adobe PDF library 4.800/Adobe Illustrator 9.0</creatingApplicationName>
-    <created toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2002:08:10 18:43:47</created>
+    <created toolname="Exiftool" toolversion="10.00" status="CONFLICT">2002:08:10 18:43:47</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2002-08-10T18:43:47Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/MMS-82A.08.12.02.ai</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">MMS-82A.08.12.02.ai</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">b09e1524642c0166da3566d4c7e03871</md5checksum>

--- a/testfiles/output/PDFA_Document with tables.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFA_Document with tables.pdf_XmlUnitExpectedOutput.xml
@@ -15,7 +15,8 @@
     <creatingApplicationName toolname="Jhove" toolversion="1.20">Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 18:32:33-04:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T22:32:33Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2015:08:19 18:32:31-04:00</created>
+    <created toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 18:32:31-04:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-08-19T22:32:31Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFA_Document with tables.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFA_Document with tables.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">fd8c309140462d55d6a76e5e3ec709ee</md5checksum>

--- a/testfiles/output/PDF_embedded_resources.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDF_embedded_resources.pdf_XmlUnitExpectedOutput.xml
@@ -18,7 +18,8 @@
     <creatingApplicationName toolname="Exiftool" toolversion="10.00">Acrobat Distiller 8.1.0 (Windows)/Adobe PageMaker 6.52</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:08:19 16:17:32-04:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2015-08-19T20:17:32Z</lastmodified>
-    <created toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2008:09:24 15:27:24-04:00</created>
+    <created toolname="Exiftool" toolversion="10.00" status="CONFLICT">2008:09:24 15:27:24-04:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2008-09-24T19:27:24Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDF_embedded_resources.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDF_embedded_resources.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">dbfbf8c633100f5d4301fed7b65ad698</md5checksum>

--- a/testfiles/output/PDF_eng.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDF_eng.pdf_XmlUnitExpectedOutput.xml
@@ -18,7 +18,8 @@
     <creatingApplicationName toolname="Jhove" toolversion="1.11">Acrobat Distiller 6.0.1 for Macintosh/QuarkXPress: pictwpstops filter 1.0</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2004:10:15 13:06:47-04:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2004-10-15T17:06:47Z</lastmodified>
-    <created toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2004:10:15 12:35:50-04:00</created>
+    <created toolname="Exiftool" toolversion="10.00" status="CONFLICT">2004:10:15 12:35:50-04:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2004-10-15T16:35:50Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDF_eng.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDF_eng.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">4ef7c6dd77d598fe8f60f84af8e4e7de</md5checksum>

--- a/testfiles/output/PDFa_embedded_resources.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_embedded_resources.pdf_XmlUnitExpectedOutput.xml
@@ -15,7 +15,8 @@
     <creatingApplicationName toolname="Jhove" toolversion="1.20">Acrobat Distiller 8.1.0 (Windows)/Adobe PageMaker 6.52</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 17:53-04:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T21:53:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2008:09:24 15:27:24-04:00</created>
+    <created toolname="Exiftool" toolversion="11.01" status="CONFLICT">2008:09:24 15:27:24-04:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2008-09-24T19:27:24Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFa_embedded_resources.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_embedded_resources.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">12b6269615243b9a62cc9181796e76bd</md5checksum>

--- a/testfiles/output/PDFa_equations.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_equations.pdf_XmlUnitExpectedOutput.xml
@@ -15,7 +15,8 @@
     <creatingApplicationName toolname="Jhove" toolversion="1.20">Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 19:13:22-04:00 2015:08:19 19:13:22-04:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T23:13:22Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2015:08:19 19:12:42-04:00</created>
+    <created toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 19:12:42-04:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-08-19T23:12:42Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFa_equations.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_equations.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">83fa9407b0ddf13a38579a18fe9f7734</md5checksum>

--- a/testfiles/output/PDFa_has_form.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_form.pdf_XmlUnitExpectedOutput.xml
@@ -16,7 +16,8 @@
     <creatingApplicationName toolname="Exiftool" toolversion="11.01" status="CONFLICT">JagPDF 1.5.0, http://jagpdf.org/Pdfcrowd - online HTML to PDF API - http://pdfcrowd.com</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 18:34:33-04:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T22:34:33Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2015:08:19 18:33:55-04:00</created>
+    <created toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 18:33:55-04:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-08-19T22:33:55Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFa_has_form.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_has_form.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">553682ae868f787654f5b2da6925861e</md5checksum>

--- a/testfiles/output/PDFa_has_table_of_contents.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_table_of_contents.pdf_XmlUnitExpectedOutput.xml
@@ -14,7 +14,8 @@
     <creatingApplicationName toolname="Jhove" toolversion="1.20">Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 18:15:37-04:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T22:15:37Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2015:08:19 16:44:12-04:00</created>
+    <created toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 16:44:12-04:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-08-19T20:44:12Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFa_has_table_of_contents.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_has_table_of_contents.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">537d5a41d854b5c03f8bb33041faf1aa</md5checksum>

--- a/testfiles/output/PDFa_has_tables.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_tables.pdf_XmlUnitExpectedOutput.xml
@@ -15,7 +15,8 @@
     <creatingApplicationName toolname="Jhove" toolversion="1.20">Mac OS X 10.5.6 Quartz PDFContext/XPP</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 18:29:41-04:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T22:29:41Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2009:04:13 18:38:02Z</created>
+    <created toolname="Exiftool" toolversion="11.01" status="CONFLICT">2009:04:13 18:38:02Z</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2009-04-13T18:38:02Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFa_has_tables.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_has_tables.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">fd321cedf56dec077704cfd5e0b6dbca</md5checksum>

--- a/testfiles/output/PDFa_multiplefonts.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_multiplefonts.pdf_XmlUnitExpectedOutput.xml
@@ -15,7 +15,8 @@
     <creatingApplicationName toolname="Jhove" toolversion="1.20">Acrobat Distiller 8.1.0 (Windows)/records policy.doc - Microsoft Word</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 17:45:08-04:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T21:45:08Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2008:09:24 15:27:39-04:00</created>
+    <created toolname="Exiftool" toolversion="11.01" status="CONFLICT">2008:09:24 15:27:39-04:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2008-09-24T19:27:39Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFa_multiplefonts.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_multiplefonts.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">ba84a24c8d09b76b1f02e359c36ebbda</md5checksum>

--- a/testfiles/output/PDFx3.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFx3.pdf_XmlUnitExpectedOutput.xml
@@ -11,7 +11,8 @@
     <creatingApplicationName toolname="Jhove" toolversion="1.11">Adobe PDF Library 10.0.1/Adobe InDesign CS6 (Windows)</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:08:20 18:22:09-04:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2015-08-20T22:22:09Z</lastmodified>
-    <created toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2015:08:20 18:22:08-04:00</created>
+    <created toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:08:20 18:22:08-04:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-08-20T22:22:08Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDFx3.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFx3.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">745c9a202265d728d5cd21f86f1d411f</md5checksum>

--- a/testfiles/output/TestDoc.rtf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/TestDoc.rtf_XmlUnitExpectedOutput.xml
@@ -12,7 +12,8 @@
   </identification>
   <fileinfo>
     <lastmodified toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2015:08:05 09:25:00</lastmodified>
-    <created toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2015:08:05 09:25:00</created>
+    <created toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:05 09:25:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-08-05T14:25:00Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/TestDoc.rtf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">TestDoc.rtf</filename>
     <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">29650</size>

--- a/testfiles/output/UnparseableDate.odt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/UnparseableDate.odt_XmlUnitExpectedOutput.xml
@@ -12,6 +12,7 @@
     </identity>
   </identification>
   <fileinfo>
+    <created toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">2015-08-05T08:25:00</created>
     <creatingApplicationName toolname="Exiftool" toolversion="11.01">OpenOffice/4.1.1$Unix OpenOffice.org_project/411m6$Build-9775</creatingApplicationName>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/UnparseableDate.odt</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">UnparseableDate.odt</filename>

--- a/testfiles/output/W00EGS1016782-I01JW30--I01JW300001__0001.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/W00EGS1016782-I01JW30--I01JW300001__0001.tif_XmlUnitExpectedOutput.xml
@@ -10,6 +10,7 @@
     <creatingApplicationName toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2006:12:19 15:08:15</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2006-12-19T10:08:15</lastmodified>
+    <created toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">2006-12-19T09:08:15</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/W00EGS1016782-I01JW30--I01JW300001__0001.tif</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">W00EGS1016782-I01JW30--I01JW300001__0001.tif</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">90f9a85c04e1bc2c5c1f689c110b1588</md5checksum>

--- a/testfiles/output/Winnie-the-Pooh-protected.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Winnie-the-Pooh-protected.epub_XmlUnitExpectedOutput.xml
@@ -7,6 +7,7 @@
     </identity>
   </identification>
   <fileinfo>
+    <created toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">1954</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Winnie-the-Pooh-protected.epub</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Winnie-the-Pooh-protected.epub</filename>
     <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">15107043</size>

--- a/testfiles/output/Word2003PasswordProtected.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2003PasswordProtected.doc_XmlUnitExpectedOutput.xml
@@ -13,6 +13,7 @@
     <lastmodified toolname="Tika" toolversion="1.19.1" status="CONFLICT">2015-08-20T15:45:00Z</lastmodified>
     <created toolname="Exiftool" toolversion="11.14" status="CONFLICT">2015:08:20 15:44:00</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-08-20 11:44:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-08-20T15:44:00Z</created>
     <creatingApplicationName toolname="Exiftool" toolversion="11.14">Microsoft Office Word</creatingApplicationName>
     <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2003PasswordProtected.doc</filepath>

--- a/testfiles/output/Word2003_has_URLs_has_embedded_resources.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2003_has_URLs_has_embedded_resources.doc_XmlUnitExpectedOutput.xml
@@ -13,6 +13,7 @@
     <lastmodified toolname="Tika" toolversion="1.19.1" status="CONFLICT">2010-11-01T16:50:00Z</lastmodified>
     <created toolname="Exiftool" toolversion="11.14" status="CONFLICT">2010:03:18 17:36:00</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2010-03-18 13:36:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2010-03-18T17:36:00Z</created>
     <creatingApplicationName toolname="Exiftool" toolversion="11.14">Microsoft Office Word</creatingApplicationName>
     <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">12.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2003_has_URLs_has_embedded_resources.doc</filepath>

--- a/testfiles/output/Word2003_has_table_of_contents.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2003_has_table_of_contents.doc_XmlUnitExpectedOutput.xml
@@ -13,6 +13,7 @@
     <lastmodified toolname="Tika" toolversion="1.19.1" status="CONFLICT">2015-08-20T15:59:00Z</lastmodified>
     <created toolname="Exiftool" toolversion="11.14" status="CONFLICT">2015:08:20 15:59:00</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-08-20 11:59:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-08-20T15:59:00Z</created>
     <creatingApplicationName toolname="Exiftool" toolversion="11.14">Microsoft Office Word</creatingApplicationName>
     <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2003_has_table_of_contents.doc</filepath>

--- a/testfiles/output/Word2003_many_graphics.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2003_many_graphics.doc_XmlUnitExpectedOutput.xml
@@ -13,6 +13,7 @@
     <lastmodified toolname="Tika" toolversion="1.19.1" status="CONFLICT">2016-01-19T20:30:00Z</lastmodified>
     <created toolname="Exiftool" toolversion="11.14" status="CONFLICT">2015:08:20 21:23:10</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-08-20 17:22:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-08-20T21:22:00Z</created>
     <creatingApplicationName toolname="Exiftool" toolversion="11.14">Microsoft Macintosh Word</creatingApplicationName>
     <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2003_many_graphics.doc</filepath>

--- a/testfiles/output/Word2011_Has_Outline.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2011_Has_Outline.doc_XmlUnitExpectedOutput.xml
@@ -13,6 +13,7 @@
     <lastmodified toolname="Tika" toolversion="1.19.1" status="CONFLICT">2015-12-18T15:11:00Z</lastmodified>
     <created toolname="Exiftool" toolversion="11.14" status="CONFLICT">2015:12:11 15:05:00</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-12-11 10:05:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-12-11T15:05:00Z</created>
     <creatingApplicationName toolname="Exiftool" toolversion="11.14">Microsoft Macintosh Word</creatingApplicationName>
     <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2011_Has_Outline.doc</filepath>

--- a/testfiles/output/Word_has_index.docx_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word_has_index.docx_XmlUnitExpectedOutput.xml
@@ -13,7 +13,8 @@
   <fileinfo>
     <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:08:19 23:04:00Z</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2015-08-19T23:04:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2015:08:19 23:03:00Z</created>
+    <created toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:08:19 23:03:00Z</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-08-19T23:03:00Z</created>
     <creatingApplicationName toolname="Tika" toolversion="1.10" status="SINGLE_RESULT">Microsoft Office Word</creatingApplicationName>
     <creatingApplicationVersion toolname="Exiftool" toolversion="10.00">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Word_has_index.docx</filepath>

--- a/testfiles/output/Word_protected_encrypted.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word_protected_encrypted.doc_XmlUnitExpectedOutput.xml
@@ -13,6 +13,7 @@
     <lastmodified toolname="Tika" toolversion="1.19.1" status="CONFLICT">2015-12-17T17:46:00Z</lastmodified>
     <created toolname="Exiftool" toolversion="11.14" status="CONFLICT">2015:12:17 17:35:00</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-12-17 12:35:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2015-12-17T17:35:00Z</created>
     <creatingApplicationName toolname="Exiftool" toolversion="11.14">Microsoft Office Word</creatingApplicationName>
     <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word_protected_encrypted.doc</filepath>

--- a/testfiles/output/altona_technical_1v2_x3_has_annotations.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/altona_technical_1v2_x3_has_annotations.pdf_XmlUnitExpectedOutput.xml
@@ -15,7 +15,8 @@
     <creatingApplicationName toolname="Jhove" toolversion="1.11">Acrobat Distiller 5.0.5 f.r Macintosh/QuarkXPress(R) 4.04</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2004:05:09 14:07:13+02:00</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2004-05-09T12:07:13Z</lastmodified>
-    <created toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2002:09:21 19:25:36Z</created>
+    <created toolname="Exiftool" toolversion="10.00" status="CONFLICT">2002:09:21 19:25:36Z</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2002-09-21T19:25:36Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/altona_technical_1v2_x3_has_annotations.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">altona_technical_1v2_x3_has_annotations.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">c524ab2cd02240b12eab3ee9f8887a9f</md5checksum>

--- a/testfiles/output/gps.jpg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/gps.jpg_XmlUnitExpectedOutput.xml
@@ -21,6 +21,7 @@
     <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2006-11-02T21:26:02</lastmodified>
     <created toolname="Exiftool" toolversion="11.01" status="CONFLICT">2006:11:03 07:14:39</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2006:11:03 02:26:02</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2006-11-03T01:14:39</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/gps.jpg</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">gps.jpg</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">201f1db44775631d307b3ffd62acb3ac</md5checksum>

--- a/testfiles/output/topazscanner.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/topazscanner.tif_XmlUnitExpectedOutput.xml
@@ -12,7 +12,8 @@
     <creatingApplicationName toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">Adobe Photoshop CS Macintosh</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="11.14" status="CONFLICT">2006:11:28 13:30:06</lastmodified>
     <lastmodified toolname="Tika" toolversion="1.20" status="CONFLICT">2006-11-28T08:30:06</lastmodified>
-    <created toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">2006:11:28 12:22:59-05:00</created>
+    <created toolname="Exiftool" toolversion="11.14" status="CONFLICT">2006:11:28 12:22:59-05:00</created>
+    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2006-11-28T07:30:06</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/topazscanner.tif</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">topazscanner.tif</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">c2c36f561b1da65ff74ea2b22fe3fba0</md5checksum>


### PR DESCRIPTION
For some reason the `created` timestamp is extracted in the Tika code, but it's never added to the `fileinfo` element. This PR adds it.