### PR TITLE
standardize created and updated timestamps

### DIFF
--- a/src/main/java/edu/harvard/hul/ois/fits/XmlContentConverter.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/XmlContentConverter.java
@@ -12,7 +12,6 @@ package edu.harvard.hul.ois.fits;
 
 
 import java.io.File;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,12 +58,6 @@ public class XmlContentConverter {
 			docMdNames.add(elem.getName());
 		}
 	}
-
-    // Exif timestamps do not include a timezone and a timezone cannot be easily inferred.
-    // See page 33 of this document for more info: https://web.archive.org/web/20180919181934/http://www.metadataworkinggroup.org/pdf/mwg_guidance.pdf
-    // SimpleDateFormat is not thread-safe, but XmlContentConvert should never be called from multiple threads.
-    private final SimpleDateFormat exifDateFormat = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss");
-    private final SimpleDateFormat mixNoTzDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 
     /** Converts an image element to a MIX object
      *
@@ -569,16 +562,10 @@ public class XmlContentConverter {
         if(fileinfo != null) {
             Element created = fileinfo.getChild (ImageElement.created.toString(),ns);
             if(created != null) {
-                String date = null;
                 try {
-                    date = mixNoTzDateFormat.format(exifDateFormat.parse(created.getText().trim()));
-                    mm.icm.getGeneralCaptureInformation().setDateTimeCreated(date);
-                }
-                catch (ParseException e) {
-                    logger.warn("Warning - unable to parse date: " + e.getMessage ());
-                }
-                catch (XmlContentException e) {
-                    logger.warn("Invalid MIX content for data element [" + date + "]: " + e.getMessage ());
+                    mm.icm.getGeneralCaptureInformation().setDateTimeCreated(created.getText().trim());
+                } catch (XmlContentException e) {
+                    logger.warn("Invalid MIX content for data element [{}]", created.getText().trim(), e);
                 }
             }
         }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/exiftool/Exiftool.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/exiftool/Exiftool.java
@@ -11,17 +11,6 @@
 
 package edu.harvard.hul.ois.fits.tools.exiftool;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import org.apache.commons.lang.StringEscapeUtils;
-import org.jdom.Document;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.exceptions.FitsException;
 import edu.harvard.hul.ois.fits.exceptions.FitsToolCLIException;
@@ -31,8 +20,22 @@ import edu.harvard.hul.ois.fits.tools.ToolInfo;
 import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import edu.harvard.hul.ois.fits.tools.utils.CommandLine;
 import edu.harvard.hul.ois.fits.tools.utils.XsltTransformMap;
+import edu.harvard.hul.ois.fits.util.DateTimeUtil;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.xpath.XPath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  *  The glue class for invoking Exiftool under FITS.
@@ -156,6 +159,10 @@ public class Exiftool extends ToolBase {
 			//use generic transform
 			fitsXml = transform(exiftoolFitsConfig+genericTransform,rawOut);
 		}
+
+		standardizeTimestamp("//fits:fileinfo/fits:created", fitsXml);
+		standardizeTimestamp("//fits:fileinfo/fits:lastmodified", fitsXml);
+
 		output = new ToolOutput(this,fitsXml,rawOut, fits);
 		//}
 
@@ -239,6 +246,19 @@ public class Exiftool extends ToolBase {
 
 	public void setEnabled(boolean value) {
 		enabled = value;
+	}
+
+	private void standardizeTimestamp(String path, Document document) {
+		try {
+			XPath xpath = XPath.newInstance(path);
+			xpath.addNamespace("fits",Fits.XML_NAMESPACE);
+			Element element = (Element) xpath.selectSingleNode(document);
+			if (element != null) {
+				element.setText(DateTimeUtil.standardize(element.getText()));
+			}
+		} catch (JDOMException e) {
+			logger.debug("Failed to standardize timestamp", e);
+		}
 	}
 
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/nlnz/MetadataExtractor.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/nlnz/MetadataExtractor.java
@@ -15,7 +15,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 
+import edu.harvard.hul.ois.fits.util.DateTimeUtil;
 import org.jdom.Document;
+import org.jdom.Element;
 import org.jdom.JDOMException;
 
 import edu.harvard.hul.ois.fits.Fits;
@@ -32,6 +34,7 @@ import nz.govt.natlib.fx.ParserListener;
 import nz.govt.natlib.meta.config.Config;
 import nz.govt.natlib.meta.harvester.DTDXmlParserListener;
 import nz.govt.natlib.meta.log.LogManager;
+import org.jdom.xpath.XPath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,6 +144,9 @@ public class MetadataExtractor extends ToolBase {
 
 		//XmlUtils.printToConsole(dom);
 
+		standardizeTimestamp("//fits:fileinfo/fits:created", fitsXml);
+		standardizeTimestamp("//fits:fileinfo/fits:lastmodified", fitsXml);
+
 		output = new ToolOutput(this,fitsXml,dom, fits);
 		duration = System.currentTimeMillis()-startTime;
         logger.debug("MetadataExtractor.extractInfo finished on " + file.getName());
@@ -173,4 +179,18 @@ public class MetadataExtractor extends ToolBase {
 	public void setEnabled(boolean value) {
 		enabled = value;
 	}
+
+	private void standardizeTimestamp(String path, Document document) {
+		try {
+			XPath xpath = XPath.newInstance(path);
+			xpath.addNamespace("fits",Fits.XML_NAMESPACE);
+			Element element = (Element) xpath.selectSingleNode(document);
+			if (element != null) {
+				element.setText(DateTimeUtil.standardize(element.getText()));
+			}
+		} catch (JDOMException e) {
+			logger.debug("Failed to standardize timestamp", e);
+		}
+	}
+
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/tika/TikaTool.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/tika/TikaTool.java
@@ -18,6 +18,7 @@ import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 
+import edu.harvard.hul.ois.fits.util.DateTimeUtil;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.EncryptedDocumentException;
@@ -379,13 +380,13 @@ public class TikaTool extends ToolBase {
         Element fileInfoElem = new Element ("fileinfo", fitsNS);
         if (lastModified != null) {
             Element lastModElem = new Element (FitsMetadataValues.LAST_MODIFIED, fitsNS);
-            lastModElem.addContent (lastModified);
+            lastModElem.addContent (DateTimeUtil.standardize(lastModified));
             fileInfoElem.addContent (lastModElem);
         }
 
         if (created != null) {
             Element createdElem = new Element (FitsMetadataValues.CREATED, fitsNS);
-            createdElem.addContent(created);
+            createdElem.addContent(DateTimeUtil.standardize(created));
             fileInfoElem.addContent(createdElem);
         }
 

--- a/src/main/java/edu/harvard/hul/ois/fits/util/DateTimeUtil.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/util/DateTimeUtil.java
@@ -1,0 +1,198 @@
+//
+// Copyright (c) 2016 by The President and Fellows of Harvard College
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permission and limitations under the License.
+//
+
+package edu.harvard.hul.ois.fits.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.SignStyle;
+import java.time.temporal.TemporalAccessor;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.YEAR;
+
+/**
+ * Utility class for working with timestamps
+ */
+public final class DateTimeUtil {
+
+    private static final DateTimeFormatter STANDARD_FORMAT = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(YEAR, 4)
+            .appendLiteral('-')
+            .appendValue(MONTH_OF_YEAR, 2)
+            .appendLiteral('-')
+            .appendValue(DAY_OF_MONTH, 2)
+            .optionalStart()
+            .appendLiteral('T')
+            .appendValue(HOUR_OF_DAY, 2)
+            .appendLiteral(':')
+            .appendValue(MINUTE_OF_HOUR, 2)
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(SECOND_OF_MINUTE, 2)
+            .optionalStart()
+            .appendFraction(NANO_OF_SECOND, 0, 9, true)
+            .optionalStart()
+            .appendOffset("+HH:MM", "Z")
+            .toFormatter();
+
+    private static final DateTimeFormatter DATE_TIME_WITH_SPACE = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE)
+            .appendLiteral(' ')
+            .append(ISO_LOCAL_TIME)
+            .optionalStart()
+            .appendOffsetId()
+            .optionalStart()
+            .appendLiteral('[')
+            .parseCaseSensitive()
+            .appendZoneRegionId()
+            .appendLiteral(']')
+            .toFormatter();
+
+    private static final DateTimeFormatter DATE_TIME_WITH_COLON = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+            .appendLiteral(':')
+            .appendValue(MONTH_OF_YEAR, 2)
+            .appendLiteral(':')
+            .appendValue(DAY_OF_MONTH, 2)
+            .appendLiteral(' ')
+            .append(ISO_LOCAL_TIME)
+            .optionalStart()
+            .appendOffsetId()
+            .optionalStart()
+            .appendLiteral('[')
+            .parseCaseSensitive()
+            .appendZoneRegionId()
+            .appendLiteral(']')
+            .toFormatter();
+
+    private static final DateTimeFormatter DATE_WITH_COLON = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+            .appendLiteral(':')
+            .appendValue(MONTH_OF_YEAR, 2)
+            .appendLiteral(':')
+            .appendValue(DAY_OF_MONTH, 2)
+            .toFormatter();
+
+    private static final DateTimeFormatter DATE_TIME_WITH_PERIOD = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+            .appendLiteral('.')
+            .appendValue(MONTH_OF_YEAR, 2)
+            .appendLiteral('.')
+            .appendValue(DAY_OF_MONTH, 2)
+            .appendLiteral(' ')
+            .append(ISO_LOCAL_TIME)
+            .optionalStart()
+            .appendOffsetId()
+            .optionalStart()
+            .appendLiteral('[')
+            .parseCaseSensitive()
+            .appendZoneRegionId()
+            .appendLiteral(']')
+            .toFormatter();
+
+    private static final DateTimeFormatter DATE_WITH_PERIOD = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+            .appendLiteral('.')
+            .appendValue(MONTH_OF_YEAR, 2)
+            .appendLiteral('.')
+            .appendValue(DAY_OF_MONTH, 2)
+            .toFormatter();
+
+    private static final DateTimeFormatter[] FORMATTERS = new DateTimeFormatter[] {
+            DateTimeFormatter.ISO_DATE_TIME,
+            DateTimeFormatter.ISO_DATE,
+            DATE_TIME_WITH_SPACE,
+            DateTimeFormatter.BASIC_ISO_DATE,
+            DateTimeFormatter.RFC_1123_DATE_TIME,
+            DATE_TIME_WITH_COLON,
+            DATE_WITH_COLON,
+            DATE_TIME_WITH_PERIOD,
+            DATE_WITH_PERIOD
+    };
+
+    private DateTimeUtil() {
+        // cannot instantiate
+    }
+
+    /**
+     * Attempts to parse the specified timestamp and convert it to a standard format. Timezones are not inferred if
+     * they are not specified. If the operation is successful, then the resulting timestamp will be in one of the
+     * following formats:
+     *
+     * <ul>
+     *     <li>yyyy-MM-dd</li>
+     *     <li>yyyy-MM-dd'T'HH:mm:ss</li>
+     *     <li>yyyy-MM-dd'T'HH:mm:ss'Z'</li>
+     * </ul>
+     *
+     * @param originalTimestamp the timestamp to standardize
+     * @return converted timestamp or the original value if it cannot be parsed
+     */
+    public static String standardize(String originalTimestamp) {
+        originalTimestamp = originalTimestamp.trim();
+
+        if (originalTimestamp.isEmpty()) {
+            return originalTimestamp;
+        }
+
+        String standardized = originalTimestamp;
+
+        TemporalAccessor parsed = null;
+
+        for (DateTimeFormatter formatter : FORMATTERS) {
+            try {
+                parsed = formatter.parseBest(originalTimestamp,
+                        OffsetDateTime::from,
+                        ZonedDateTime::from,
+                        LocalDateTime::from,
+                        LocalDate::from);
+                break;
+            } catch (Exception e) {
+                // not the right format -- try another
+            }
+        }
+
+        if (parsed != null) {
+            if (parsed instanceof OffsetDateTime) {
+                OffsetDateTime offset = (OffsetDateTime) parsed;
+                parsed = offset.withOffsetSameInstant(ZoneOffset.UTC);
+            } else if (parsed instanceof ZonedDateTime) {
+                ZonedDateTime zoned = (ZonedDateTime) parsed;
+                parsed = zoned.withZoneSameInstant(ZoneOffset.UTC);
+            }
+
+            standardized = STANDARD_FORMAT.format(parsed);
+        }
+
+        return standardized;
+    }
+
+
+
+}

