### PR TITLE
Docker image for executing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,16 @@ The build artifacts are fits-<version>.jar and fits-<version>.zip. The JAR file 
 The ZIP file can be built with the following command, which will also run the entire test suite:
 
     mvn clean package
-    
+
+Because the outcome of some of the tests are system dependent, it is
+recommended to run them in a Docker container so that the results are
+consistent. To do so, first install Docker, Podman, or an equivalent
+container service, and execute the following:
+
+    # The build only needs to be run once
+    docker build -f docker/Dockerfile-test -t fits-test .
+    docker run -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test mvn clean test
+
 To build yet skip the tests, use the following command:
 
     mvn clean package -DskipTests

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The ZIP file can be built with the following command, which will also run the en
 
     mvn clean package
 
-Because the outcome of some of the tests are system dependent, it is
+Because the outcome of some of the tests is system dependent, it is
 recommended to run them in a Docker container so that the results are
 consistent. To do so, first install Docker, Podman, or an equivalent
 container service, and execute the following:

--- a/docker/Dockerfile-test
+++ b/docker/Dockerfile-test
@@ -1,0 +1,58 @@
+# This file creates an image that can be used to execute the unit tests.
+#
+# Usage:
+#   # Build the image
+#   podman build -f docker/Dockerfile-test -t fits-docker-test
+#
+#   # Run the tests
+#   podman run -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-docker-test mvn clean test
+#
+#   # Interactive container access
+#   podman run -it -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-docker-test
+
+FROM docker.io/maven:3-eclipse-temurin-17
+
+ENV FILE_VERSION=5.41
+
+RUN apt-get update
+
+# Set timezone to eastern because some of the tests need this
+RUN echo 'America/New_York' > /etc/timezone
+
+# Install exiftool dependencies https://github.com/exiftool/exiftool
+RUN apt-get install -yqq \
+    libarchive-zip-perl \
+    libio-compress-perl \
+    libcompress-raw-zlib-perl \
+    libcompress-bzip2-perl \
+    libcompress-raw-bzip2-perl \
+    libio-digest-perl \
+    libdigest-md5-file-perl \
+    libdigest-perl-md5-perl \
+    libdigest-sha-perl \
+    libposix-strptime-perl \
+    libunicode-linebreak-perl
+
+# Install file dependencies
+RUN apt-get install -yqq \
+    make \
+    gcc
+
+# Install file https://github.com/file/file
+RUN cd /var/tmp && \
+    curl -so file-${FILE_VERSION}.tar.gz https://astron.com/pub/file/file-${FILE_VERSION}.tar.gz && \
+    tar xzf file-${FILE_VERSION}.tar.gz && \
+    cd file-${FILE_VERSION} && \
+    ./configure && \
+    make -j4 && \
+    make install && \
+    ldconfig && \
+    cd .. && \
+    rm -rf file-${FILE_VERSION}*
+
+# Cleanup package list
+RUN  rm -rf /var/lib/apt/lists/*
+
+WORKDIR /fits
+
+CMD ["bash"]

--- a/docker/Dockerfile-test
+++ b/docker/Dockerfile-test
@@ -2,17 +2,17 @@
 #
 # Usage:
 #   # Build the image
-#   podman build -f docker/Dockerfile-test -t fits-docker-test
+#   podman build -f docker/Dockerfile-test -t fits-test
 #
 #   # Run the tests
-#   podman run -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-docker-test mvn clean test
+#   podman run -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test mvn clean test
 #
 #   # Interactive container access
-#   podman run -it -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-docker-test
+#   podman run -it -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test
 
 FROM docker.io/maven:3-eclipse-temurin-17
 
-ENV FILE_VERSION=5.41
+ARG FILE_VERSION=5.41
 
 RUN apt-get update
 

--- a/docker/Dockerfile-test
+++ b/docker/Dockerfile-test
@@ -2,13 +2,13 @@
 #
 # Usage:
 #   # Build the image
-#   podman build -f docker/Dockerfile-test -t fits-test
+#   docker build -f docker/Dockerfile-test -t fits-test .
 #
 #   # Run the tests
-#   podman run -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test mvn clean test
+#   docker run -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test mvn clean test
 #
 #   # Interactive container access
-#   podman run -it -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test
+#   docker run -it -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test
 
 FROM docker.io/maven:3-eclipse-temurin-17
 

--- a/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
@@ -62,9 +62,8 @@
       <flash toolname="Jhove" toolversion="1.20.1">No flash function</flash>
       <focalLength toolname="Jhove" toolversion="1.20.1" status="CONFLICT">2.77</focalLength>
       <focalLength toolname="Exiftool" toolversion="11.54" status="CONFLICT">2.8</focalLength>
-      <exposureIndex toolname="Jhove" toolversion="1.20.1" status="CONFLICT">�</exposureIndex>
+      <exposureIndex toolname="Jhove" toolversion="1.20.1" status="CONFLICT">NaN</exposureIndex>
       <exposureIndex toolname="Exiftool" toolversion="11.54" status="CONFLICT">undef</exposureIndex>
-      <exposureIndex toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">NaN</exposureIndex>
       <iccProfileVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
       <captureDevice toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">digital still camera</captureDevice>
       <digitalCameraManufacturer toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">GoPro</digitalCameraManufacturer>

--- a/testfiles/output/WordPasswordProtected.docx_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPasswordProtected.docx_XmlUnitExpectedOutput.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="12/6/21 3:56 PM">
   <identification status="CONFLICT">
-    <identity format="OLE 2 Compound Document, v3.62, SecID 0x1, 11 FAT sectors, Mini FAT start sector 0x2 : UNKNOWN" mimetype="application/x-ole-storage" toolname="FITS" toolversion="1.5.0">
+    <identity format="OLE 2 Compound Document, v3.62, SecID 0x1, 11 FAT sectors, Mini FAT start sector 0x2 : UNKNOWN with names EncryptedPackage \006DataSpaces Version" mimetype="application/x-ole-storage" toolname="FITS" toolversion="1.5.0">
       <tool toolname="file utility" toolversion="5.39" />
     </identity>
     <identity format="Office Open XML Document" mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document" toolname="FITS" toolversion="1.5.0">

--- a/xml/fileutility/fileutility_to_fits.xslt
+++ b/xml/fileutility/fileutility_to_fits.xslt
@@ -201,7 +201,7 @@
 					</xsl:when>						
 					<!-- PDF document, version 1.5 -->
 					<xsl:when test="$mime='application/pdf'">
-					  	<xsl:analyze-string select="$format" regex="(.*), version (.*)">		
+					  	<xsl:analyze-string select="$format" regex="([^,]*), version ([^,]*).*">
 						    <xsl:matching-substring>
 						    	<xsl:attribute name="format">
 						    		<xsl:if test="regex-group(1)='PDF document'">
@@ -396,7 +396,7 @@
                     </xsl:when> 
 					<!-- Zip archive data, at least v2.0 to extract -->
 					<xsl:when test="$mime='application/zip'">
-					  	<xsl:analyze-string select="$format" regex="(.*),(.*)">		
+					  	<xsl:analyze-string select="$format" regex="([^,]*),(.*)">
 						    <xsl:matching-substring>
 						    	<xsl:attribute name="format">
 						    		<xsl:if test="regex-group(1)='Zip archive data'">


### PR DESCRIPTION
This PR creates a Docker image that can be used to consistently run the tests on any system.

Example usage:

```shell
# The build only needs to be run once
podman build -f docker/Dockerfile-test -t fits-test
podman run -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test mvn clean test
```

(You can alternatively use `docker`.)

Additionally, a few tweaks for necessary to support the latest version of `file`.

I think FITS should be entirely containerized, but I will create a separate ticket for discussing that.