### PR TITLE
Make NLNZ Metadata Extractor output consistent with expected value.

### DIFF
--- a/xml/nlnz/fits/nlnz_jpeg_to_fits.xslt
+++ b/xml/nlnz/fits/nlnz_jpeg_to_fits.xslt
@@ -296,7 +296,7 @@
 	       	<xsl:variable name="exposureProgram" select="JPG/EXIF/EXPOSUREPROGRAM/VALUE"/>
 	      	<xsl:choose>
 				<xsl:when test="$exposureProgram=0">
-					<xsl:value-of select="string('Not Defined')"/>
+					<xsl:value-of select="string('Not defined')"/>
 				</xsl:when>
 				<xsl:when test="$exposureProgram=1">
 					<xsl:value-of select="string('Manual')"/>


### PR DESCRIPTION
Changed case of one word so it matches other tool xslt output.