--- a/src/test/java/edu/harvard/hul/ois/fits/util/DateTimeUtilTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/util/DateTimeUtilTest.java
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2016 by The President and Fellows of Harvard College
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permission and limitations under the License.
+//
+
+package edu.harvard.hul.ois.fits.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DateTimeUtilTest {
+
+    @Test
+    public void convertKnownFormats() {
+        assertEquals("2020-02-20T01:20:00", DateTimeUtil.standardize("2020-02-20T01:20"));
+        assertEquals("2020-02-20T01:20:13", DateTimeUtil.standardize("2020-02-20T01:20:13"));
+        assertEquals("2020-02-20T01:20:13Z", DateTimeUtil.standardize("2020-02-20T01:20:13Z"));
+        assertEquals("2020-02-20T03:20:13Z", DateTimeUtil.standardize("2020-02-20T01:20:13-02:00"));
+        assertEquals("2020-02-19T22:20:13Z", DateTimeUtil.standardize("2020-02-20T01:20:13+03:00"));
+        assertEquals("2015-09-21T11:42:44.173", DateTimeUtil.standardize("2015-09-21T11:42:44.173000000"));
+
+        assertEquals("2020-02-20T01:20:00", DateTimeUtil.standardize("2020-02-20 01:20"));
+        assertEquals("2020-02-20T01:20:13", DateTimeUtil.standardize("2020-02-20 01:20:13"));
+        assertEquals("2020-02-20T01:20:13Z", DateTimeUtil.standardize("2020-02-20 01:20:13Z"));
+        assertEquals("2020-02-20T03:20:13Z", DateTimeUtil.standardize("2020-02-20 01:20:13-02:00"));
+        assertEquals("2020-02-19T22:20:13Z", DateTimeUtil.standardize("2020-02-20 01:20:13+03:00"));
+        assertEquals("2015-09-21T11:42:44.173", DateTimeUtil.standardize("2015-09-21 11:42:44.173000000"));
+
+        assertEquals("2020-02-20T01:20:00", DateTimeUtil.standardize("2020:02:20 01:20"));
+        assertEquals("2020-02-20T01:20:13", DateTimeUtil.standardize("2020:02:20 01:20:13"));
+        assertEquals("2020-02-20T01:20:13Z", DateTimeUtil.standardize("2020:02:20 01:20:13Z"));
+        assertEquals("2020-02-20T03:20:13Z", DateTimeUtil.standardize("2020:02:20 01:20:13-02:00"));
+        assertEquals("2020-02-19T22:20:13Z", DateTimeUtil.standardize("2020:02:20 01:20:13+03:00"));
+        assertEquals("2015-09-21T11:42:44.173", DateTimeUtil.standardize("2015:09:21 11:42:44.173000000"));
+
+        assertEquals("2020-02-20T01:20:00", DateTimeUtil.standardize("2020.02.20 01:20"));
+        assertEquals("2020-02-20T01:20:13", DateTimeUtil.standardize("2020.02.20 01:20:13"));
+        assertEquals("2020-02-20T01:20:13Z", DateTimeUtil.standardize("2020.02.20 01:20:13Z"));
+        assertEquals("2020-02-20T03:20:13Z", DateTimeUtil.standardize("2020.02.20 01:20:13-02:00"));
+        assertEquals("2020-02-19T22:20:13Z", DateTimeUtil.standardize("2020.02.20 01:20:13+03:00"));
+        assertEquals("2015-09-21T11:42:44.173", DateTimeUtil.standardize("2015.09.21 11:42:44.173000000"));
+
+        assertEquals("2020-02-20", DateTimeUtil.standardize("2020-02-20"));
+        assertEquals("2020-02-20", DateTimeUtil.standardize("2020:02:20"));
+        assertEquals("2020-02-20", DateTimeUtil.standardize("2020.02.20"));
+        assertEquals("2020-02-20", DateTimeUtil.standardize("20200220"));
+
+        assertEquals("2022", DateTimeUtil.standardize("2022"));
+
+        assertEquals("2008-06-03T11:05:30Z", DateTimeUtil.standardize("Tue, 3 Jun 2008 11:05:30 GMT"));
+    }
+
+    @Test
+    public void doNotConvertUnknownFormats() {
+        assertEquals("2020-02-20T0120", DateTimeUtil.standardize("2020-02-20T0120"));
+        assertEquals("bogus", DateTimeUtil.standardize("bogus"));
+        assertEquals("2020-02-20 01", DateTimeUtil.standardize("2020-02-20 01"));
+    }
+
+}

