### PR TITLE
fix the build so it runs on

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ dev ]
+    branches: [ main ]
   pull_request:
-    branches: [ dev ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
The GH Actions build was configured to only run on the `dev` branch. However, now `main` is the default branch. This updates the build to run on `main`.