### PR TITLE
add xml dep needed by saxon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,11 @@
 			<version>${saxon.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.xmlresolver</groupId>
+			<artifactId>xmlresolver</artifactId>
+			<version>4.2.0</version>
+		</dependency>
+		<dependency>
 			<groupId>com.joyent.util</groupId>
 			<artifactId>fast-md5</artifactId>
 			<version>${fast-md5.version}</version>


### PR DESCRIPTION
This dep is needed by the new version of saxon that I upgraded yesterday. FITS will not start without it.