--- a/testfiles/output/4072820.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/4072820.tif_XmlUnitExpectedOutput.xml
@@ -13,10 +13,10 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20.1">13941032</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Adobe Photoshop CS Macintosh</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2005:12:15 12:46:50</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2005-12-15T07:46:50</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2005:12:15 10:56:19-05:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2005-12-15T05:56:19</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40" status="CONFLICT">2005-12-15T12:46:50</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.3.0" status="CONFLICT">2005-12-15T07:46:50</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2005-12-15T15:56:19Z</created>
+    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2005-12-15T05:56:19</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/4072820.tif</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">4072820.tif</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">4a333061a5619b94aa5afc3bb106eb54</md5checksum>
@@ -121,7 +121,7 @@
           </mix:BasicImageInformation>
           <mix:ImageCaptureMetadata>
             <mix:GeneralCaptureInformation>
-              <mix:dateTimeCreated>2005-12-15T10:56:19</mix:dateTimeCreated>
+              <mix:dateTimeCreated>2005-12-15T15:56:19Z</mix:dateTimeCreated>
               <mix:captureDevice>digital still camera</mix:captureDevice>
             </mix:GeneralCaptureInformation>
             <mix:ScannerCapture>

--- a/testfiles/output/Book_pdfx1a.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Book_pdfx1a.pdf_XmlUnitExpectedOutput.xml
@@ -9,10 +9,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.11">962199</size>
     <creatingApplicationName toolname="Jhove" toolversion="1.11">Adobe PDF Library 10.0.1/Adobe InDesign CS6 (Windows)</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:08:20 18:29:04-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2015-08-20T22:29:04Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:20 18:29-04:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-20T22:29:00Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-20T22:29:04Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2015-08-20T22:29:00Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Book_pdfx1a.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Book_pdfx1a.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">2d4fc60b4498c7cb63a95d7d247f6160</md5checksum>

