### PR TITLE
fix tika mime resolutions when charset is set

### DIFF
--- a/src/main/java/edu/harvard/hul/ois/fits/FitsMetadataValues.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/FitsMetadataValues.java
@@ -206,6 +206,12 @@ public class FitsMetadataValues {
         if (mime == null || mime.length()==0) {
             return DEFAULT_MIMETYPE;
         }
+
+        // Tika is the primary tool that sets the charset in the MIME and it throws off comparisons
+        if (mime.contains("; charset=")) {
+            mime = mime.replaceFirst("; charset=[^;]+", "");
+        }
+
         String normMime = mimeMap.get(mime);
         if (normMime != null) {
             return normMime;

--- a/testfiles/output/T-350_036_Archival_Side_1.adl_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/T-350_036_Archival_Side_1.adl_XmlUnitExpectedOutput.xml
@@ -40,7 +40,7 @@
     <tool toolname="OIS File Information" toolversion="0.2" executionTime="98" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="570" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="144" />
+    <tool toolname="Tika" toolversion="1.21" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/plain-text.txt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/plain-text.txt_XmlUnitExpectedOutput.xml
@@ -5,6 +5,7 @@
       <tool toolname="Droid" toolversion="6.3" />
       <tool toolname="Jhove" toolversion="1.20" />
       <tool toolname="file utility" toolversion="5.31" />
+      <tool toolname="Tika" toolversion="2.0.0" />
       <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">x-fmt/111</externalIdentifier>
     </identity>
   </identification>
@@ -22,7 +23,8 @@
   <metadata>
     <text>
       <linebreak toolname="Jhove" toolversion="1.20" status="SINGLE_RESULT">LF</linebreak>
-      <charset toolname="Jhove" toolversion="1.20">US-ASCII</charset>
+      <charset toolname="Jhove" toolversion="1.20" status="CONFLICT">US-ASCII</charset>
+      <charset toolname="Tika" toolversion="2.0.0" status="CONFLICT">ISO-8859-1</charset>
       <standard>
         <textMD:textMD xmlns:textMD="info:lc/xmlns/textMD-v3">
           <textMD:character_info>

--- a/testfiles/output/random_data.csv_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/random_data.csv_XmlUnitExpectedOutput.xml
@@ -28,7 +28,7 @@
     <tool toolname="OIS File Information" toolversion="0.2" executionTime="72" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="295" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="167" />
+    <tool toolname="Tika" toolversion="1.10" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/simple_webvtt.vtt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/simple_webvtt.vtt_XmlUnitExpectedOutput.xml
@@ -27,7 +27,7 @@
     <tool toolname="OIS File Information" toolversion="0.2" executionTime="109" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="613" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="143" />
+    <tool toolname="Tika" toolversion="1.21" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/utf16.txt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/utf16.txt_XmlUnitExpectedOutput.xml
@@ -4,20 +4,21 @@
     <identity format="Plain text" mimetype="text/plain" toolname="FITS" toolversion="0.11.0">
       <tool toolname="Droid" toolversion="6.1.5" />
       <tool toolname="file utility" toolversion="5.04" />
+      <tool toolname="Tika" toolversion="2.0.0" />
       <externalIdentifier toolname="Droid" toolversion="6.1.5" type="puid">x-fmt/111</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/utf16.txt</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">utf16.txt</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">30</size>
+    <size toolname="OIS File Information" toolversion="0.2">30</size>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">fbb8ef84677fad5a798cef6cf69aef1d</md5checksum>
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1446674963000</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <text>
-      <charset toolname="file utility" toolversion="5.04" status="SINGLE_RESULT">UTF-16LE</charset>
+      <charset toolname="file utility" toolversion="5.04">UTF-16LE</charset>
       <standard>
         <textMD:textMD xmlns:textMD="info:lc/xmlns/textMD-v3">
           <textMD:character_info>

--- a/testfiles/properties/fits-full-with-tool-output.xml
+++ b/testfiles/properties/fits-full-with-tool-output.xml
@@ -18,7 +18,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />
         <tool class="edu.harvard.hul.ois.fits.tools.ffident.FFIdent" exclude-exts="dng,wps,vsd,jar,ppt,rtf" classpath-dirs="lib/ffident" />
-        <tool class="edu.harvard.hul.ois.fits.tools.tika.TikaTool" exclude-exts="jar,avi,mov,mpg,mpeg,mkv,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv" classpath-dirs="lib/tika"/>
+        <tool class="edu.harvard.hul.ois.fits.tools.tika.TikaTool" exclude-exts="adl,vtt,csv,jar,avi,mov,mpg,mpeg,mkv,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv" classpath-dirs="lib/tika"/>
 	</tools>
 	
 	<output>

--- a/xml/fits.xml
+++ b/xml/fits.xml
@@ -17,7 +17,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />
         <tool class="edu.harvard.hul.ois.fits.tools.ffident.FFIdent" exclude-exts="dng,wps,vsd,jar,ppt,rtf" classpath-dirs="lib/ffident" />
-        <tool class="edu.harvard.hul.ois.fits.tools.tika.TikaTool" exclude-exts="jar,avi,mov,mpg,mpeg,mkv,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv" classpath-dirs="lib/tika"/>
+        <tool class="edu.harvard.hul.ois.fits.tools.tika.TikaTool" exclude-exts="adl,vtt,csv,jar,avi,mov,mpg,mpeg,mkv,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv" classpath-dirs="lib/tika"/>
 	</tools>
 	
 	<output>

--- a/xml/mime_to_format_map.txt
+++ b/xml/mime_to_format_map.txt
@@ -10,3 +10,4 @@ application/rtf=Rich Text Format (RTF)
 text/rtf=Rich Text Format (RTF)
 application/vnd.wordperfect=WordPerfect Document
 application/msword=Microsoft Word Binary File Format
+text/plain=Plain text


### PR DESCRIPTION
Unlike the other tools, Tika often often includes the character set in the mime type, which throws off the mime resolution within FITS. This PR:

1. Strips out character set from the mime type when it's present
2. Maps `text/plain` to a format, because the Tika type does not have an associated description
3. Adds excludes for vtt, adl, and csv types, which Tika does not identify properly

It's possible that all of the tests do not pass correctly in this PR. I run the tests against the current state of our fork which includes a number of updates and fixes that have not been merged upstream.