### PR TITLE
remove unneeded namespaces from MediaInfo output

### DIFF
--- a/xml/mediainfo/mediainfo_common_to_fits.xslt
+++ b/xml/mediainfo/mediainfo_common_to_fits.xslt
@@ -1,12 +1,6 @@
 <?xml version="1.0" ?>
 <xsl:stylesheet version="2.0"   
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-
-   xmlns:dc="http://purl.org/dc/elements/1.1/" 
-   xmlns:ebucore="urn:ebu:metadata-schema:ebuCore_2014" 
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-   xmlns:xalan="http://xml.apache.org/xalan"
-   >
+   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:output method="xml" indent="yes"/>
 <xsl:strip-space elements="*"/>
 

--- a/xml/mediainfo/mediainfo_video_to_fits.xslt
+++ b/xml/mediainfo/mediainfo_video_to_fits.xslt
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xsl:stylesheet version="2.0"
    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-   xmlns:dc="http://purl.org/dc/elements/1.1/" 
-   xmlns:ebucore="urn:ebu:metadata-schema:ebuCore_2014" 
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-   xmlns:xalan="http://xml.apache.org/xalan"
    xmlns:local="http://local"
-   >
+   exclude-result-prefixes="local">
 <xsl:import href="mediainfo_common_to_fits.xslt"/>
 
 <!-- Used to convert case of the string -->


### PR DESCRIPTION
I noticed when I as upgraded MediaInfo that inappropriate namespaces were leaking into the FITS output. This will clean them up.