--- a/testfiles/output/DH43D5TQESXBZ8W.xlsx_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/DH43D5TQESXBZ8W.xlsx_XmlUnitExpectedOutput.xml
@@ -11,10 +11,8 @@
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="12.29" status="CONFLICT">2016:08:23 15:51:49Z</lastmodified>
-    <lastmodified toolname="Tika" toolversion="2.0.0" status="CONFLICT">2016-08-23T15:51:49Z</lastmodified>
-    <created toolname="Exiftool" toolversion="12.29" status="CONFLICT">2016:08:22 16:47:09Z</created>
-    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2016-08-22T16:47:09Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2016-08-23T15:51:49Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2016-08-22T16:47:09Z</created>
     <creatingApplicationName toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">Microsoft Macintosh Excel</creatingApplicationName>
     <creatingApplicationVersion toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">15.0300</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/home/winckles/workspace/3rd-party/fits/testfiles/DH43D5TQESXBZ8W.xlsx</filepath>

--- a/testfiles/output/Document_Has_Form_Controls.docm_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Document_Has_Form_Controls.docm_XmlUnitExpectedOutput.xml
@@ -10,10 +10,8 @@
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:09:30 20:34:00Z</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2015-09-30T20:34:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:09:30 20:34:00Z</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-09-30T20:34:00Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-09-30T20:34:00Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2015-09-30T20:34:00Z</created>
     <creatingApplicationName toolname="Tika" toolversion="1.10" status="SINGLE_RESULT">Microsoft Office Word</creatingApplicationName>
     <creatingApplicationVersion toolname="Exiftool" toolversion="10.00">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Document_Has_Form_Controls.docm</filepath>

