### PR TITLE
fixed exiftool txt support

### DIFF
--- a/testfiles/output/plain-text.txt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/plain-text.txt_XmlUnitExpectedOutput.xml
@@ -5,6 +5,7 @@
       <tool toolname="Droid" toolversion="6.3" />
       <tool toolname="Jhove" toolversion="1.20" />
       <tool toolname="file utility" toolversion="5.31" />
+      <tool toolname="Exiftool" toolversion="12.29" />
       <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">x-fmt/111</externalIdentifier>
     </identity>
   </identification>
@@ -21,8 +22,10 @@
   </filestatus>
   <metadata>
     <text>
-      <linebreak toolname="Jhove" toolversion="1.20" status="SINGLE_RESULT">LF</linebreak>
+      <linebreak toolname="Jhove" toolversion="1.20">LF</linebreak>
       <charset toolname="Jhove" toolversion="1.20">US-ASCII</charset>
+      <lineCount toolname="Exiftool" toolversion="12.29" status="SINGLE_RESULT">1</lineCount>
+      <wordCount toolname="Exiftool" toolversion="12.29" status="SINGLE_RESULT">7</wordCount>
       <standard>
         <textMD:textMD xmlns:textMD="info:lc/xmlns/textMD-v3">
           <textMD:character_info>
@@ -41,7 +44,7 @@
     <tool toolname="Droid" toolversion="6.3" executionTime="146" />
     <tool toolname="Jhove" toolversion="1.20" executionTime="1005" />
     <tool toolname="file utility" toolversion="5.31" executionTime="1173" />
-    <tool toolname="Exiftool" toolversion="10.00" status="did not run" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="950" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
     <tool toolname="OIS File Information" toolversion="0.2" executionTime="141" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />

--- a/testfiles/output/random_data.csv_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/random_data.csv_XmlUnitExpectedOutput.xml
@@ -15,7 +15,20 @@
     <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1456866565000</fslastmodified>
   </fileinfo>
   <filestatus />
-  <metadata />
+  <metadata>
+    <text>
+      <charset toolname="Exiftool" toolversion="12.29" status="SINGLE_RESULT">us-ascii</charset>
+      <linebreak toolname="Exiftool" toolversion="12.29" status="SINGLE_RESULT">CR</linebreak>
+      <standard>
+        <textMD:textMD xmlns:textMD="info:lc/xmlns/textMD-v3">
+          <textMD:character_info>
+            <textMD:charset>US-ASCII</textMD:charset>
+            <textMD:linebreak>CR</textMD:linebreak>
+          </textMD:character_info>
+        </textMD:textMD>
+      </standard>
+    </text>
+  </metadata>
   <statistics fitsExecutionTime="425">
     <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />

--- a/testfiles/output/utf16.txt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/utf16.txt_XmlUnitExpectedOutput.xml
@@ -4,6 +4,7 @@
     <identity format="Plain text" mimetype="text/plain" toolname="FITS" toolversion="0.11.0">
       <tool toolname="Droid" toolversion="6.1.5" />
       <tool toolname="file utility" toolversion="5.04" />
+      <tool toolname="Exiftool" toolversion="12.29" />
       <externalIdentifier toolname="Droid" toolversion="6.1.5" type="puid">x-fmt/111</externalIdentifier>
     </identity>
   </identification>
@@ -17,7 +18,7 @@
   <filestatus />
   <metadata>
     <text>
-      <charset toolname="file utility" toolversion="5.04" status="SINGLE_RESULT">UTF-16LE</charset>
+      <charset toolname="file utility" toolversion="5.04">UTF-16LE</charset>
       <standard>
         <textMD:textMD xmlns:textMD="info:lc/xmlns/textMD-v3">
           <textMD:character_info>
@@ -35,7 +36,7 @@
     <tool toolname="Droid" toolversion="6.1.5" executionTime="24" />
     <tool toolname="Jhove" toolversion="1.11" executionTime="205" />
     <tool toolname="file utility" toolversion="5.04" executionTime="142" />
-    <tool toolname="Exiftool" toolversion="10.00" status="did not run" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="278" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
     <tool toolname="OIS File Information" toolversion="0.2" executionTime="90" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />

--- a/testfiles/properties/fits-full-with-tool-output.xml
+++ b/testfiles/properties/fits-full-with-tool-output.xml
@@ -13,7 +13,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.droid.Droid"  exclude-exts="odm,m4a,mpg" classpath-dirs="lib/droid" />
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,epub,csv,m4a" classpath-dirs="lib/fileutility" />
-        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="txt,wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt" classpath-dirs="lib/exiftool" />
+        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt" classpath-dirs="lib/exiftool" />
         <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" include-exts="bmp,gif,jpg,jpeg,wp,wpd,odt,doc,pdf,mp3,bfw,flac,html,xml,arc" classpath-dirs="lib/nzmetool,xml/nlnz"/>
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />

--- a/xml/exiftool/exiftool_common_to_fits.xslt
+++ b/xml/exiftool/exiftool_common_to_fits.xslt
@@ -283,6 +283,9 @@
 				<xsl:when test="$format='CSV'">
 					<xsl:value-of select="string('Comma-Separated Values (CSV)')"/>
 				</xsl:when>
+				<xsl:when test="$format='TXT'">
+					<xsl:value-of select="string('Plain text')"/>
+				</xsl:when>
 				<xsl:when test="$format=''">
 					<xsl:value-of select="string('Unknown Binary')"/>
 				</xsl:when>		

--- a/xml/exiftool/exiftool_text_to_fits.xslt
+++ b/xml/exiftool/exiftool_text_to_fits.xslt
@@ -11,12 +11,23 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 		<metadata>
 		<text>
 			<charset>
-		  		<xsl:value-of select="substring-after(exiftool/ContentType[1],'charset=')"/>
+		  		<xsl:value-of select="exiftool/MIMEEncoding[1]"/>
 			</charset>
-			<markupBasis>
-				<xsl:value-of select="exiftool/FileType[1]"/>
-			</markupBasis>
-		</text>				
+			<linebreak>
+				<xsl:value-of select="substring-after(exiftool/Newlines[1], ' ')"/>
+			</linebreak>
+			<lineCount>
+				<xsl:value-of select="exiftool/LineCount[1]"/>
+			</lineCount>
+			<wordCount>
+				<xsl:value-of select="exiftool/WordCount[1]"/>
+			</wordCount>
+			<xsl:if test="exiftool/FileType[1] != 'TXT' and exiftool/FileType[1] != 'CSV'">
+				<markupBasis>
+					<xsl:value-of select="exiftool/FileType[1]"/>
+				</markupBasis>
+			</xsl:if>
+		</text>
 		</metadata>
 	</fits>	
 

--- a/xml/exiftool/exiftool_xslt_map.xml
+++ b/xml/exiftool/exiftool_xslt_map.xml
@@ -165,6 +165,7 @@
 	<map format="WMV" transform="exiftool_video_to_fits.xslt"/>
 	
 	<!-- text -->
+	<map format="CSV" transform="exiftool_text_to_fits.xslt"/>
 	<map format="CHM" transform="exiftool_text_to_fits.xslt"/>
 	<map format="HTM" transform="exiftool_text_to_fits.xslt"/>
 	<map format="HTML" transform="exiftool_text_to_fits.xslt"/>
@@ -173,6 +174,7 @@
 	<map format="RAM" transform="exiftool_text_to_fits.xslt"/>
 	<map format="RPM" transform="exiftool_text_to_fits.xslt"/>
 	<map format="SVG" transform="exiftool_text_to_fits.xslt"/>
+	<map format="TXT" transform="exiftool_text_to_fits.xslt"/>
 	<map format="XHTML" transform="exiftool_text_to_fits.xslt"/>
 	<map format="XML" transform="exiftool_text_to_fits.xslt"/>
 	<map format="XMP" transform="exiftool_text_to_fits.xslt"/>

--- a/xml/fits.xml
+++ b/xml/fits.xml
@@ -12,7 +12,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.droid.Droid"  exclude-exts="odm,m4a,mpg" classpath-dirs="lib/droid" />
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,epub,csv,m4a" classpath-dirs="lib/fileutility" />
-        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="txt,wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
+        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
         <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" include-exts="bmp,gif,jpg,jpeg,wp,wpd,odt,doc,pdf,mp3,bfw,flac,html,xml,arc" classpath-dirs="lib/nzmetool,xml/nlnz"/>
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />


### PR DESCRIPTION
This PR enhances the exiftool support for plain text files. exiftool provides decent information for plain text and csv files, but for some reason this information was not being captured by FITS previously.

It's possible that all of the tests do not pass correctly in this PR. I run the tests against the current state of our fork which includes a number of updates and fixes that have not been merged upstream.