### PR TITLE
fix incorrect namespace on elements coming from jhove

### DIFF
--- a/xml/jhove/jhove_audio_to_fits.xslt
+++ b/xml/jhove/jhove_audio_to_fits.xslt
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <xsl:stylesheet version="2.0"
-xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-xmlns:aes="http://www.aes.org/audioObject" 
-xmlns:tcf="http://www.aes.org/tcf">
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:aes="http://www.aes.org/audioObject"
+	xmlns:tcf="http://www.aes.org/tcf"
+	exclude-result-prefixes="aes tcf">
 
 <xsl:import href="jhove_common_to_fits.xslt"/>
 <xsl:template match="/">

--- a/xml/jhove/jhove_common_to_fits.xslt
+++ b/xml/jhove/jhove_common_to_fits.xslt
@@ -2,7 +2,9 @@
 <xsl:stylesheet version="2.0"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:mix="http://www.loc.gov/mix/v20"
-	xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output">
+	xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output"
+	exclude-result-prefixes="mix">
+
 	<xsl:output method="xml" indent="yes" />
 	<xsl:strip-space elements="*"/>
 

--- a/xml/jhove/jhove_html_to_fits.xslt
+++ b/xml/jhove/jhove_html_to_fits.xslt
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <xsl:stylesheet version="2.0"
-xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-xmlns:mix="http://www.loc.gov/mix/v20">
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:import href="jhove_common_to_fits.xslt"/>
 <xsl:template match="/">

--- a/xml/jhove/jhove_image_to_fits.xslt
+++ b/xml/jhove/jhove_image_to_fits.xslt
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="2.0"
-xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-xmlns:mix="http://www.loc.gov/mix/v20">
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:mix="http://www.loc.gov/mix/v20"
+	exclude-result-prefixes="mix">
 
 <xsl:import href="jhove_common_to_fits.xslt"/>
 <xsl:template match="/">

--- a/xml/jhove/jhove_text_to_fits.xslt
+++ b/xml/jhove/jhove_text_to_fits.xslt
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <xsl:stylesheet version="2.0"
-xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-xmlns:mix="http://www.loc.gov/mix/v20">
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:import href="jhove_common_to_fits.xslt"/>
 <xsl:template match="/">

--- a/xml/jhove/jhove_unknown_to_fits.xslt
+++ b/xml/jhove/jhove_unknown_to_fits.xslt
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <xsl:stylesheet version="2.0"
-xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-xmlns:mix="http://www.loc.gov/mix/v20">
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:import href="jhove_common_to_fits.xslt"/>
 <xsl:template match="/">

--- a/xml/jhove/jhove_xml_to_fits.xslt
+++ b/xml/jhove/jhove_xml_to_fits.xslt
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <xsl:stylesheet version="2.0"
-xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-xmlns:mix="http://www.loc.gov/mix/v20">
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:import href="jhove_common_to_fits.xslt"/>
 <xsl:template match="/">


### PR DESCRIPTION
I noticed this morning that the mix namespace was being included on FITS data elements coming from Jhove outside of a mix document. Look at some of the files currently in your test output to see what I mean. I suspect that this bug was introduced when I updated the xml libraries yesterday. This PR corrects the problem and excludes the namespaces from the output.