--- a/testfiles/output/HasAnnotations.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/HasAnnotations.pdf_XmlUnitExpectedOutput.xml
@@ -17,10 +17,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20.1">103323</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54">Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:19 17:12:03-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2015-08-19T21:12:03Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:19 17:10:14-04:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-19T21:10:14Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T21:12:03Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2015-08-19T21:10:14Z</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/HasAnnotations.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">HasAnnotations.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">4475c0c78050f41718837eb3f8069cbd</md5checksum>

--- a/testfiles/output/HasChangeHistory.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/HasChangeHistory.pdf_XmlUnitExpectedOutput.xml
@@ -17,10 +17,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20.1">101002</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54">Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:19 17:10:57-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2015-08-19T21:10:57Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:19 17:10:14-04:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-19T21:10:14Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T21:10:57Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2015-08-19T21:10:14Z</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/HasChangeHistory.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">HasChangeHistory.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">ad18d1a191b7ab53614f3d003fa60472</md5checksum>

--- a/testfiles/output/ICFA.KC.BIA.1524-small.jpg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/ICFA.KC.BIA.1524-small.jpg_XmlUnitExpectedOutput.xml
@@ -17,11 +17,11 @@
     <size toolname="Jhove" toolversion="1.20.1">38829</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="CONFLICT">Canon EOS 5D Mark II</creatingApplicationName>
     <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">Adobe Photoshop CS6 (Windows)</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2017:01:30 11:39:51</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2017-01-30T06:39:51</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2010:07:07 14:22:53</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2017:01:30 11:39:51</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2010-07-07T10:22:53</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40" status="CONFLICT">2017-01-30T11:39:51</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.3.0" status="CONFLICT">2017-01-30T06:39:51</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2010-07-07T14:22:53</created>
+    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2017-01-30T11:39:51</created>
+    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2010-07-07T10:22:53</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/ICFA.KC.BIA.1524-small.jpg</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">ICFA.KC.BIA.1524-small.jpg</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">0108175c9153da1d41278066a2e3c1a2</md5checksum>

--- a/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
@@ -16,11 +16,11 @@
     <size toolname="Jhove" toolversion="1.20.1">4324778</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="CONFLICT">HERO3+ Black Edition</creatingApplicationName>
     <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">Adobe Photoshop CS6 (Macintosh)</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:06:25 11:03:38</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2015-06-25T07:03:38</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2014:10:27 12:34:43</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015:06:25 11:03:38</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2014-10-27T08:34:43</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40" status="CONFLICT">2015-06-25T11:03:38</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.3.0" status="CONFLICT">2015-06-25T07:03:38</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2014-10-27T12:34:43</created>
+    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-06-25T11:03:38</created>
+    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2014-10-27T08:34:43</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/JPEGTest_20170591--JPEGTest_20170591.jpeg</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">JPEGTest_20170591--JPEGTest_20170591.jpeg</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">3c5a86c471809d347e99d19c51bd1b94</md5checksum>

