### PR TITLE
Bump Javadoc plugin version to resolve NPE with Java 11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.4.0</version>
 				<configuration>
 					<source>${java.version}</source>
 				</configuration>


### PR DESCRIPTION
**Resolves Issue**: (https://github.com/harvard-lts/fits/issues/329)

# What does this Pull Request do?
When building the project with `mvn clean package` there is a NullPointerException when using maven-javadoc-plugin 3.0.0. Bumping this to version 3.4.0 resolves this issue.

# How should this be tested?
`mvn clean package -DskipTests`   (It is unnecessary to run tests.)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n/a
- integration tests? n/a

# Interested parties
@awoods 