### PR TITLE
fix deprecation warnings

### DIFF
--- a/src/main/java/edu/harvard/hul/ois/fits/EbuCoreModel.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/EbuCoreModel.java
@@ -308,10 +308,10 @@ public class EbuCoreModel {
 		    		List<ChannelPositionWrapper> positions = cpp.getChannelsFromString(dataValue);
 
 		    		for (ChannelPositionWrapper positionWrapper : positions) {
-		    			Position positionX = new Position(new Integer(positionWrapper.getXpos()));
+		    			Position positionX = new Position(positionWrapper.getXpos());
 		    			positionX.setCoordinate("x");
 
-		    			Position positionY = new Position(new Integer(positionWrapper.getYpos()));
+		    			Position positionY = new Position(positionWrapper.getYpos());
 		    			positionY.setCoordinate("y");
 
 		    			AudioBlockFormat abf = new AudioBlockFormat();
@@ -470,8 +470,8 @@ public class EbuCoreModel {
     	case duration:
     		//Integer intValue = new Integer(dataValue);
     		// Sometimes MediaInfo returns a value with a decimal place
-    		Double d = new Double(dataValue);
-    		Integer intValue = Integer.valueOf((int) Math.round(d));
+    		double d = Double.parseDouble(dataValue);
+    		int intValue = (int) Math.round(d);
     		EditUnitNumber eun = new EditUnitNumber(intValue, "editUnitNumber");
     		eun.setEditRate(1000);
     		eun.setFactorNumerator(1);
@@ -497,7 +497,7 @@ public class EbuCoreModel {
         int framesFromTc = Integer.parseInt(timecode.substring(9, 11 ));
 
         EbuCoreFrameRateRatio ratio = new EbuCoreFrameRateRatio(framerate);
-        int fps = new Integer (ratio.getValue());
+        int fps = Integer.parseInt(ratio.getValue());
 
         // hours
         int frames = (int)(( double)hours * 3600 * fps);
@@ -516,10 +516,10 @@ public class EbuCoreModel {
         // frames
         frames += framesFromTc;
 
-		EditUnitNumber eun = new EditUnitNumber(new Integer(frames), "editUnitNumber");
+		EditUnitNumber eun = new EditUnitNumber(frames, "editUnitNumber");
 		eun.setEditRate(fps);
-		eun.setFactorNumerator(new Integer(ratio.getNumerator()));
-		eun.setFactorDenominator(new Integer(ratio.getDenominator()));
+		eun.setFactorNumerator(Integer.parseInt(ratio.getNumerator()));
+		eun.setFactorDenominator(Integer.parseInt(ratio.getDenominator()));
 
 		Start start = new Start("start");
 		start.setTimecode(eun);

--- a/src/main/java/edu/harvard/hul/ois/fits/EbuCoreNormalizedRatio.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/EbuCoreNormalizedRatio.java
@@ -75,8 +75,8 @@ public class EbuCoreNormalizedRatio {
 		// Must be an integer
 		else {
 			// set the denormalized value
-			this.normalizedNumerator = new Integer(numerator).intValue();
-			this.normalizedDenominator = new Integer(denominator).intValue();
+			this.normalizedNumerator = Integer.parseInt(numerator);
+			this.normalizedDenominator = Integer.parseInt(denominator);
 		}
 
 

--- a/src/main/java/edu/harvard/hul/ois/fits/Fits.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/Fits.java
@@ -18,6 +18,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -38,7 +39,7 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
@@ -265,7 +266,7 @@ public class Fits {
     outputOptions.addOption( combinedStd );
     options.addOptionGroup( outputOptions );
 
-    CommandLineParser parser = new GnuParser();
+    CommandLineParser parser = new DefaultParser();
     CommandLine cmd = null;
     try {
     	cmd = parser.parse( options, args );
@@ -527,8 +528,8 @@ public class Fits {
 	String factoryImpl = "net.sf.saxon.TransformerFactoryImpl";
 	try {
 		Class<?> clazz = Class.forName(factoryImpl);
-		tFactory = (TransformerFactory)clazz.newInstance();
-	} catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+		tFactory = (TransformerFactory)clazz.getDeclaredConstructor().newInstance();
+	} catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 		throw new FitsToolException("Could not access or instantiate class: " + factoryImpl, e);
 	}
 

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/ToolBase.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/ToolBase.java
@@ -11,6 +11,7 @@
 package edu.harvard.hul.ois.fits.tools;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
@@ -60,8 +61,8 @@ public abstract class ToolBase implements Tool {
 		String factoryImpl = "net.sf.saxon.TransformerFactoryImpl";
 		try {
 			Class<?> clazz = Class.forName(factoryImpl, true, ToolBase.class.getClassLoader());
-			tFactory = (TransformerFactory)clazz.newInstance();
-		} catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+			tFactory = (TransformerFactory)clazz.getDeclaredConstructor().newInstance();
+		} catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 			throw new FitsToolException("Could not access or instantiate class: " + factoryImpl, e);
 		}
 		

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/ToolBelt.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/ToolBelt.java
@@ -172,7 +172,7 @@ public class ToolBelt {
 		} catch (NoSuchMethodException e) {
 			// now try a no-arg constructor
 			logger.debug("No Fits 1-arg constructor for tool class: {} -- trying no-arg constructor. Error message: {}", toolClass.getName(), e.getMessage());
-			instanceOfTheClass = toolClass.newInstance();
+			instanceOfTheClass = toolClass.getDeclaredConstructor().newInstance();
 			logger.debug("Instantiated no-arg constructor for tool class: {}", toolClass.getName());
 		}
 		return (Tool)instanceOfTheClass;

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/ffident/FormatDescriptionReader.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/ffident/FormatDescriptionReader.java
@@ -51,9 +51,9 @@ public class FormatDescriptionReader
 		desc.setLongName(items[2]);
 		desc.addMimeTypes(items[3]);
 		desc.addFileExtensions(items[4]);
-		desc.setOffset(new Integer(items[5]));
+		desc.setOffset(Integer.parseInt(items[5]));
 		desc.setMagicBytes(items[6]);
-		desc.setMinimumSize(new Integer(items[7]));
+		desc.setMinimumSize(Integer.parseInt(items[7]));
 		return desc;
 	}
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoNativeWrapper.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoNativeWrapper.java
@@ -34,7 +34,6 @@ package edu.harvard.hul.ois.fits.tools.mediainfo;
 import static java.util.Collections.singletonMap;
 
 import java.lang.reflect.Method;
-import java.net.URL;
 
 import com.sun.jna.FunctionMapper;
 import com.sun.jna.Library;
@@ -99,12 +98,9 @@ class MediaInfoNativeWrapper
    interface MediaInfoDLL_Internal extends Library
    {
 
-       MediaInfoDLL_Internal INSTANCE = (MediaInfoDLL_Internal) Native.loadLibrary(LibraryPath, MediaInfoDLL_Internal.class, singletonMap(OPTION_FUNCTION_MAPPER, new FunctionMapper()
-           {
-
+       MediaInfoDLL_Internal INSTANCE = Native.load(LibraryPath, MediaInfoDLL_Internal.class, singletonMap(OPTION_FUNCTION_MAPPER, new FunctionMapper() {
                @Override
-               public String getFunctionName(NativeLibrary lib, Method method)
-               {
+               public String getFunctionName(NativeLibrary lib, Method method) {
                    return "MediaInfo_" + method.getName();
                }
            }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/tika/TikaTool.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/tika/TikaTool.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.tika.Tika;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.EncryptedDocumentException;
 import org.apache.tika.exception.TikaException;
@@ -640,10 +639,7 @@ public class TikaTool extends ToolBase {
         String[] metadataNames = metadata.names();
         Element elem = new Element (FitsMetadataValues.DOCUMENT, fitsNS);
 
-        String subject = metadata.get(OfficeOpenXMLCore.SUBJECT.getName());
-        if (subject == null) {
-            subject = metadata.get(TikaCoreProperties.SUBJECT.getName());
-        }
+        String subject = metadata.get(TikaCoreProperties.SUBJECT.getName());
         if (subject != null) {
             addSimpleElement (elem, FitsMetadataValues.SUBJECT, subject);
         }

--- a/src/main/java/nz/govt/natlib/meta/config/Config.java
+++ b/src/main/java/nz/govt/natlib/meta/config/Config.java
@@ -713,6 +713,7 @@ public class Config {
 					try {
 						adapter = (DataAdapter) Class.forName(className, true,
 								classLoader)
+								.getDeclaredConstructor()
 								.newInstance();
 						String jarName = map.getNamedItem(JAR_TAG)
 								.getNodeValue();


### PR DESCRIPTION
Resolves https://github.com/harvard-lts/fits/issues/272

Fixes all of the deprecation warnings except:

```
/fits/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoNativeWrapper.java:[221,18] [deprecation] finalize() in Object has been deprecated
```

That one is potentially dangerous to fix and it has not be addressed upstream yet either.

https://github.com/MediaArea/MediaInfoLib/blob/master/Source/MediaInfoDLL/MediaInfoDLL.JNA.java#L200