--- a/testfiles/output/PDFA_Document with tables.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFA_Document with tables.pdf_XmlUnitExpectedOutput.xml
@@ -13,10 +13,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20">248559</size>
     <creatingApplicationName toolname="Jhove" toolversion="1.20">Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 18:32:33-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T22:32:33Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:19 18:32:31-04:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-19T22:32:31Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T22:32:33Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2015-08-19T22:32:31Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFA_Document with tables.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFA_Document with tables.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">fd8c309140462d55d6a76e5e3ec709ee</md5checksum>

--- a/testfiles/output/PDF_embedded_resources.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDF_embedded_resources.pdf_XmlUnitExpectedOutput.xml
@@ -17,10 +17,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20.1">1113979</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54">Acrobat Distiller 8.1.0 (Windows)/Adobe PageMaker 6.52</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:19 16:17:32-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2015-08-19T20:17:32Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2008:09:24 15:27:24-04:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2008-09-24T19:27:24Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T20:17:32Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2008-09-24T19:27:24Z</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDF_embedded_resources.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">PDF_embedded_resources.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">dbfbf8c633100f5d4301fed7b65ad698</md5checksum>

--- a/testfiles/output/PDF_eng.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDF_eng.pdf_XmlUnitExpectedOutput.xml
@@ -16,10 +16,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.11">100306</size>
     <creatingApplicationName toolname="Jhove" toolversion="1.11">Acrobat Distiller 6.0.1 for Macintosh/QuarkXPress: pictwpstops filter 1.0</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2004:10:15 13:06:47-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2004-10-15T17:06:47Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2004:10:15 12:35:50-04:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2004-10-15T16:35:50Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2004-10-15T17:06:47Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2004-10-15T16:35:50Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDF_eng.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDF_eng.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">4ef7c6dd77d598fe8f60f84af8e4e7de</md5checksum>

--- a/testfiles/output/PDFa_embedded_resources.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_embedded_resources.pdf_XmlUnitExpectedOutput.xml
@@ -13,10 +13,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20">1219058</size>
     <creatingApplicationName toolname="Jhove" toolversion="1.20">Acrobat Distiller 8.1.0 (Windows)/Adobe PageMaker 6.52</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 17:53-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T21:53:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2008:09:24 15:27:24-04:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2008-09-24T19:27:24Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T21:53:00Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2008-09-24T19:27:24Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFa_embedded_resources.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_embedded_resources.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">12b6269615243b9a62cc9181796e76bd</md5checksum>

--- a/testfiles/output/PDFa_equations.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_equations.pdf_XmlUnitExpectedOutput.xml
@@ -13,10 +13,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20">105831</size>
     <creatingApplicationName toolname="Jhove" toolversion="1.20">Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 19:13:22-04:00 2015:08:19 19:13:22-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T23:13:22Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:19 19:12:42-04:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-19T23:12:42Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T23:13:22Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2015-08-19T23:12:42Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFa_equations.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_equations.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">83fa9407b0ddf13a38579a18fe9f7734</md5checksum>

--- a/testfiles/output/PDFa_has_form.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_form.pdf_XmlUnitExpectedOutput.xml
@@ -14,10 +14,8 @@
     <size toolname="Jhove" toolversion="1.20">111020</size>
     <creatingApplicationName toolname="Jhove" toolversion="1.20" status="CONFLICT">JagPDF 1.5.0, http://jagpdf.org            /Pdfcrowd - online HTML to PDF API - http://pdfcrowd.com</creatingApplicationName>
     <creatingApplicationName toolname="Exiftool" toolversion="11.01" status="CONFLICT">JagPDF 1.5.0, http://jagpdf.org/Pdfcrowd - online HTML to PDF API - http://pdfcrowd.com</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 18:34:33-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T22:34:33Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:19 18:33:55-04:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-19T22:33:55Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T22:34:33Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2015-08-19T22:33:55Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFa_has_form.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_has_form.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">553682ae868f787654f5b2da6925861e</md5checksum>

--- a/testfiles/output/PDFa_has_table_of_contents.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_table_of_contents.pdf_XmlUnitExpectedOutput.xml
@@ -12,10 +12,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20">357428</size>
     <creatingApplicationName toolname="Jhove" toolversion="1.20">Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 18:15:37-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T22:15:37Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:19 16:44:12-04:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-19T20:44:12Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T22:15:37Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2015-08-19T20:44:12Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFa_has_table_of_contents.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_has_table_of_contents.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">537d5a41d854b5c03f8bb33041faf1aa</md5checksum>

