### PR TITLE
DPX File Format Identification Mapping and Exclusion

### DIFF
--- a/xml/fits.xml
+++ b/xml/fits.xml
@@ -11,7 +11,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.VTTTool" include-exts="vtt" />
         <tool class="edu.harvard.hul.ois.fits.tools.droid.Droid"  exclude-exts="odm,m4a,mpg" classpath-dirs="lib/droid" />
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip" classpath-dirs="lib/jhove" />
-        <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,csv,m4a" classpath-dirs="lib/fileutility" />
+        <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,csv,m4a,dpx" classpath-dirs="lib/fileutility" />
         <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
         <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" include-exts="bmp,gif,jpg,jpeg,wp,wpd,odt,doc,pdf,mp3,bfw,flac,html,xml,arc" classpath-dirs="lib/nzmetool,xml/nlnz"/>
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />

--- a/xml/fits_xml_map.xml
+++ b/xml/fits_xml_map.xml
@@ -109,6 +109,11 @@
 				<map from="Centered" to="1"/>
 				<map from="Co-sited" to="2"/>
 			</element>
+			<element name="identity">
+				<attribute name="format">
+					<map from="DPX" to="Digital Picture Exchange"/>
+				</attribute>
+			</element>
 		</mime>
 	</tool>
 
@@ -158,7 +163,17 @@
                 <map from="MXF" to="Material Exchange Format (MXF)"/>
 			</element>
 		</mime>
-	</tool>	
+	</tool>
+
+	<tool name="Tika">
+		<mime type="all">
+			<element name="identity">
+				<attribute name="format">
+					<map from="Digital Picture Exchange from SMPTE" to="Digital Picture Exchange"/>
+				</attribute>
+			</element>
+		</mime>
+	</tool>
 
 
 <!-- METADATA EXTRACTION TOOLS -->


### PR DESCRIPTION
Resolves https://github.com/harvard-lts/fits/issues/293

Adds dpx to FileUtility's list of excluded extensions in fits.xml
Adds mapping for dpx identity format to ExifTool and Tika in fits_xml_map.xml