--- a/testfiles/output/PDFa_has_tables.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_tables.pdf_XmlUnitExpectedOutput.xml
@@ -13,10 +13,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20">397527</size>
     <creatingApplicationName toolname="Jhove" toolversion="1.20">Mac OS X 10.5.6 Quartz PDFContext/XPP</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 18:29:41-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T22:29:41Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2009:04:13 18:38:02Z</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2009-04-13T18:38:02Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T22:29:41Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2009-04-13T18:38:02Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFa_has_tables.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_has_tables.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">fd321cedf56dec077704cfd5e0b6dbca</md5checksum>

--- a/testfiles/output/PDFa_multiplefonts.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_multiplefonts.pdf_XmlUnitExpectedOutput.xml
@@ -13,10 +13,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20">117120</size>
     <creatingApplicationName toolname="Jhove" toolversion="1.20">Acrobat Distiller 8.1.0 (Windows)/records policy.doc - Microsoft Word</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2015:08:19 17:45:08-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2015-08-19T21:45:08Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2008:09:24 15:27:39-04:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2008-09-24T19:27:39Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T21:45:08Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2008-09-24T19:27:39Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/PDFa_multiplefonts.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFa_multiplefonts.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">ba84a24c8d09b76b1f02e359c36ebbda</md5checksum>

--- a/testfiles/output/PDFx3.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFx3.pdf_XmlUnitExpectedOutput.xml
@@ -9,10 +9,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.11">592522</size>
     <creatingApplicationName toolname="Jhove" toolversion="1.11">Adobe PDF Library 10.0.1/Adobe InDesign CS6 (Windows)</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:08:20 18:22:09-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2015-08-20T22:22:09Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:20 18:22:08-04:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-20T22:22:08Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-20T22:22:09Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2015-08-20T22:22:08Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/PDFx3.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">PDFx3.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">745c9a202265d728d5cd21f86f1d411f</md5checksum>

--- a/testfiles/output/W00EGS1016782-I01JW30--I01JW300001__0001.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/W00EGS1016782-I01JW30--I01JW300001__0001.tif_XmlUnitExpectedOutput.xml
@@ -14,9 +14,9 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20">35130</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.01" status="CONFLICT">2006:12:19 15:08:15</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.18" status="CONFLICT">2006-12-19T10:08:15</lastmodified>
-    <created toolname="Tika" toolversion="2.2.1" status="SINGLE_RESULT">2006-12-19T10:08:15</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40" status="CONFLICT">2006-12-19T15:08:15</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.3.0" status="CONFLICT">2006-12-19T10:08:15</lastmodified>
+    <created toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">2006-12-19T10:08:15</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/W00EGS1016782-I01JW30--I01JW300001__0001.tif</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">W00EGS1016782-I01JW30--I01JW300001__0001.tif</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">90f9a85c04e1bc2c5c1f689c110b1588</md5checksum>
@@ -63,7 +63,9 @@
             </mix:BasicImageCharacteristics>
           </mix:BasicImageInformation>
           <mix:ImageCaptureMetadata>
-            <mix:GeneralCaptureInformation />
+            <mix:GeneralCaptureInformation>
+              <mix:dateTimeCreated>2006-12-19T10:08:15</mix:dateTimeCreated>
+            </mix:GeneralCaptureInformation>
             <mix:ScannerCapture>
               <mix:ScanningSystemSoftware>
                 <mix:scanningSoftwareName>ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org</mix:scanningSoftwareName>

--- a/testfiles/output/Word_has_index.docx_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word_has_index.docx_XmlUnitExpectedOutput.xml
@@ -11,10 +11,8 @@
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2015:08:19 23:04:00Z</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2015-08-19T23:04:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:19 23:03:00Z</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-19T23:03:00Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T23:04:00Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2015-08-19T23:03:00Z</created>
     <creatingApplicationName toolname="Tika" toolversion="1.10" status="SINGLE_RESULT">Microsoft Office Word</creatingApplicationName>
     <creatingApplicationVersion toolname="Exiftool" toolversion="10.00">14.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Word_has_index.docx</filepath>

--- a/testfiles/output/altona_technical_1v2_x3_has_annotations.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/altona_technical_1v2_x3_has_annotations.pdf_XmlUnitExpectedOutput.xml
@@ -13,10 +13,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.11">4274074</size>
     <creatingApplicationName toolname="Jhove" toolversion="1.11">Acrobat Distiller 5.0.5 f.r Macintosh/QuarkXPress(R) 4.04</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2004:05:09 14:07:13+02:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2004-05-09T12:07:13Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2002:09:21 19:25:36Z</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2002-09-21T19:25:36Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2004-05-09T12:07:13Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2002-09-21T19:25:36Z</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/altona_technical_1v2_x3_has_annotations.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">altona_technical_1v2_x3_has_annotations.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">c524ab2cd02240b12eab3ee9f8887a9f</md5checksum>

--- a/testfiles/output/gps.jpg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/gps.jpg_XmlUnitExpectedOutput.xml
@@ -17,11 +17,11 @@
     <size toolname="Jhove" toolversion="1.20.1">41851</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="CONFLICT">FinePix F30</creatingApplicationName>
     <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">Digital Camera FinePix F30     Ver1.02</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2006:11:03 02:26:02</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2006-11-02T21:26:02</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2006:11:03 07:14:39</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2006:11:03 02:26:02</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2006-11-03T02:14:39</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40" status="CONFLICT">2006-11-03T02:26:02</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.3.0" status="CONFLICT">2006-11-02T21:26:02</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2006-11-03T07:14:39</created>
+    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2006-11-03T02:26:02</created>
+    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2006-11-03T02:14:39</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/gps.jpg</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">gps.jpg</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">201f1db44775631d307b3ffd62acb3ac</md5checksum>

--- a/testfiles/output/samplepptx.pptx_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/samplepptx.pptx_XmlUnitExpectedOutput.xml
@@ -11,10 +11,8 @@
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="12.29" status="CONFLICT">2009:05:06 22:13:30Z</lastmodified>
-    <lastmodified toolname="Tika" toolversion="2.0.0" status="CONFLICT">2009-05-06T22:13:30Z</lastmodified>
-    <created toolname="Exiftool" toolversion="12.29" status="CONFLICT">2009:05:06 22:06:09Z</created>
-    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2009-05-06T22:06:09Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40">2009-05-06T22:13:30Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40">2009-05-06T22:06:09Z</created>
     <creatingApplicationName toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">Microsoft Office PowerPoint</creatingApplicationName>
     <creatingApplicationVersion toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">12.0000</creatingApplicationVersion>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/home/winckles/workspace/3rd-party/fits/testfiles/samplepptx.pptx</filepath>

--- a/testfiles/output/test.jp2_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/test.jp2_XmlUnitExpectedOutput.xml
@@ -13,7 +13,7 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20.1">253214</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Photostation v1</creatingApplicationName>
-    <created toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2007:09:21 00:00:00+08:00</created>
+    <created toolname="Exiftool" toolversion="12.40" status="SINGLE_RESULT">2007-09-20T16:00:00Z</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/test.jp2</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">test.jp2</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">a9f2c77997e438c97639ad3a843f4fdb</md5checksum>
@@ -77,7 +77,7 @@
           </mix:BasicImageInformation>
           <mix:ImageCaptureMetadata>
             <mix:GeneralCaptureInformation>
-              <mix:dateTimeCreated>2007-09-21T00:00:00</mix:dateTimeCreated>
+              <mix:dateTimeCreated>2007-09-20T16:00:00Z</mix:dateTimeCreated>
             </mix:GeneralCaptureInformation>
             <mix:ScannerCapture>
               <mix:scannerManufacturer>Google</mix:scannerManufacturer>

--- a/testfiles/output/topazscanner.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/topazscanner.tif_XmlUnitExpectedOutput.xml
@@ -9,10 +9,10 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20.1">5146108</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Adobe Photoshop CS Macintosh</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2006:11:28 13:30:06</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2006-11-28T08:30:06</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2006:11:28 12:22:59-05:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2006-11-28T08:30:06</created>
+    <lastmodified toolname="Exiftool" toolversion="12.40" status="CONFLICT">2006-11-28T13:30:06</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.3.0" status="CONFLICT">2006-11-28T08:30:06</lastmodified>
+    <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2006-11-28T17:22:59Z</created>
+    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2006-11-28T08:30:06</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/topazscanner.tif</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">topazscanner.tif</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">c2c36f561b1da65ff74ea2b22fe3fba0</md5checksum>
@@ -97,7 +97,7 @@
           </mix:BasicImageInformation>
           <mix:ImageCaptureMetadata>
             <mix:GeneralCaptureInformation>
-              <mix:dateTimeCreated>2006-11-28T12:22:59</mix:dateTimeCreated>
+              <mix:dateTimeCreated>2006-11-28T17:22:59Z</mix:dateTimeCreated>
             </mix:GeneralCaptureInformation>
             <mix:ScannerCapture>
               <mix:ScanningSystemSoftware>


### PR DESCRIPTION
Resolves https://github.com/harvard-lts/fits/issues/298

This PR standardizes the create and last modified timestamps in the file info to be in one of the following formats:

* `yyyy-MM-dd`
* `yyyy-MM-dd'T'HH:mm:ss`
* `yyyy-MM-dd'T'HH:mm:ss'Z'`

If the source date cannot be parsed using any of the configured formats, then it remains unchanged. If the timestamp can be parsed, and it contains timezone information, then it is standardized to UTC. If it does not contain timezone information, then a timezone is not assumed. Unfortunately, some of the tools make incorrect timezone assumptions before the data reaches FITS, so there are still conflicts.