### PR TITLE
integrate code formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ Learn more
 ----------
 After you are up and running see the [User Manual](http://fitstool.org/user-manual) for more documentation.
 
+
+Development
+-----------
+
+This project uses a code formatter to ensure consist formatting. To run the formatter:
+
+    mvn spotless:apply
+
+When the project builds, it checks the formatting and will fail if there are any files that are not formatted per the standard.
+
 License Details
 ---------------
 FITS is released under the [GNU LGPL](http://www.gnu.org/licenses/lgpl.html) open source license. The source code for FITS is included in the downloadable ZIP files.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ After you are up and running see the [User Manual](http://fitstool.org/user-manu
 Development
 -----------
 
+### JDK
+
+While FITS only requires Java 8 to run, it requires **Java 11** or later to _build_.
+
+### Formatting
+
 This project uses a code formatter to apply the [palantir-java-format](https://github.com/palantir/palantir-java-format)
 to ensure consist formatting based on the [Google Style Guide](https://google.github.io/styleguide/javaguide.html).
 To run the formatter:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Development
 -----------
 
 This project uses a code formatter to apply the [palantir-java-format](https://github.com/palantir/palantir-java-format)
-to ensure consist formatting. To run the formatter:
+to ensure consist formatting based on the [Google Style Guide](https://google.github.io/styleguide/javaguide.html).
+To run the formatter:
 
     mvn spotless:apply
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ After you are up and running see the [User Manual](http://fitstool.org/user-manu
 Development
 -----------
 
-This project uses a code formatter to ensure consist formatting. To run the formatter:
+This project uses a code formatter to apply the [palantir-java-format](https://github.com/palantir/palantir-java-format)
+to ensure consist formatting. To run the formatter:
 
     mvn spotless:apply
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,28 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>2.27.2</version>
+				<configuration>
+					<java>
+						<importOrder />
+						<removeUnusedImports />
+						<palantirJavaFormat>
+							<version>2.27.0</version>
+						</palantirJavaFormat>
+					</java>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<phase>compile</phase>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/edu/harvard/hul/ois/fits/AESModel.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/AESModel.java
@@ -10,8 +10,6 @@
 
 package edu.harvard.hul.ois.fits;
 
-import java.util.UUID;
-
 import edu.harvard.hul.ois.ots.schemas.AES.AudioObject;
 import edu.harvard.hul.ois.ots.schemas.AES.BitrateReduction;
 import edu.harvard.hul.ois.ots.schemas.AES.ChannelAssignment;
@@ -21,13 +19,14 @@ import edu.harvard.hul.ois.ots.schemas.AES.FaceRegion;
 import edu.harvard.hul.ois.ots.schemas.AES.Format;
 import edu.harvard.hul.ois.ots.schemas.AES.FormatList;
 import edu.harvard.hul.ois.ots.schemas.AES.FormatRegion;
+import edu.harvard.hul.ois.ots.schemas.AES.FormatRegion.regionTypeEnum;
 import edu.harvard.hul.ois.ots.schemas.AES.GenericFormatRegion;
 import edu.harvard.hul.ois.ots.schemas.AES.Identifier;
 import edu.harvard.hul.ois.ots.schemas.AES.Stream;
 import edu.harvard.hul.ois.ots.schemas.AES.TimeRange;
-import edu.harvard.hul.ois.ots.schemas.AES.FormatRegion.regionTypeEnum;
 import edu.harvard.hul.ois.ots.schemas.AES.Use;
 import edu.harvard.hul.ois.ots.schemas.XmlContent.XmlContentException;
+import java.util.UUID;
 
 public class AESModel {
 
@@ -41,100 +40,102 @@ public class AESModel {
     protected TimeRange timeRange;
     protected BitrateReduction brr;
 
-    protected final String audioObjectID = "AUDIO_OBJECT_"+UUID.randomUUID().toString();
-    protected final String faceID = "FACE_"+UUID.randomUUID().toString();
-    protected final String regionID = "REGION_"+UUID.randomUUID().toString();
-    protected final String formatRegionID = "FORMAT_REGION_"+UUID.randomUUID().toString();
+    protected final String audioObjectID = "AUDIO_OBJECT_" + UUID.randomUUID().toString();
+    protected final String faceID = "FACE_" + UUID.randomUUID().toString();
+    protected final String regionID = "REGION_" + UUID.randomUUID().toString();
+    protected final String formatRegionID = "FORMAT_REGION_" + UUID.randomUUID().toString();
 
+    protected AESModel() throws XmlContentException {
 
-    protected AESModel () throws XmlContentException {
-
-    	//set up base AES object structure
-        aes = new AudioObject (true);
+        // set up base AES object structure
+        aes = new AudioObject(true);
         aes.setSchemaVersion("1.0.0");
         aes.setID(audioObjectID);
         aes.setDisposition("");
-        Identifier ident = new Identifier("","primaryIdentifier");
+        Identifier ident = new Identifier("", "primaryIdentifier");
         ident.setIdentifierType("FILE_NAME");
         aes.setPrimaryIdentifier(ident);
 
-    	face = new Face();
-    	face.setLabel("face 1");
-    	face.setDirection("NONE");
-    	face.setID(faceID);
-    	face.setAudioObjectRef(audioObjectID);
-    	aes.addFace(face);
+        face = new Face();
+        face.setLabel("face 1");
+        face.setDirection("NONE");
+        face.setID(faceID);
+        face.setAudioObjectRef(audioObjectID);
+        aes.addFace(face);
 
-    	timeline = new TimeRange("timeline");
-    	EditUnitNumber startTime = new EditUnitNumber(0,"startTime");
-    	startTime.setEditRate(1);
-    	timeline.setStartTime(startTime);
-    	face.setTimeline(timeline);
+        timeline = new TimeRange("timeline");
+        EditUnitNumber startTime = new EditUnitNumber(0, "startTime");
+        startTime.setEditRate(1);
+        timeline.setStartTime(startTime);
+        face.setTimeline(timeline);
 
-    	region = new FaceRegion();
-    	region.setID(regionID);
-    	region.setFaceRef(faceID);
-    	region.setLabel("region 1");
-    	timeRange = new TimeRange("timeRange");
-    	timeRange.setStartTime(startTime);
-    	region.setTimeRange(timeRange);
-    	region.setFormatRef(formatRegionID);
-    	face.addRegion(region);
+        region = new FaceRegion();
+        region.setID(regionID);
+        region.setFaceRef(faceID);
+        region.setLabel("region 1");
+        timeRange = new TimeRange("timeRange");
+        timeRange.setStartTime(startTime);
+        region.setTimeRange(timeRange);
+        region.setFormatRef(formatRegionID);
+        face.addRegion(region);
 
-    	formatList = new FormatList();
+        formatList = new FormatList();
 
-    	formatRegion = new FormatRegion(regionTypeEnum.GENERIC);
-    	genericFormatRegion = (GenericFormatRegion) formatRegion.getContent();
-    	genericFormatRegion.setID(formatRegionID);
-    	genericFormatRegion.setOwnerRef(regionID);
-    	genericFormatRegion.setLabel("format region 1");
+        formatRegion = new FormatRegion(regionTypeEnum.GENERIC);
+        genericFormatRegion = (GenericFormatRegion) formatRegion.getContent();
+        genericFormatRegion.setID(formatRegionID);
+        genericFormatRegion.setOwnerRef(regionID);
+        genericFormatRegion.setLabel("format region 1");
 
-    	formatList.addFormatRegion(formatRegion);
-    	aes.setFormatList(formatList);
-
+        formatList.addFormatRegion(formatRegion);
+        aes.setFormatList(formatList);
     }
 
     private void initBitRateReduction() throws XmlContentException {
-    	brr = new BitrateReduction();
-    	brr.setCodecName("");
-    	brr.setCodecNameVersion("");
-    	brr.setCodecCreatorApplication("");
-    	brr.setCodecCreatorApplicationVersion("");
-    	brr.setCodecQuality("LOSSY");
-    	brr.setDataRate("");
-    	brr.setDataRateMode("FIXED");
-    	genericFormatRegion.addBitrateReduction(brr);
+        brr = new BitrateReduction();
+        brr.setCodecName("");
+        brr.setCodecNameVersion("");
+        brr.setCodecCreatorApplication("");
+        brr.setCodecCreatorApplicationVersion("");
+        brr.setCodecQuality("LOSSY");
+        brr.setDataRate("");
+        brr.setDataRateMode("FIXED");
+        genericFormatRegion.addBitrateReduction(brr);
     }
 
     protected void setBitRate(String rate) throws XmlContentException {
-    	if(brr == null) {
-    		initBitRateReduction();
-    	}
-    	brr.setDataRate(rate);
+        if (brr == null) {
+            initBitRateReduction();
+        }
+        brr.setDataRate(rate);
     }
+
     protected void setCodec(String codec) throws XmlContentException {
-    	if(brr == null) {
-    		initBitRateReduction();
-    	}
-    	brr.setCodecName(codec);
+        if (brr == null) {
+            initBitRateReduction();
+        }
+        brr.setCodecName(codec);
     }
+
     protected void setCodecVersion(String codecVersion) throws XmlContentException {
-    	if(brr == null) {
-    		initBitRateReduction();
-    	}
-    	brr.setCodecNameVersion(codecVersion);
+        if (brr == null) {
+            initBitRateReduction();
+        }
+        brr.setCodecNameVersion(codecVersion);
     }
+
     protected void setCodecCreatorApplication(String codecCreatorApp) throws XmlContentException {
-    	if(brr == null) {
-    		initBitRateReduction();
-    	}
-    	brr.setCodecCreatorApplication(codecCreatorApp);
+        if (brr == null) {
+            initBitRateReduction();
+        }
+        brr.setCodecCreatorApplication(codecCreatorApp);
     }
+
     protected void setCodecCreatorApplicationVersion(String codecCreatorAppVersion) throws XmlContentException {
-    	if(brr == null) {
-    		initBitRateReduction();
-    	}
-    	brr.setCodecCreatorApplicationVersion(codecCreatorAppVersion);
+        if (brr == null) {
+            initBitRateReduction();
+        }
+        brr.setCodecCreatorApplicationVersion(codecCreatorAppVersion);
     }
 
     /**
@@ -144,11 +145,11 @@ public class AESModel {
      * @throws XmlContentException
      */
     protected void setStartTime(String time, int editRate) throws XmlContentException {
-    	EditUnitNumber startTime = getEditUnitNumber(time,editRate,0,"startTime");
-    	//set timeline duration
-    	timeline.setStartTime(startTime);
-     	//set timeRange startTime
-    	timeRange.setStartTime(startTime);
+        EditUnitNumber startTime = getEditUnitNumber(time, editRate, 0, "startTime");
+        // set timeline duration
+        timeline.setStartTime(startTime);
+        // set timeRange startTime
+        timeRange.setStartTime(startTime);
     }
 
     /**
@@ -159,62 +160,59 @@ public class AESModel {
      * @throws XmlContentException
      */
     protected void setDuration(String time, int editRate, long numSamples) throws XmlContentException {
-    	EditUnitNumber duration = getEditUnitNumber(time,editRate,numSamples,"duration");
-    	//set timeline duration
-    	timeline.setDuration(duration);
-    	//set timeRange duration
-    	timeRange.setDuration(duration);
+        EditUnitNumber duration = getEditUnitNumber(time, editRate, numSamples, "duration");
+        // set timeline duration
+        timeline.setDuration(duration);
+        // set timeRange duration
+        timeRange.setDuration(duration);
     }
 
     private EditUnitNumber getEditUnitNumber(String time, int editRate, long numSamples, String elementName) {
-    	EditUnitNumber eun = null;
-    	if(editRate != 0 && numSamples != 0) {
-        	eun = new EditUnitNumber((int)numSamples,elementName);
-        	eun.setEditRate(editRate);
-    	}
-    	else {
-	    	double timeval = timeUnitToAddress(time);
-	    	//check if time is a whole number
-	    	if(Math.floor(timeval) == timeval) {
-	    		//whole number so use seconds, use timeval as is
-	    		editRate = 1;
-	    	}
-	    	else {
-	    		//convert timevalto milliseconds
-	    		timeval = timeval * 1000;
-	    		editRate = 1000;
-	    	}
-	    	eun = new EditUnitNumber((int)timeval,elementName);
-	    	eun.setEditRate(editRate);
-    	}
-    	return eun;
+        EditUnitNumber eun = null;
+        if (editRate != 0 && numSamples != 0) {
+            eun = new EditUnitNumber((int) numSamples, elementName);
+            eun.setEditRate(editRate);
+        } else {
+            double timeval = timeUnitToAddress(time);
+            // check if time is a whole number
+            if (Math.floor(timeval) == timeval) {
+                // whole number so use seconds, use timeval as is
+                editRate = 1;
+            } else {
+                // convert timevalto milliseconds
+                timeval = timeval * 1000;
+                editRate = 1000;
+            }
+            eun = new EditUnitNumber((int) timeval, elementName);
+            eun.setEditRate(editRate);
+        }
+        return eun;
     }
 
     private double timeUnitToAddress(String time) {
-    	String[] parts = time.split(":");
+        String[] parts = time.split(":");
 
-    	double seconds = 0;
+        double seconds = 0;
 
-    	// hours:minutes:seconds:milliseconds
-    	if(parts.length >= 3) {
-	    	//hours
-	    	seconds = (Long.valueOf(parts[0]) * 60 * 60);
-	    	//minutes
-	    	seconds += Long.valueOf(parts[1]) * 60;
-	    	//seconds
-	    	seconds += Long.valueOf(parts[2]);
-	    	//milliseconds
-	    	if(parts.length == 4)
-	    		seconds += Long.valueOf(parts[3]) / 1000.000;
-    	}
-    	// minutes:seconds
-    	else if (parts.length == 2) {
-	    	//minutes
-	    	seconds += Long.valueOf(parts[0]) * 60;
-	    	//seconds
-	    	seconds += Long.valueOf(parts[1]);
-    	}
-    	return seconds;
+        // hours:minutes:seconds:milliseconds
+        if (parts.length >= 3) {
+            // hours
+            seconds = (Long.valueOf(parts[0]) * 60 * 60);
+            // minutes
+            seconds += Long.valueOf(parts[1]) * 60;
+            // seconds
+            seconds += Long.valueOf(parts[2]);
+            // milliseconds
+            if (parts.length == 4) seconds += Long.valueOf(parts[3]) / 1000.000;
+        }
+        // minutes:seconds
+        else if (parts.length == 2) {
+            // minutes
+            seconds += Long.valueOf(parts[0]) * 60;
+            // seconds
+            seconds += Long.valueOf(parts[1]);
+        }
+        return seconds;
     }
 
     /**
@@ -222,62 +220,59 @@ public class AESModel {
      * @throws XmlContentException
      */
     protected void setBitDepth(int bitDepth) throws XmlContentException {
-    	genericFormatRegion.setBitDepth(bitDepth);
+        genericFormatRegion.setBitDepth(bitDepth);
     }
 
     protected void setWordSize(int wordsize) throws XmlContentException {
-    	genericFormatRegion.setWordSize(wordsize);
+        genericFormatRegion.setWordSize(wordsize);
     }
 
     protected void setNumChannels(int num) throws XmlContentException {
-    	region.setNumChannels(num);
-		if (num == 1) {
-			genericFormatRegion.setSoundField("MONO");
-		}
-		else if (num == 2) {
-			genericFormatRegion.setSoundField("STEREO");
-		}
-		else if (num != 0) {
-			genericFormatRegion.setSoundField("SURROUND");
-		}
+        region.setNumChannels(num);
+        if (num == 1) {
+            genericFormatRegion.setSoundField("MONO");
+        } else if (num == 2) {
+            genericFormatRegion.setSoundField("STEREO");
+        } else if (num != 0) {
+            genericFormatRegion.setSoundField("SURROUND");
+        }
     }
 
-
     protected void setDummyUseType() throws XmlContentException {
-    	if(aes.getUses().size() == 0) {
-    		Use use = new Use();
-	    	aes.addUse(use);
-	    	use.setUseType("OTHER");
-	    	use.setOtherType("unknown");
-    	}
+        if (aes.getUses().size() == 0) {
+            Use use = new Use();
+            aes.addUse(use);
+            use.setUseType("OTHER");
+            use.setOtherType("unknown");
+        }
     }
 
     protected void addStream(int channelNum, double leftRightPos, double frontRearPos) throws XmlContentException {
-    	Stream stream = new Stream();
-    	stream.setID("STREAM_"+UUID.randomUUID().toString());
-    	stream.setFaceRegionRef(regionID);
-    	stream.setLabel("stream "+channelNum);
-    	ChannelAssignment channelAssignment = new ChannelAssignment();
-    	channelAssignment.setChannelNum(channelNum);
-    	channelAssignment.setLeftRightPosition(leftRightPos);
-    	channelAssignment.setFrontRearPosition(frontRearPos);
-    	stream.setChannelAssignment(channelAssignment);
-    	region.addStream(stream);
+        Stream stream = new Stream();
+        stream.setID("STREAM_" + UUID.randomUUID().toString());
+        stream.setFaceRegionRef(regionID);
+        stream.setLabel("stream " + channelNum);
+        ChannelAssignment channelAssignment = new ChannelAssignment();
+        channelAssignment.setChannelNum(channelNum);
+        channelAssignment.setLeftRightPosition(leftRightPos);
+        channelAssignment.setFrontRearPosition(frontRearPos);
+        stream.setChannelAssignment(channelAssignment);
+        region.addStream(stream);
     }
 
     protected void setFormat(String format, String version) throws XmlContentException {
-    	Format formatElem = new Format(format);
-    	if(version != null && version.length() > 0) {
-    		formatElem.setAttribute("specificationVersion", version);
-    	}
-    	aes.setFormat(formatElem);
+        Format formatElem = new Format(format);
+        if (version != null && version.length() > 0) {
+            formatElem.setAttribute("specificationVersion", version);
+        }
+        aes.setFormat(formatElem);
     }
 
     protected void setAudioDataEncoding(String encoding) throws XmlContentException {
-    	aes.setAudioDataEncoding(encoding);
+        aes.setAudioDataEncoding(encoding);
     }
 
     protected void setAudioDataBlockSize(int adbs) throws XmlContentException {
-    	aes.setAudioDataBlockSize(adbs);
+        aes.setAudioDataBlockSize(adbs);
     }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/AudioFormatElements.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/AudioFormatElements.java
@@ -11,42 +11,41 @@
 package edu.harvard.hul.ois.fits;
 
 public enum AudioFormatElements {
+    soundField("soundField"),
+    bitRate("bitRate"),
+    bitRateMode("bitRateMode"),
+    samplingRate("samplingRate"),
+    sampleSize("sampleSize"),
+    channels("channels"),
+    byteOrder("byteOrder"),
+    delay("delay"),
+    compression("compression"),
 
-	soundField ("soundField"),
-	bitRate ("bitRate"),
-	bitRateMode ("bitRateMode"),
-	samplingRate ("samplingRate"),
-	sampleSize ("sampleSize"),
-	channels("channels"),
-	byteOrder ("byteOrder"),
-	delay ("delay"),
-	compression ("compression"),
+    // NOTE the difference between the name and the ebucoreName so that .name()
+    // and .getEbucoreName() are different
+    trackSize("streamSize"),
+    numSamples("sampleCount"),
 
-	// NOTE the difference between the name and the ebucoreName so that .name()
-	// and .getEbucoreName() are different
-	trackSize ("streamSize"),
-	numSamples ("sampleCount"),
+    duration("duration");
 
-	duration ("duration");
+    private String ebucoreName;
 
-	private String ebucoreName;
-
-	AudioFormatElements(String ebcoreName) {
+    AudioFormatElements(String ebcoreName) {
         this.ebucoreName = ebcoreName;
     }
 
-    public String getEbucoreName () {
+    public String getEbucoreName() {
         return ebucoreName;
     }
 
-//    static public AudioFormatElements lookup(String name) {
-//    	AudioFormatElements retMethod = null;
-//    	for(AudioFormatElements method : AudioFormatElements.values()) {
-//    		if (method.Name().equals(name)) {
-//    			retMethod = method;
-//    			break;
-//    		}
-//    	}
-//    	return retMethod;
-//    }
+    //    static public AudioFormatElements lookup(String name) {
+    //    	AudioFormatElements retMethod = null;
+    //    	for(AudioFormatElements method : AudioFormatElements.values()) {
+    //    		if (method.Name().equals(name)) {
+    //    			retMethod = method;
+    //    			break;
+    //    		}
+    //    	}
+    //    	return retMethod;
+    //    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/DocumentMDModel.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/DocumentMDModel.java
@@ -12,26 +12,25 @@ package edu.harvard.hul.ois.fits;
 
 import edu.harvard.hul.ois.ots.schemas.DocumentMD.DocumentMD;
 import edu.harvard.hul.ois.ots.schemas.DocumentMD.DocumentMD.Feature;
-
 import org.jdom2.Element;
 
 public class DocumentMDModel {
 
     protected DocumentMD docMD;
 
-    protected DocumentMDModel () {
-        docMD = new DocumentMD ();
+    protected DocumentMDModel() {
+        docMD = new DocumentMD();
     }
 
     /** Adds a feature to the document metadata. The element name needs to
      *  be the same as a value of the Enum Feature, or nothing will happen.
      */
-    protected void addFeature (Element featureElem) {
-        String name = featureElem.getName ();
+    protected void addFeature(Element featureElem) {
+        String name = featureElem.getName();
         String text = featureElem.getText().trim();
         if ("yes".equals(text)) {
-            for (Feature ftr: Feature.values()) {
-                if (ftr.toString().equals (name)) {
+            for (Feature ftr : Feature.values()) {
+                if (ftr.toString().equals(name)) {
                     docMD.addFeature(ftr);
                     break;
                 }

--- a/src/main/java/edu/harvard/hul/ois/fits/DocumentTypes.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/DocumentTypes.java
@@ -30,98 +30,95 @@ public class DocumentTypes {
 
     /** Map of MIME types to FITS doctypes.
      *  exiftool_xslt_map.xml is a good reference to use. */
-    private final static Map<String, Doctype> doctypeMap =
-            new HashMap<String, Doctype> ();
+    private static final Map<String, Doctype> doctypeMap = new HashMap<String, Doctype>();
+
     static {
-        doctypeMap.put ("audio/basic", Doctype.AUDIO);
-        doctypeMap.put ("audio/mid", Doctype.AUDIO);
-        doctypeMap.put ("audio/mpeg", Doctype.AUDIO);
-        doctypeMap.put ("audio/ogg", Doctype.AUDIO);
-        doctypeMap.put ("audio/x-flac", Doctype.AUDIO);
-        doctypeMap.put ("audio/x-pn-realaudio", Doctype.AUDIO);
-        doctypeMap.put ("audio/wav", Doctype.AUDIO);
-        doctypeMap.put ("audio/x-wave", Doctype.AUDIO);
-        doctypeMap.put ("audio/x-mid", Doctype.AUDIO);
-        doctypeMap.put ("audio/x-midi", Doctype.AUDIO);
-        doctypeMap.put ("audio/x-wave", Doctype.AUDIO);
-        doctypeMap.put ("audio/x-aiff", Doctype.AUDIO);
+        doctypeMap.put("audio/basic", Doctype.AUDIO);
+        doctypeMap.put("audio/mid", Doctype.AUDIO);
+        doctypeMap.put("audio/mpeg", Doctype.AUDIO);
+        doctypeMap.put("audio/ogg", Doctype.AUDIO);
+        doctypeMap.put("audio/x-flac", Doctype.AUDIO);
+        doctypeMap.put("audio/x-pn-realaudio", Doctype.AUDIO);
+        doctypeMap.put("audio/wav", Doctype.AUDIO);
+        doctypeMap.put("audio/x-wave", Doctype.AUDIO);
+        doctypeMap.put("audio/x-mid", Doctype.AUDIO);
+        doctypeMap.put("audio/x-midi", Doctype.AUDIO);
+        doctypeMap.put("audio/x-wave", Doctype.AUDIO);
+        doctypeMap.put("audio/x-aiff", Doctype.AUDIO);
 
-        doctypeMap.put ("application/epub+zip", Doctype.DOCUMENT);
-        doctypeMap.put ("application/pdf", Doctype.DOCUMENT);
-        doctypeMap.put ("application/rtf", Doctype.DOCUMENT);
-        doctypeMap.put ("application/msword", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.ms-excel", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.ms-powerpoint", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.ms-works", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.openxmlformats-officedocument.wordprocessingml.document", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.openxmlformats-officedocument.wordprocessingml.template", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.openxmlformats-officedocument.spreadsheetml.template", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.openxmlformats-officedocument.presentationml.presentation", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.ms-word.document.macroEnabled.12", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.ms-powerpoint.presentation.macroEnabled.12", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.ms-powerpoint.template.macroEnabled.12", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.ms-powerpoint.slideshow.macroEnabled.12", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.oasis.opendocument.chart", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.oasis.opendocument.database", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.oasis.opendocument.formula", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.oasis.opendocument.presentation", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.oasis.opendocument.text", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.oasis.opendocument.spreadsheet", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.sun.xml.math", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.sun.xml.writer", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.stardivision.chart", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.stardivision.impress", Doctype.DOCUMENT);
-        doctypeMap.put ("application/vnd.stardivision.writer", Doctype.DOCUMENT);
-        doctypeMap.put ("application/wordperfect", Doctype.DOCUMENT);
-        doctypeMap.put ("application/x-troff", Doctype.DOCUMENT);
+        doctypeMap.put("application/epub+zip", Doctype.DOCUMENT);
+        doctypeMap.put("application/pdf", Doctype.DOCUMENT);
+        doctypeMap.put("application/rtf", Doctype.DOCUMENT);
+        doctypeMap.put("application/msword", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.ms-excel", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.ms-powerpoint", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.ms-works", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.openxmlformats-officedocument.wordprocessingml.document", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.openxmlformats-officedocument.wordprocessingml.template", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.openxmlformats-officedocument.spreadsheetml.template", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.openxmlformats-officedocument.presentationml.presentation", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.ms-word.document.macroEnabled.12", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.ms-powerpoint.presentation.macroEnabled.12", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.ms-powerpoint.template.macroEnabled.12", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.ms-powerpoint.slideshow.macroEnabled.12", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.oasis.opendocument.chart", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.oasis.opendocument.database", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.oasis.opendocument.formula", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.oasis.opendocument.presentation", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.oasis.opendocument.text", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.oasis.opendocument.spreadsheet", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.sun.xml.math", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.sun.xml.writer", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.stardivision.chart", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.stardivision.impress", Doctype.DOCUMENT);
+        doctypeMap.put("application/vnd.stardivision.writer", Doctype.DOCUMENT);
+        doctypeMap.put("application/wordperfect", Doctype.DOCUMENT);
+        doctypeMap.put("application/x-troff", Doctype.DOCUMENT);
 
-        doctypeMap.put ("application/postscript", Doctype.IMAGE);
-        doctypeMap.put ("image/bmp", Doctype.IMAGE);
-        doctypeMap.put ("image/vnd.adobe.photoshop", Doctype.IMAGE);
-        doctypeMap.put ("application/vnd.oasis.opendocument.graphics", Doctype.IMAGE);
-        doctypeMap.put ("application/vnd.oasis.opendocument.image", Doctype.IMAGE);
-        doctypeMap.put ("image/gif", Doctype.IMAGE);
-        doctypeMap.put ("image/jp2", Doctype.IMAGE);
-        doctypeMap.put ("image/jpx", Doctype.IMAGE);
-        doctypeMap.put ("image/jpm", Doctype.IMAGE);
-        doctypeMap.put ("image/jpeg", Doctype.IMAGE);
-        doctypeMap.put ("image/png", Doctype.IMAGE);
-        doctypeMap.put ("image/tiff", Doctype.IMAGE);
-        doctypeMap.put ("image/x-icon", Doctype.IMAGE);
+        doctypeMap.put("application/postscript", Doctype.IMAGE);
+        doctypeMap.put("image/bmp", Doctype.IMAGE);
+        doctypeMap.put("image/vnd.adobe.photoshop", Doctype.IMAGE);
+        doctypeMap.put("application/vnd.oasis.opendocument.graphics", Doctype.IMAGE);
+        doctypeMap.put("application/vnd.oasis.opendocument.image", Doctype.IMAGE);
+        doctypeMap.put("image/gif", Doctype.IMAGE);
+        doctypeMap.put("image/jp2", Doctype.IMAGE);
+        doctypeMap.put("image/jpx", Doctype.IMAGE);
+        doctypeMap.put("image/jpm", Doctype.IMAGE);
+        doctypeMap.put("image/jpeg", Doctype.IMAGE);
+        doctypeMap.put("image/png", Doctype.IMAGE);
+        doctypeMap.put("image/tiff", Doctype.IMAGE);
+        doctypeMap.put("image/x-icon", Doctype.IMAGE);
 
-        doctypeMap.put ("text/css", Doctype.TEXT);
-        doctypeMap.put ("text/html", Doctype.TEXT);
-        doctypeMap.put ("text/plain", Doctype.TEXT);
-        doctypeMap.put ("text/xml", Doctype.TEXT);
+        doctypeMap.put("text/css", Doctype.TEXT);
+        doctypeMap.put("text/html", Doctype.TEXT);
+        doctypeMap.put("text/plain", Doctype.TEXT);
+        doctypeMap.put("text/xml", Doctype.TEXT);
 
-        doctypeMap.put ("application/mp4", Doctype.VIDEO);
-        doctypeMap.put ("video/mp4", Doctype.VIDEO);
-        doctypeMap.put ("video/avi", Doctype.VIDEO);
-        doctypeMap.put ("video/x-dvi", Doctype.VIDEO);
-        doctypeMap.put ("video/x-matroska", Doctype.VIDEO);
-        doctypeMap.put ("video/video/ogg", Doctype.VIDEO);
-        doctypeMap.put ("video/mj2", Doctype.VIDEO);
-        doctypeMap.put ("video/mpeg", Doctype.VIDEO);
-        doctypeMap.put ("video/quicktime", Doctype.VIDEO);
-        doctypeMap.put ("video/x-m4v", Doctype.VIDEO);
-        doctypeMap.put ("video/x-ms-asf", Doctype.VIDEO);
-        doctypeMap.put ("video/x-msvideo", Doctype.VIDEO);
-
+        doctypeMap.put("application/mp4", Doctype.VIDEO);
+        doctypeMap.put("video/mp4", Doctype.VIDEO);
+        doctypeMap.put("video/avi", Doctype.VIDEO);
+        doctypeMap.put("video/x-dvi", Doctype.VIDEO);
+        doctypeMap.put("video/x-matroska", Doctype.VIDEO);
+        doctypeMap.put("video/video/ogg", Doctype.VIDEO);
+        doctypeMap.put("video/mj2", Doctype.VIDEO);
+        doctypeMap.put("video/mpeg", Doctype.VIDEO);
+        doctypeMap.put("video/quicktime", Doctype.VIDEO);
+        doctypeMap.put("video/x-m4v", Doctype.VIDEO);
+        doctypeMap.put("video/x-ms-asf", Doctype.VIDEO);
+        doctypeMap.put("video/x-msvideo", Doctype.VIDEO);
     }
 
     /* Select a document type based on the MIME type.  */
-    public static Doctype mimeToDoctype (String mime) {
+    public static Doctype mimeToDoctype(String mime) {
         // trim down to base type
-        int semi = mime.indexOf (";");
+        int semi = mime.indexOf(";");
         if (semi >= 0) {
-            mime = mime.substring (0, semi);
+            mime = mime.substring(0, semi);
         }
         Doctype dt = doctypeMap.get(mime);
         if (dt == null) {
             return Doctype.UNKNOWN;
-        }
-        else return dt;
+        } else return dt;
     }
-
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/EbuCoreFrameRateRatio.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/EbuCoreFrameRateRatio.java
@@ -34,48 +34,46 @@ package edu.harvard.hul.ois.fits;
  */
 public class EbuCoreFrameRateRatio {
 
-	private String numerator = "1";
-	private String denominator = "1";
-	private String value;
-	private final static String DECIMAL = ".";
-	private final static String SPACE = " ";
+    private String numerator = "1";
+    private String denominator = "1";
+    private String value;
+    private static final String DECIMAL = ".";
+    private static final String SPACE = " ";
 
-	public EbuCoreFrameRateRatio(String value) {
+    public EbuCoreFrameRateRatio(String value) {
 
-		// the string might have fps, or a identifier at the end, so we need to
-		// remove it
-		String[] parts = value.split(SPACE);
-		this.value = parts[0];
+        // the string might have fps, or a identifier at the end, so we need to
+        // remove it
+        String[] parts = value.split(SPACE);
+        this.value = parts[0];
 
-		// If a decimal value, revise members
-    	if(value.contains(DECIMAL)) {
-        	this.numerator = "1000";
-        	this.denominator = "1001";
+        // If a decimal value, revise members
+        if (value.contains(DECIMAL)) {
+            this.numerator = "1000";
+            this.denominator = "1001";
 
-        	// Round FrameRate to whole number
+            // Round FrameRate to whole number
             Double dblValue = null;
             try {
-                dblValue = Double.parseDouble (this.value);
+                dblValue = Double.parseDouble(this.value);
+            } catch (NumberFormatException e) {
             }
-            catch (NumberFormatException e) {}
 
             int a = (int) Math.round(dblValue);
 
-        	this.value = ""+a;
-    	}
+            this.value = "" + a;
+        }
+    }
 
-	}
+    public String getValue() {
+        return value;
+    }
 
-	public String getValue() {
-		return value;
-	}
+    public String getNumerator() {
+        return numerator;
+    }
 
-	public String getNumerator() {
-		return numerator;
-	}
-
-	public String getDenominator() {
-		return denominator;
-	}
-
+    public String getDenominator() {
+        return denominator;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/EbuCoreModel.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/EbuCoreModel.java
@@ -10,12 +10,6 @@
 
 package edu.harvard.hul.ois.fits;
 
-import java.util.List;
-
-import org.apache.commons.lang.StringUtils;
-import org.jdom2.Element;
-import org.jdom2.Namespace;
-
 import edu.harvard.hul.ois.fits.tools.mediainfo.ChannelPositionParser;
 import edu.harvard.hul.ois.fits.tools.mediainfo.ChannelPositionWrapper;
 import edu.harvard.hul.ois.ots.schemas.Ebucore.AspectRatio;
@@ -33,9 +27,9 @@ import edu.harvard.hul.ois.ots.schemas.Ebucore.ContainerFormat;
 import edu.harvard.hul.ois.ots.schemas.Ebucore.CoreMetadata;
 import edu.harvard.hul.ois.ots.schemas.Ebucore.DateTime;
 import edu.harvard.hul.ois.ots.schemas.Ebucore.Duration;
+import edu.harvard.hul.ois.ots.schemas.Ebucore.EbuCoreMain;
 import edu.harvard.hul.ois.ots.schemas.Ebucore.EditUnitNumber;
 import edu.harvard.hul.ois.ots.schemas.Ebucore.Format;
-import edu.harvard.hul.ois.ots.schemas.Ebucore.EbuCoreMain;
 import edu.harvard.hul.ois.ots.schemas.Ebucore.FrameRate;
 import edu.harvard.hul.ois.ots.schemas.Ebucore.HeightIdentifier;
 import edu.harvard.hul.ois.ots.schemas.Ebucore.MimeType;
@@ -48,10 +42,14 @@ import edu.harvard.hul.ois.ots.schemas.Ebucore.VideoFormat;
 import edu.harvard.hul.ois.ots.schemas.Ebucore.VideoTrack;
 import edu.harvard.hul.ois.ots.schemas.Ebucore.WidthIdentifier;
 import edu.harvard.hul.ois.ots.schemas.XmlContent.XmlContentException;
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
 
 public class EbuCoreModel {
 
-	private final static String UTC_TEXT = "UTC ";
+    private static final String UTC_TEXT = "UTC ";
 
     protected EbuCoreMain ebucoreMain;
     protected Format format;
@@ -60,20 +58,20 @@ public class EbuCoreModel {
     protected ContainerFormat containerFormat;
     protected Duration duration;
 
-    protected EbuCoreModel () throws XmlContentException {
+    protected EbuCoreModel() throws XmlContentException {
 
-    	//set up base ebucore main object structure
-    	ebucoreMain = new EbuCoreMain ();
+        // set up base ebucore main object structure
+        ebucoreMain = new EbuCoreMain();
 
         containerFormat = new ContainerFormat();
         duration = new Duration();
 
-		format = new Format("format");
-		format.setContainerFormat(containerFormat);
-		format.setDuration(duration);
+        format = new Format("format");
+        format.setContainerFormat(containerFormat);
+        format.setDuration(duration);
 
-		audioFmtExt = new AudioFormatExtended();
-		format.setAudioFormatExtended(audioFmtExt);
+        audioFmtExt = new AudioFormatExtended();
+        format.setAudioFormatExtended(audioFmtExt);
 
         CoreMetadata cm = new CoreMetadata();
         cm.setFormat(format);
@@ -81,458 +79,425 @@ public class EbuCoreModel {
         ebucoreMain.setCoreMetadata(cm);
     }
 
-    protected void createVideoFormatElement(Element elem, Namespace ns, String mimeType)
-    		throws XmlContentException {
+    protected void createVideoFormatElement(Element elem, Namespace ns, String mimeType) throws XmlContentException {
 
-    	VideoFormat vfmt = new VideoFormat("videoFormat");
+        VideoFormat vfmt = new VideoFormat("videoFormat");
 
-    	String id = elem.getAttribute("id").getValue();
-    	VideoTrack vt = new VideoTrack();
-    	vt.setTrackId(id);
-    	vfmt.setVideoTrack(vt);
+        String id = elem.getAttribute("id").getValue();
+        VideoTrack vt = new VideoTrack();
+        vt.setTrackId(id);
+        vfmt.setVideoTrack(vt);
 
-    	for (VideoFormatElements videoElem : VideoFormatElements.values()) {
+        for (VideoFormatElements videoElem : VideoFormatElements.values()) {
 
-    		// NOTE: use the .name(), not .getName(), so we can use the correct
-    		// value to set the typeLabel
-    		String fitsName = videoElem.name();
-    		Element dataElement = elem.getChild (fitsName,ns);
-    		if (dataElement == null)
-    			continue;
-    		String dataValue = dataElement.getText().trim();
-    		if (StringUtils.isEmpty(dataValue))
-    			continue;
-    		switch (videoElem) {
+            // NOTE: use the .name(), not .getName(), so we can use the correct
+            // value to set the typeLabel
+            String fitsName = videoElem.name();
+            Element dataElement = elem.getChild(fitsName, ns);
+            if (dataElement == null) continue;
+            String dataValue = dataElement.getText().trim();
+            if (StringUtils.isEmpty(dataValue)) continue;
+            switch (videoElem) {
+                case width:
+                    dataValue = dataElement.getText().replace(" pixels", "");
+                    WidthIdentifier width = new WidthIdentifier(dataValue, videoElem.getName());
+                    width.setUnit("pixel");
+                    vfmt.setWidthIdentifier(width);
+                    break;
+                case height:
+                    dataValue = dataElement.getText().replace(" pixels", "");
+                    HeightIdentifier height = new HeightIdentifier(dataValue, videoElem.getName());
+                    height.setUnit("pixel");
+                    vfmt.setHeightIdentifier(height);
+                    break;
+                case frameRate:
+                    EbuCoreFrameRateRatio frRatio = new EbuCoreFrameRateRatio(dataValue);
 
-    		case width:
-    			dataValue =
-    					dataElement.getText().replace(" pixels", "");
-    			WidthIdentifier width = new WidthIdentifier(
-    					dataValue,
-    					videoElem.getName());
-    			width.setUnit("pixel");
-    			vfmt.setWidthIdentifier(width);
-    			break;
-    		case height:
-        		dataValue =
-        				dataElement.getText().replace(" pixels", "");
-        		HeightIdentifier height = new HeightIdentifier(
-        				dataValue,
-        				videoElem.getName());
-        		height.setUnit("pixel");
-        		vfmt.setHeightIdentifier(height);
-    			break;
-    		case frameRate:
-        		EbuCoreFrameRateRatio frRatio =
-					new EbuCoreFrameRateRatio(dataValue);
+                    FrameRate frameRate = new FrameRate(frRatio.getValue(), videoElem.getName());
+                    frameRate.setFactorNumerator(frRatio.getNumerator());
+                    frameRate.setFactorDenominator(frRatio.getDenominator());
+                    vfmt.setFrameRate(frameRate);
+                    break;
+                case bitRate:
+                    // workaround for handling multiple bitrate values that are sometimes returned by mediainfo
+                    String[] bitRateParts = dataValue.split(" ");
+                    dataValue = bitRateParts[0];
+                    vfmt.setBitRate(Integer.parseInt(dataValue));
+                    break;
+                case bitRateMax:
+                    vfmt.setBitRateMax(Integer.parseInt(dataValue));
+                    break;
+                case bitRateMode:
+                    vfmt.setBitRateMode(dataValue.toLowerCase());
+                    break;
+                case scanningFormat:
+                    if (dataValue.equals("MBAFF")) vfmt.setScanningFormat("interlaced");
+                    else vfmt.setScanningFormat(dataValue.toLowerCase());
+                    break;
+                case videoDataEncoding:
+                    VideoEncoding ve = new VideoEncoding();
+                    ve.setTypeLabel(dataValue);
+                    vfmt.setVideoEncoding(ve);
+                    break;
+                case aspectRatio:
+                    EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(dataValue);
+                    AspectRatio ar = new AspectRatio(videoElem.getName());
+                    ar.setFactorNumerator(ratio.getNormalizedNumerator());
+                    ar.setFactorDenominator(ratio.getNormalizedDenominator());
+                    ar.setTypeLabel("display");
+                    vfmt.setAspectRatio(ar);
+                    break;
 
-        		FrameRate frameRate = new FrameRate(frRatio.getValue(),
-        				videoElem.getName());
-        		frameRate.setFactorNumerator(frRatio.getNumerator());
-        		frameRate.setFactorDenominator(frRatio.getDenominator());
-        		vfmt.setFrameRate(frameRate);
-    			break;
-      		case bitRate:
-        	 	// workaround for handling multiple bitrate values that are sometimes returned by mediainfo
-      			String[] bitRateParts = dataValue.split(" ");
-        		dataValue = bitRateParts[0];
-        		vfmt.setBitRate(Integer.parseInt(dataValue));
-        		break;
-    		case bitRateMax:
-    			vfmt.setBitRateMax(Integer.parseInt(dataValue));
-    			break;
-    		case bitRateMode:
-    			vfmt.setBitRateMode(dataValue.toLowerCase());
-    			break;
-    		case scanningFormat:
-    			if(dataValue.equals("MBAFF"))
-    				vfmt.setScanningFormat("interlaced");
-    			else
-    				vfmt.setScanningFormat(dataValue.toLowerCase());
-    			break;
-    		case videoDataEncoding:
-        		VideoEncoding ve = new VideoEncoding();
-        		ve.setTypeLabel(dataValue);
-        		vfmt.setVideoEncoding(ve);
-        		break;
-    		case aspectRatio:
-    			EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(dataValue);
-    			AspectRatio ar = new AspectRatio(videoElem.getName());
-    			ar.setFactorNumerator(ratio.getNormalizedNumerator());
-    			ar.setFactorDenominator(ratio.getNormalizedDenominator());
-    			ar.setTypeLabel("display");
-    			vfmt.setAspectRatio(ar);
-    			break;
+                    // Technical Attribute Strings
+                case colorspace:
+                case broadcastStandard:
+                    TechnicalAttributeString tas = new TechnicalAttributeString(dataValue);
+                    tas.setTypeLabel(videoElem.getName());
+                    vfmt.addTechnicalAttributeString(tas);
+                    break;
 
-    		// Technical Attribute Strings
-    		case colorspace:
-    		case broadcastStandard:
-        		TechnicalAttributeString tas =
-    				new TechnicalAttributeString(dataValue);
-        		tas.setTypeLabel(videoElem.getName());
-        		vfmt.addTechnicalAttributeString(tas);
-        		break;
+                case chromaSubsampling:
+                case frameRateMode:
+                case byteOrder:
+                case delay:
+                case compression:
+                    TechnicalAttributeString tasLc = new TechnicalAttributeString(dataValue.toLowerCase());
+                    tasLc.setTypeLabel(videoElem.getName());
+                    vfmt.addTechnicalAttributeString(tasLc);
+                    break;
 
-    		case chromaSubsampling:
-    		case frameRateMode:
-    		case byteOrder:
-    		case delay:
-    		case compression:
-        		TechnicalAttributeString tasLc =
-    				new TechnicalAttributeString(dataValue.toLowerCase());
-        		tasLc.setTypeLabel(videoElem.getName());
-        		vfmt.addTechnicalAttributeString(tasLc);
-    			break;
+                    // Technical Attribute Longs
+                case trackSize:
+                case frameCount:
+                case bitDepth:
+                case duration:
+                    // For bitDepth, the string might have "bits" at the tail, so
+                    // we need to remove it
+                    if (videoElem.getName().equals("bitDepth")) {
+                        String[] parts = dataValue.split(" ");
+                        dataValue = parts[0];
+                    }
+                    TechnicalAttributeLong tal = new TechnicalAttributeLong(Long.parseLong(dataValue));
+                    tal.setTypeLabel(videoElem.getName());
+                    vfmt.addTechnicalAttributeLong(tal);
+                    break;
 
-        	// Technical Attribute Longs
-    		case trackSize:
-    		case frameCount:
-    		case bitDepth:
-    		case duration:
-	    		// For bitDepth, the string might have "bits" at the tail, so
-	    		// we need to remove it
-    			if (videoElem.getName().equals("bitDepth")) {
-    	    		String[] parts = dataValue.
-    	    				split(" ");
-    	    		dataValue = parts[0];
-    			}
-        		TechnicalAttributeLong tal =
-        				new TechnicalAttributeLong(Long.
-						parseLong(dataValue));
-        		tal.setTypeLabel(videoElem.getName());
-        		vfmt.addTechnicalAttributeLong(tal);
-    			break;
+                default:
+                    break;
+            }
+        }
 
-    		default:
-    			break;
-    		}
-    	}
+        // Codec element
+        String codecIdentifierValue = null;
+        Element dataElement = elem.getChild("codecCC", ns);
+        if (dataElement != null) {
+            codecIdentifierValue = dataElement.getText().trim();
+        }
+        //
+        // Sometimes the codeId will not be returned by MediaInfo.
+        // If MXF file, we need to get the codec identifier value from codecId
+        //
+        else if (mimeType != null && mimeType.equals("application/mxf")) { // no codecCC and mxf
+            dataElement = elem.getChild("codecId", ns);
+            if (dataElement != null) {
+                codecIdentifierValue = dataElement.getText().trim();
+            }
+        }
 
-    	// Codec element
-    	String codecIdentifierValue = null;
-   		Element dataElement = elem.getChild ("codecCC",ns);
-   		if(dataElement != null) {
-   			codecIdentifierValue = dataElement.getText().trim();
-   		}
-   		//
-   		// Sometimes the codeId will not be returned by MediaInfo.
-   		// If MXF file, we need to get the codec identifier value from codecId
-   		//
-   		else if(mimeType != null && mimeType.equals("application/mxf")) {	// no codecCC and mxf
-   	   	   	dataElement = elem.getChild ("codecId",ns);
-   	   	   	if(dataElement != null) {
-   	   	   		codecIdentifierValue = dataElement.getText().trim();
-   	   	   	}
-   		}
+        if (codecIdentifierValue != null) {
+            CodecIdentifier ci = new CodecIdentifier("codecIdentifier");
+            ci.setIdentifier(codecIdentifierValue);
 
-        if(codecIdentifierValue != null) {
-        	CodecIdentifier ci = new CodecIdentifier("codecIdentifier");
-        	ci.setIdentifier(codecIdentifierValue);
+            Codec codec = new Codec("codec");
+            codec.setCodecIdentifier(ci);
 
-        	Codec codec = new Codec("codec");
-           	codec.setCodecIdentifier(ci);
-
-           	//Element codecElement = elem.getChild ("codecInfo",ns);
-        	//if(codecElement != null) {
-        	//	dataValue = codecElement.getText().trim();
-        	//	codec.setNameField(dataValue);
-        	//}
-        	Element codecElement = elem.getChild ("codecName",ns);
-        	if(codecElement != null) {
-        		String dataValue = codecElement.getText().trim();
-        		codec.setNameField(dataValue);
-        	}
-        	codecElement = elem.getChild ("codecVersion",ns);
-        	if(codecElement != null) {
-        		String dataValue = codecElement.getText().trim();
-        		codec.setVersion(dataValue);
-        	}
-        	codecElement = elem.getChild ("codecFamily",ns);
-        	if(codecElement != null) {
-        		String dataValue = codecElement.getText().trim();
-        		codec.setFamily(dataValue);
-        	}
-        	vfmt.setCodec(codec);
+            // Element codecElement = elem.getChild ("codecInfo",ns);
+            // if(codecElement != null) {
+            //	dataValue = codecElement.getText().trim();
+            //	codec.setNameField(dataValue);
+            // }
+            Element codecElement = elem.getChild("codecName", ns);
+            if (codecElement != null) {
+                String dataValue = codecElement.getText().trim();
+                codec.setNameField(dataValue);
+            }
+            codecElement = elem.getChild("codecVersion", ns);
+            if (codecElement != null) {
+                String dataValue = codecElement.getText().trim();
+                codec.setVersion(dataValue);
+            }
+            codecElement = elem.getChild("codecFamily", ns);
+            if (codecElement != null) {
+                String dataValue = codecElement.getText().trim();
+                codec.setFamily(dataValue);
+            }
+            vfmt.setCodec(codec);
         }
 
         // Add the audio format object to the list
         this.format.addVideoFormat(vfmt);
     }
 
-    protected void createAudioFormatElement(Element elem, Namespace ns)
-    		throws XmlContentException {
+    protected void createAudioFormatElement(Element elem, Namespace ns) throws XmlContentException {
 
-    	AudioFormat afmt = new AudioFormat("audioFormat");
+        AudioFormat afmt = new AudioFormat("audioFormat");
 
-    	Element encodingDataElement = elem.getChild ("audioDataEncoding",ns);
-    	if (encodingDataElement != null) {
-    		String dataValue = encodingDataElement.getText().trim();
-    		AudioEncoding ae = new AudioEncoding();
-    		ae.setTypeLabel(dataValue);
-    		// Type Link NOT in AVPreserve example, so don't expose
-    		// ae.setTypeLink("http://www.ebu.ch/metadata/cs/ebu_AudioCompressionCodeCS.xml#11");
-    		afmt.setAudioEncoding(ae);
+        Element encodingDataElement = elem.getChild("audioDataEncoding", ns);
+        if (encodingDataElement != null) {
+            String dataValue = encodingDataElement.getText().trim();
+            AudioEncoding ae = new AudioEncoding();
+            ae.setTypeLabel(dataValue);
+            // Type Link NOT in AVPreserve example, so don't expose
+            // ae.setTypeLink("http://www.ebu.ch/metadata/cs/ebu_AudioCompressionCodeCS.xml#11");
+            afmt.setAudioEncoding(ae);
 
-    		//afmt.setAudioFormatName(dataValue);
-    	}
-
-    	String id = elem.getAttribute("id").getValue();
-    	AudioTrack at = new AudioTrack();
-    	at.setTrackId(id);
-    	afmt.setAudioTrack(at);
-
-    	for (AudioFormatElements audioElem : AudioFormatElements.values()) {
-
-    		// NOTE: use the .name(), not .getName(), so we can use the correct
-    		// value to set the typeLabel
-    		String fitsName = audioElem.name();
-    		Element dataElement = elem.getChild (fitsName,ns);
-    		if (dataElement == null)
-    			continue;
-    		String dataValue = dataElement.getText().trim();
-    		if (StringUtils.isEmpty(dataValue))
-    			continue;
-
-    		switch (audioElem) {
-
-    		case soundField:
-	    		AudioTrackConfiguration atc = new AudioTrackConfiguration();
-	    		atc.setTypeLabel(dataValue);
-	    		afmt.setAudioTrackConfiguration(atc);
-
-	    		// Convert the text to x/y coordinates
-	    		if(dataValue != null && dataValue.length() != 0) {
-		    		ChannelPositionParser cpp = new ChannelPositionParser();
-		    		List<ChannelPositionWrapper> positions = cpp.getChannelsFromString(dataValue);
-
-		    		for (ChannelPositionWrapper positionWrapper : positions) {
-		    			Position positionX = new Position(positionWrapper.getXpos());
-		    			positionX.setCoordinate("x");
-
-		    			Position positionY = new Position(positionWrapper.getYpos());
-		    			positionY.setCoordinate("y");
-
-		    			AudioBlockFormat abf = new AudioBlockFormat();
-		    			abf.addPosition(positionX);
-		    			abf.addPosition(positionY);
-
-		    			AudioChannelFormat acf = new AudioChannelFormat();
-		    			acf.setAudioBlockFormat(abf);
-
-		    			audioFmtExt.addAudioChannelFormat(acf);
-		    		}
-	    		}
-    			break;
-
-    		case bitRate:
-    	    	afmt.setBitRate(Integer.parseInt(dataValue));
-    	    	break;
-    		case bitRateMode:
-   	    		afmt.setBitRateMode(dataValue.toLowerCase());
-   	    		break;
-    		case samplingRate:
-	    		afmt.setSamplingRate(Integer.parseInt(dataValue));
-	    		break;
-    		case sampleSize:
-	    		afmt.setSampleSize(dataValue);
-	    		break;
-    		case channels:
-  	    		afmt.setChannels(Integer.parseInt(dataValue));
-	    		break;
-
-    		// Technical Attribute Strings
-    		case byteOrder:
-    		case delay:
-    		case compression:
- 	    		TechnicalAttributeString tas =
-				new TechnicalAttributeString(dataValue.toLowerCase());
- 	    		tas.setTypeLabel(audioElem.getEbucoreName());
- 	    		afmt.addTechnicalAttributeString(tas);
- 	    		break;
-
- 	    	// Technical Attribute Longs
-    		case trackSize:
-    		case numSamples:
-    		case duration:
-	    		TechnicalAttributeLong tal =
-					new TechnicalAttributeLong(Long.
-					parseLong(dataValue));
-	    			tal.setTypeLabel(audioElem.getEbucoreName());
-	    		afmt.addTechnicalAttributeLong(tal);
-    			break;
-
-    		default:
-    			break;
-    		}
-    	}
-
-    	// TODO: break this out to enum code
-    	// Codec element
-   		Element dataElement = elem.getChild ("codecId",ns);
-        if(dataElement != null) {
-        	String dataValue = dataElement.getText().trim();
-        	CodecIdentifier ci = new CodecIdentifier("codecIdentifier");
-        	ci.setIdentifier(dataValue);
-
-        	Codec codec = new Codec("codec");
-           	codec.setCodecIdentifier(ci);
-
-           	Element codecElement = elem.getChild ("codecInfo",ns);
-        	if(codecElement != null) {
-        		dataValue = codecElement.getText().trim();
-        		codec.setNameField(dataValue);
-        	}
-        	//codecElement = elem.getChild ("codecFamily",ns);
-        	//if(codecElement != null) {
-        	//	dataValue = codecElement.getText().trim();
-        	//	codec.setFamily(dataValue);
-        	//}
-        	afmt.setCodec(codec);
+            // afmt.setAudioFormatName(dataValue);
         }
-//
-//        //
-//        // Channel Positions
-//        //
-//   		dataElement = elem.getChild ("soundField",ns);
-//        if(dataElement != null) {
-//        	String dataValue = dataElement.getText().trim();
-//
-//        	//if(StringUtilts.)
-//        	if(dataValue != null) {
-//
-//        	}
-//        }
+
+        String id = elem.getAttribute("id").getValue();
+        AudioTrack at = new AudioTrack();
+        at.setTrackId(id);
+        afmt.setAudioTrack(at);
+
+        for (AudioFormatElements audioElem : AudioFormatElements.values()) {
+
+            // NOTE: use the .name(), not .getName(), so we can use the correct
+            // value to set the typeLabel
+            String fitsName = audioElem.name();
+            Element dataElement = elem.getChild(fitsName, ns);
+            if (dataElement == null) continue;
+            String dataValue = dataElement.getText().trim();
+            if (StringUtils.isEmpty(dataValue)) continue;
+
+            switch (audioElem) {
+                case soundField:
+                    AudioTrackConfiguration atc = new AudioTrackConfiguration();
+                    atc.setTypeLabel(dataValue);
+                    afmt.setAudioTrackConfiguration(atc);
+
+                    // Convert the text to x/y coordinates
+                    if (dataValue != null && dataValue.length() != 0) {
+                        ChannelPositionParser cpp = new ChannelPositionParser();
+                        List<ChannelPositionWrapper> positions = cpp.getChannelsFromString(dataValue);
+
+                        for (ChannelPositionWrapper positionWrapper : positions) {
+                            Position positionX = new Position(positionWrapper.getXpos());
+                            positionX.setCoordinate("x");
+
+                            Position positionY = new Position(positionWrapper.getYpos());
+                            positionY.setCoordinate("y");
+
+                            AudioBlockFormat abf = new AudioBlockFormat();
+                            abf.addPosition(positionX);
+                            abf.addPosition(positionY);
+
+                            AudioChannelFormat acf = new AudioChannelFormat();
+                            acf.setAudioBlockFormat(abf);
+
+                            audioFmtExt.addAudioChannelFormat(acf);
+                        }
+                    }
+                    break;
+
+                case bitRate:
+                    afmt.setBitRate(Integer.parseInt(dataValue));
+                    break;
+                case bitRateMode:
+                    afmt.setBitRateMode(dataValue.toLowerCase());
+                    break;
+                case samplingRate:
+                    afmt.setSamplingRate(Integer.parseInt(dataValue));
+                    break;
+                case sampleSize:
+                    afmt.setSampleSize(dataValue);
+                    break;
+                case channels:
+                    afmt.setChannels(Integer.parseInt(dataValue));
+                    break;
+
+                    // Technical Attribute Strings
+                case byteOrder:
+                case delay:
+                case compression:
+                    TechnicalAttributeString tas = new TechnicalAttributeString(dataValue.toLowerCase());
+                    tas.setTypeLabel(audioElem.getEbucoreName());
+                    afmt.addTechnicalAttributeString(tas);
+                    break;
+
+                    // Technical Attribute Longs
+                case trackSize:
+                case numSamples:
+                case duration:
+                    TechnicalAttributeLong tal = new TechnicalAttributeLong(Long.parseLong(dataValue));
+                    tal.setTypeLabel(audioElem.getEbucoreName());
+                    afmt.addTechnicalAttributeLong(tal);
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        // TODO: break this out to enum code
+        // Codec element
+        Element dataElement = elem.getChild("codecId", ns);
+        if (dataElement != null) {
+            String dataValue = dataElement.getText().trim();
+            CodecIdentifier ci = new CodecIdentifier("codecIdentifier");
+            ci.setIdentifier(dataValue);
+
+            Codec codec = new Codec("codec");
+            codec.setCodecIdentifier(ci);
+
+            Element codecElement = elem.getChild("codecInfo", ns);
+            if (codecElement != null) {
+                dataValue = codecElement.getText().trim();
+                codec.setNameField(dataValue);
+            }
+            // codecElement = elem.getChild ("codecFamily",ns);
+            // if(codecElement != null) {
+            //	dataValue = codecElement.getText().trim();
+            //	codec.setFamily(dataValue);
+            // }
+            afmt.setCodec(codec);
+        }
+        //
+        //        //
+        //        // Channel Positions
+        //        //
+        //   		dataElement = elem.getChild ("soundField",ns);
+        //        if(dataElement != null) {
+        //        	String dataValue = dataElement.getText().trim();
+        //
+        //        	//if(StringUtilts.)
+        //        	if(dataValue != null) {
+        //
+        //        	}
+        //        }
 
         // Add the audio format object to the list
         this.format.addAudioFormat(afmt);
     }
 
-    protected void createFormatElement(String fitsName, Element elem)
-    		throws XmlContentException {
+    protected void createFormatElement(String fitsName, Element elem) throws XmlContentException {
 
-    	String dataValue = elem.getText().trim();
-    	if (StringUtils.isEmpty(dataValue)) {
-    		// TODO: Log and throw Error
-    		return;
-    	}
+        String dataValue = elem.getText().trim();
+        if (StringUtils.isEmpty(dataValue)) {
+            // TODO: Log and throw Error
+            return;
+        }
 
-    	FormatElements formatElem = FormatElements.lookup(fitsName);
-    	if (formatElem == null) {
-    		// TODO: Log and throw Error
-    		return;
-    	}
+        FormatElements formatElem = FormatElements.lookup(fitsName);
+        if (formatElem == null) {
+            // TODO: Log and throw Error
+            return;
+        }
 
-    	switch (formatElem) {
-    	// Note: size may be filtered off by the consolidator
-    	case size:
-    		this.format.setFileSize(dataValue);
-    		break;
-    	// Note: filename may be filtered off by the consolidator
-    	case filename:
-    		this.format.setFileName(dataValue);
-    		break;
-    	case mimeType:
-    		MimeType mimeType  = new MimeType();
-    		mimeType.setTypeLabel(dataValue);
-    		this.format.setMimeType(mimeType);
-    		break;
-    	case location:
-    		this.format.setLocator(dataValue);
-    		break;
-    	case bitRate:
-    		TechnicalAttributeString tas =
-    			new TechnicalAttributeString(dataValue);
-    		tas.setTypeLabel("overallBitRate");
-    		this.format.setTechnicalAttributeString(tas);
-    		break;
-    	case dateCreated:
-    	case dateModified:
-    		String parts[] = dataValue.replace(UTC_TEXT, "").split(" ");
-    		DateTime dateTime = new DateTime(formatElem.getEbucoreName());
-    		dateTime.setStartDate(parts[0]);
-    		dateTime.setStartTime(parts[1]+"Z");
-    		this.format.setDateCreated(dateTime);
-    		break;
-    	case formatProfile:
-    	case format:
-    		Comment comment = new Comment(dataValue);
-    		// Add the type label
-    		if (formatElem.name().equals("formatProfile")) {
-    	   		comment.setTypeLabel("formatProfile");
-    		}
-    		else {
-    	   		comment.setTypeLabel("format");
-    		}
-    		this.containerFormat.addComment(comment);
-    		break;
-    	case duration:
-    		//Integer intValue = new Integer(dataValue);
-    		// Sometimes MediaInfo returns a value with a decimal place
-    		double d = Double.parseDouble(dataValue);
-    		int intValue = (int) Math.round(d);
-    		EditUnitNumber eun = new EditUnitNumber(intValue, "editUnitNumber");
-    		eun.setEditRate(1000);
-    		eun.setFactorNumerator(1);
-    		eun.setFactorDenominator(1);
-    		this.duration.setDuration(eun);
-    		break;
+        switch (formatElem) {
+                // Note: size may be filtered off by the consolidator
+            case size:
+                this.format.setFileSize(dataValue);
+                break;
+                // Note: filename may be filtered off by the consolidator
+            case filename:
+                this.format.setFileName(dataValue);
+                break;
+            case mimeType:
+                MimeType mimeType = new MimeType();
+                mimeType.setTypeLabel(dataValue);
+                this.format.setMimeType(mimeType);
+                break;
+            case location:
+                this.format.setLocator(dataValue);
+                break;
+            case bitRate:
+                TechnicalAttributeString tas = new TechnicalAttributeString(dataValue);
+                tas.setTypeLabel("overallBitRate");
+                this.format.setTechnicalAttributeString(tas);
+                break;
+            case dateCreated:
+            case dateModified:
+                String parts[] = dataValue.replace(UTC_TEXT, "").split(" ");
+                DateTime dateTime = new DateTime(formatElem.getEbucoreName());
+                dateTime.setStartDate(parts[0]);
+                dateTime.setStartTime(parts[1] + "Z");
+                this.format.setDateCreated(dateTime);
+                break;
+            case formatProfile:
+            case format:
+                Comment comment = new Comment(dataValue);
+                // Add the type label
+                if (formatElem.name().equals("formatProfile")) {
+                    comment.setTypeLabel("formatProfile");
+                } else {
+                    comment.setTypeLabel("format");
+                }
+                this.containerFormat.addComment(comment);
+                break;
+            case duration:
+                // Integer intValue = new Integer(dataValue);
+                // Sometimes MediaInfo returns a value with a decimal place
+                double d = Double.parseDouble(dataValue);
+                int intValue = (int) Math.round(d);
+                EditUnitNumber eun = new EditUnitNumber(intValue, "editUnitNumber");
+                eun.setEditRate(1000);
+                eun.setFactorNumerator(1);
+                eun.setFactorDenominator(1);
+                this.duration.setDuration(eun);
+                break;
 
-    	default:
-    		break;
-    	}
-
+            default:
+                break;
+        }
     }
 
-    protected void createStart(String timecode, String framerate)
-    		throws XmlContentException {
+    protected void createStart(String timecode, String framerate) throws XmlContentException {
 
-    	if(timecode.equals("NOT_SET") || framerate.equals("NOT_SET"))
-    		return;
+        if (timecode.equals("NOT_SET") || framerate.equals("NOT_SET")) return;
 
         int hours = Integer.parseInt(timecode.substring(0, 2));
         int minutes = Integer.parseInt(timecode.substring(3, 5));
         int seconds = Integer.parseInt(timecode.substring(6, 8));
-        int framesFromTc = Integer.parseInt(timecode.substring(9, 11 ));
+        int framesFromTc = Integer.parseInt(timecode.substring(9, 11));
 
         EbuCoreFrameRateRatio ratio = new EbuCoreFrameRateRatio(framerate);
         int fps = Integer.parseInt(ratio.getValue());
 
         // hours
-        int frames = (int)(( double)hours * 3600 * fps);
+        int frames = (int) ((double) hours * 3600 * fps);
 
         // minutes
         frames += (double) minutes * 60 * fps;
 
         // seconds
-        double tmpFrame = (double)seconds * fps;
+        double tmpFrame = (double) seconds * fps;
         // Not necessary, as normalization is already done in the
         // EbuCoreFrameRateRatio class
-        //if (tmpFrame > Math.floor(tmpFrame))
+        // if (tmpFrame > Math.floor(tmpFrame))
         //	tmpFrame = Math.floor(tmpFrame) + 1;
         frames += tmpFrame;
 
         // frames
         frames += framesFromTc;
 
-		EditUnitNumber eun = new EditUnitNumber(frames, "editUnitNumber");
-		eun.setEditRate(fps);
-		eun.setFactorNumerator(Integer.parseInt(ratio.getNumerator()));
-		eun.setFactorDenominator(Integer.parseInt(ratio.getDenominator()));
+        EditUnitNumber eun = new EditUnitNumber(frames, "editUnitNumber");
+        eun.setEditRate(fps);
+        eun.setFactorNumerator(Integer.parseInt(ratio.getNumerator()));
+        eun.setFactorDenominator(Integer.parseInt(ratio.getDenominator()));
 
-		Start start = new Start("start");
-		start.setTimecode(eun);
-		this.format.setStart(start);
-
+        Start start = new Start("start");
+        start.setTimecode(eun);
+        this.format.setStart(start);
     }
 
-//    public static void main(String[] args) throws XmlContentException {
-//
-//    	String timecode = "00:00:01:00";
-//    	String framerate = "29.97";
-//
-//    	EbuCoreModel test = new EbuCoreModel();
-//
-//    	test.createStart(timecode, framerate);
-//    }
+    //    public static void main(String[] args) throws XmlContentException {
+    //
+    //    	String timecode = "00:00:01:00";
+    //    	String framerate = "29.97";
+    //
+    //    	EbuCoreModel test = new EbuCoreModel();
+    //
+    //    	test.createStart(timecode, framerate);
+    //    }
 
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/EbuCoreNormalizedRatio.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/EbuCoreNormalizedRatio.java
@@ -11,7 +11,6 @@
 package edu.harvard.hul.ois.fits;
 
 import java.math.BigDecimal;
-
 import org.apache.commons.lang.math.NumberUtils;
 
 /** This class handles the transformation of the numerator and denominator
@@ -26,116 +25,111 @@ import org.apache.commons.lang.math.NumberUtils;
  */
 public class EbuCoreNormalizedRatio {
 
-	private int normalizedNumerator;
-	private int normalizedDenominator;
-	public final static String DECIMAL = ".";
-	public final static String COLON = ":";
+    private int normalizedNumerator;
+    private int normalizedDenominator;
+    public static final String DECIMAL = ".";
+    public static final String COLON = ":";
 
-	public EbuCoreNormalizedRatio(String ratioStr) {
+    public EbuCoreNormalizedRatio(String ratioStr) {
 
-		// This should not happen
-		if(ratioStr == null || ratioStr.length() < 1)
-	    	return;
+        // This should not happen
+        if (ratioStr == null || ratioStr.length() < 1) return;
 
-		// Handles the conversion of a single decimal value to an x:y ratio, if
-		// necessary
-		ratioStr = convertDecimalToRatio(ratioStr);
+        // Handles the conversion of a single decimal value to an x:y ratio, if
+        // necessary
+        ratioStr = convertDecimalToRatio(ratioStr);
 
-		// If we don't have a proper ratio, just return
-		// TODO: Should we throw an exception here?
-		if(!ratioStr.contains(COLON))
-			return;
+        // If we don't have a proper ratio, just return
+        // TODO: Should we throw an exception here?
+        if (!ratioStr.contains(COLON)) return;
 
-		String[] splitValues = ratioStr.split(EbuCoreNormalizedRatio.COLON);
-		// TODO: throw exception if there are not 2 pieces
-		if (splitValues != null && splitValues.length == 2) {
-			// Normalize the ratio, if necessary
-			normalizeRatio(splitValues[0], splitValues[1]);
-		}
+        String[] splitValues = ratioStr.split(EbuCoreNormalizedRatio.COLON);
+        // TODO: throw exception if there are not 2 pieces
+        if (splitValues != null && splitValues.length == 2) {
+            // Normalize the ratio, if necessary
+            normalizeRatio(splitValues[0], splitValues[1]);
+        }
+    }
 
-	}
+    private void normalizeRatio(String numerator, String denominator) {
 
-	private void normalizeRatio(String numerator, String denominator) {
+        // Verify that the strings passed in are both numbers
+        if (!NumberUtils.isNumber(numerator) || !NumberUtils.isNumber(denominator)) {
+            return;
+        }
 
-		// Verify that the strings passed in are both numbers
-		if(!NumberUtils.isNumber(numerator) || !NumberUtils.isNumber(denominator)) {
-			return;
-		}
+        // We only need to normalize the values if one contains a decimal
+        if (numerator.contains(DECIMAL) || denominator.contains(DECIMAL)) {
+            BigDecimal numBD = new BigDecimal(numerator);
+            BigDecimal denomBD = new BigDecimal(denominator);
 
-		// We only need to normalize the values if one contains a decimal
-		if(numerator.contains(DECIMAL) || denominator.contains(DECIMAL)) {
-			BigDecimal numBD = new BigDecimal(numerator);
-			BigDecimal denomBD = new BigDecimal(denominator);
+            double multiplier = getMultiplierForRatio(numBD, denomBD);
+            this.normalizedNumerator =
+                    numBD.multiply(new BigDecimal(multiplier)).intValue();
+            this.normalizedDenominator =
+                    denomBD.multiply(new BigDecimal(multiplier)).intValue();
 
-			double multiplier = getMultiplierForRatio(numBD, denomBD);
-			this.normalizedNumerator = numBD.multiply(new BigDecimal(multiplier)).intValue();
-			this.normalizedDenominator = denomBD.multiply(new BigDecimal(multiplier)).intValue();
+        }
+        // Must be an integer
+        else {
+            // set the denormalized value
+            this.normalizedNumerator = Integer.parseInt(numerator);
+            this.normalizedDenominator = Integer.parseInt(denominator);
+        }
+    }
 
-		}
-		// Must be an integer
-		else {
-			// set the denormalized value
-			this.normalizedNumerator = Integer.parseInt(numerator);
-			this.normalizedDenominator = Integer.parseInt(denominator);
-		}
+    /**
+     * If the AspectRatio is a single decimal value, such as "1.067" this will
+     * convert it to an x:y ratio. Otherwise it will return the original ratioStr
+     *
+     * @param ratioStr The decimal representation of the aspect ratio to convert
+     * @return
+     */
+    private String convertDecimalToRatio(String ratioStr) {
 
+        // If this isn't a decimal value such as 1.067, we don't need to convert it
+        if (!NumberUtils.isNumber(ratioStr) || !ratioStr.contains(DECIMAL)) {
+            return ratioStr;
+        }
+        // Convert the value to an x:y representation by revising it to ratioStr:1
+        return ratioStr + COLON + "1";
+    }
 
-	}
+    /**
+     * Return the value required to normalize a ratio. For example, if the
+     * numerator is 2.22 and the denominator is 1, the multiplier will be
+     * 100. This is the number used to multiply both the numerator and the
+     * denominator to remove any decimal positions.
+     *
+     * @param numBD The numerator as a BigDecimal
+     * @param denomBD The denominator as a BigDecimal
+     * @return
+     */
+    private double getMultiplierForRatio(BigDecimal numBD, BigDecimal denomBD) {
 
-	/**
-	 * If the AspectRatio is a single decimal value, such as "1.067" this will
-	 * convert it to an x:y ratio. Otherwise it will return the original ratioStr
-	 *
-	 * @param ratioStr The decimal representation of the aspect ratio to convert
-	 * @return
-	 */
-	private String convertDecimalToRatio(String ratioStr) {
+        int numDecimal = getNumberOfDecimalPlaces(numBD);
+        int tmpNumDecimal = getNumberOfDecimalPlaces(denomBD);
+        if (tmpNumDecimal > numDecimal) numDecimal = tmpNumDecimal;
+        return Math.pow(10, numDecimal);
+    }
 
-		// If this isn't a decimal value such as 1.067, we don't need to convert it
-		if (!NumberUtils.isNumber(ratioStr) || !ratioStr.contains(DECIMAL)) {
-			return ratioStr;
-		}
-		// Convert the value to an x:y representation by revising it to ratioStr:1
-		return  ratioStr + COLON + "1";
-	}
+    /**
+     * Returns the number of decimal places in the number.
+     *
+     * @param bigDec
+     * @return
+     */
+    private int getNumberOfDecimalPlaces(BigDecimal bigDec) {
+        String strTrim = bigDec.stripTrailingZeros().toPlainString();
+        int index = strTrim.indexOf(DECIMAL);
+        return index < 0 ? 0 : strTrim.length() - index - 1;
+    }
 
-	/**
-	 * Return the value required to normalize a ratio. For example, if the
-	 * numerator is 2.22 and the denominator is 1, the multiplier will be
-	 * 100. This is the number used to multiply both the numerator and the
-	 * denominator to remove any decimal positions.
-	 *
-	 * @param numBD The numerator as a BigDecimal
-	 * @param denomBD The denominator as a BigDecimal
-	 * @return
-	 */
-	private double getMultiplierForRatio(BigDecimal numBD, BigDecimal denomBD) {
+    public int getNormalizedNumerator() {
+        return normalizedNumerator;
+    }
 
-		int numDecimal = getNumberOfDecimalPlaces(numBD);
-		int tmpNumDecimal = getNumberOfDecimalPlaces(denomBD);
-		if(tmpNumDecimal > numDecimal)
-			numDecimal = tmpNumDecimal;
-		return Math.pow(10, numDecimal);
-	}
-
-	/**
-	 * Returns the number of decimal places in the number.
-	 *
-	 * @param bigDec
-	 * @return
-	 */
-	private int getNumberOfDecimalPlaces(BigDecimal bigDec) {
-		String strTrim = bigDec.stripTrailingZeros().toPlainString();
-		int index = strTrim.indexOf(DECIMAL);
-		return index < 0 ? 0 : strTrim.length() - index - 1;
-	}
-
-	public int getNormalizedNumerator() {
-		return normalizedNumerator;
-	}
-
-	public int getNormalizedDenominator() {
-		return normalizedDenominator;
-	}
-
+    public int getNormalizedDenominator() {
+        return normalizedDenominator;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/Fits.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/Fits.java
@@ -10,6 +10,16 @@
 
 package edu.harvard.hul.ois.fits;
 
+import edu.harvard.hul.ois.fits.consolidation.ToolOutputConsolidator;
+import edu.harvard.hul.ois.fits.exceptions.FitsConfigurationException;
+import edu.harvard.hul.ois.fits.exceptions.FitsException;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import edu.harvard.hul.ois.fits.mapping.FitsXmlMapper;
+import edu.harvard.hul.ois.fits.tools.Tool;
+import edu.harvard.hul.ois.fits.tools.Tool.RunStatus;
+import edu.harvard.hul.ois.fits.tools.ToolBelt;
+import edu.harvard.hul.ois.fits.tools.ToolOutput;
+import edu.harvard.hul.ois.ots.schemas.XmlContent.XmlContent;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -19,13 +29,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Properties;
-
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -36,7 +43,6 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -51,17 +57,6 @@ import org.apache.commons.lang.StringUtils;
 import org.jdom2.Document;
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
-
-import edu.harvard.hul.ois.fits.consolidation.ToolOutputConsolidator;
-import edu.harvard.hul.ois.fits.exceptions.FitsConfigurationException;
-import edu.harvard.hul.ois.fits.exceptions.FitsException;
-import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
-import edu.harvard.hul.ois.fits.mapping.FitsXmlMapper;
-import edu.harvard.hul.ois.fits.tools.Tool;
-import edu.harvard.hul.ois.fits.tools.Tool.RunStatus;
-import edu.harvard.hul.ois.fits.tools.ToolBelt;
-import edu.harvard.hul.ois.fits.tools.ToolOutput;
-import edu.harvard.hul.ois.ots.schemas.XmlContent.XmlContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,651 +65,680 @@ import org.slf4j.LoggerFactory;
  */
 public class Fits {
 
-  public static volatile String FITS_HOME; // during initialization this value will always have a trailing slash.
-  public static String FITS_XML_DIR;
-  public static String FITS_TOOLS_DIR;
-  public static String VERSION = "<unknown>";
-  public static final String XML_NAMESPACE = "http://hul.harvard.edu/ois/xml/ns/fits/fits_output";
-  
-  private static boolean traverseDirs;
-  private static boolean nestDirs; // whether traversing nested directories of input files creates nest output directories - if false, all output goes in same output directory
-  private static XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
-  private static boolean rawToolOutput = false;
+    public static volatile String FITS_HOME; // during initialization this value will always have a trailing slash.
+    public static String FITS_XML_DIR;
+    public static String FITS_TOOLS_DIR;
+    public static String VERSION = "<unknown>";
+    public static final String XML_NAMESPACE = "http://hul.harvard.edu/ois/xml/ns/fits/fits_output";
 
-  private static final String FITS_CONFIG_FILE_NAME = "fits.xml";
-  private static final String VERSION_PROPERTIES_FILE = "version.properties";
-  private static final int DEFAULT_MAX_THREADS = 20;
-  
-  private XMLConfiguration config;
-  private FitsXmlMapper mapper;
-  private boolean enableStatistics;
-  private boolean consolidateFirstIdentity;
-  private String externalOutputSchema;
-  private String internalOutputSchema;
-  private boolean validateToolOutput;
-  private int maxThreads;
-  private ToolOutputConsolidator consolidator;
-  private ToolBelt toolbelt;
-  private boolean resetToolOutput = true; // should always be true except for unit tests
-  
-  private static Logger logger;
+    private static boolean traverseDirs;
+    private static boolean
+            nestDirs; // whether traversing nested directories of input files creates nest output directories - if
+    // false, all output goes in same output directory
+    private static XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
+    private static boolean rawToolOutput = false;
+
+    private static final String FITS_CONFIG_FILE_NAME = "fits.xml";
+    private static final String VERSION_PROPERTIES_FILE = "version.properties";
+    private static final int DEFAULT_MAX_THREADS = 20;
+
+    private XMLConfiguration config;
+    private FitsXmlMapper mapper;
+    private boolean enableStatistics;
+    private boolean consolidateFirstIdentity;
+    private String externalOutputSchema;
+    private String internalOutputSchema;
+    private boolean validateToolOutput;
+    private int maxThreads;
+    private ToolOutputConsolidator consolidator;
+    private ToolBelt toolbelt;
+    private boolean resetToolOutput = true; // should always be true except for unit tests
+
+    private static Logger logger;
 
     static {
         // set FITS_HOME from environment variable if it exists
-        FITS_HOME = System.getenv( "FITS_HOME" );
-        if ( StringUtils.isEmpty(FITS_HOME) ) {
+        FITS_HOME = System.getenv("FITS_HOME");
+        if (StringUtils.isEmpty(FITS_HOME)) {
             // if not set use the current directory
             FITS_HOME = "";
         }
     }
 
-  /**
-   * Default, no-arg constructor. FITS configuration file expected in default location with
-   * FITS_HOME either default location or set by environment variable.
-   *
-   * @throws FitsConfigurationException If there is a problem configuring FITS.
-   */
-  public Fits() throws FitsConfigurationException {
-    this( null );
-  }
-
-  /**
-   * Constructor with path to alternate FITS_HOME.
-   *
-   * @param fits_home Full path to home directory of FITS installation.
-   *        NOTE: If FITS_HOME set as environment variable this argument has no effect.
-   * @throws FitsConfigurationException If there is a problem configuring FITS.
-   */
-  public Fits( String fits_home ) throws FitsConfigurationException {
-	  this( fits_home, null );
-  }
-
-  /**
-   * Constructor with alternate FITS_HOME and alternate FITS configuration file.
-   *
-   * @param fits_home Full path to home directory of FITS installation.
-   *        NOTE: If FITS_HOME set as environment variable this argument has no effect.
-   * @param fitsXmlConfig File containing FITS configuration.
-   * @throws FitsConfigurationException If there is a problem configuring FITS.
-   */
-  public Fits( String fits_home, File fitsXmlConfig ) throws FitsConfigurationException {
-
-	  // NOTE: a "FITS_HOME" environment variable (see initial static block of this class)
-	  // "wins" over a FITS home value passed into the constructor.
-    if ( StringUtils.isEmpty(FITS_HOME) ) {
-      // if env variable not set check for fits_home passed into constructor
-      if (fits_home != null) {
-        FITS_HOME = fits_home;
-      }
+    /**
+     * Default, no-arg constructor. FITS configuration file expected in default location with
+     * FITS_HOME either default location or set by environment variable.
+     *
+     * @throws FitsConfigurationException If there is a problem configuring FITS.
+     */
+    public Fits() throws FitsConfigurationException {
+        this(null);
     }
 
-    setFitsVersionFromFile();
-
-    FITS_XML_DIR = FITS_HOME + "xml" + File.separator;
-    FITS_TOOLS_DIR = FITS_HOME + "tools" + File.separator;
-
-    // Set up logging explicitly so one of the tools aggregated into FITS does not circumvent this.
-    //
-    // First look for a system property (the Log4j preferred way of configuration) at the Log4j expected value, "log4j2.configurationFile".
-    // This value can be either a file path, file protocol (e.g. - file:/path/to/log4j2.xml), or a URL (http://some/server/log4j2.xml).
-    // If this value either is does not, the default file that comes with FITS will be used for initialization.
-    String log4jSystemProp = System.getProperty("log4j2.configurationFile");
-    if (log4jSystemProp == null) {
-        File log4jProperties = new File(FITS_HOME + "log4j2.xml");
-        System.setProperty( "log4j2.configurationFile", log4jProperties.getPath());
-    }
-    logger = LoggerFactory.getLogger(Fits.class);
-    logger.info("Logging initialized with: " + System.getProperty("log4j2.configurationFile"));
-    try {
-      if ( fitsXmlConfig != null ) {
-          config = new XMLConfiguration( fitsXmlConfig );
-      } else {
-          config = new XMLConfiguration( FITS_XML_DIR + FITS_CONFIG_FILE_NAME );
-      }
-    } catch (ConfigurationException e) {
-      logger.error( "Error reading {}{}: {}", FITS_XML_DIR, FITS_CONFIG_FILE_NAME, e.getClass().getName() );
-      throw new FitsConfigurationException( "Error reading " + FITS_XML_DIR + FITS_CONFIG_FILE_NAME, e );
-    }
-    try {
-      mapper = new FitsXmlMapper();
-    } catch (Exception e) {
-      logger.error( "Error creating FITS XML Mapper: {}", e.getClass().getName() );
-      throw new FitsConfigurationException( "Error creating FITS XML Mapper", e );
-    }
-    // required config values
-    try {
-      validateToolOutput = config.getBoolean( "output.validate-tool-output" );
-      externalOutputSchema = config.getString( "output.external-output-schema" );
-      internalOutputSchema = config.getString( "output.internal-output-schema" );
-      enableStatistics = config.getBoolean( "output.enable-statistics" );
-      consolidateFirstIdentity = config.getBoolean("output.consolidate-first-identity", true);
-    } catch (NoSuchElementException e) {
-      logger.error( "Error in configuration file: {}", e.getClass().getName() );
-      System.out.println( "Error inconfiguration file: " + e.getMessage() );
-      return;
+    /**
+     * Constructor with path to alternate FITS_HOME.
+     *
+     * @param fits_home Full path to home directory of FITS installation.
+     *        NOTE: If FITS_HOME set as environment variable this argument has no effect.
+     * @throws FitsConfigurationException If there is a problem configuring FITS.
+     */
+    public Fits(String fits_home) throws FitsConfigurationException {
+        this(fits_home, null);
     }
 
-    // optional config values GDM 16-Nov-2012
-    try {
-      maxThreads = config.getShort( "process.max-threads" );
-    } catch (NoSuchElementException e) {
-        logger.warn("'max-threads' value not set in fit.xml. Setting to default: {}", DEFAULT_MAX_THREADS);
-        maxThreads = DEFAULT_MAX_THREADS;
-    }
-    if (maxThreads < 1) {
-      // If invalid number specified, use a default.
-      logger.warn("Invalid number of threads specified: {} -- Resetting to default: {}", maxThreads, DEFAULT_MAX_THREADS);
-      maxThreads = DEFAULT_MAX_THREADS;
-    }
-    logger.debug( "Maximum threads = " + maxThreads );
+    /**
+     * Constructor with alternate FITS_HOME and alternate FITS configuration file.
+     *
+     * @param fits_home Full path to home directory of FITS installation.
+     *        NOTE: If FITS_HOME set as environment variable this argument has no effect.
+     * @param fitsXmlConfig File containing FITS configuration.
+     * @throws FitsConfigurationException If there is a problem configuring FITS.
+     */
+    public Fits(String fits_home, File fitsXmlConfig) throws FitsConfigurationException {
 
-    String consolidatorClassFullyQualifiedName = config.getString( "output.dataConsolidator[@class]" );
-    try {
-		// Instantiate the Consolidator class using Reflection by passing Fits into the constructor.
-		Class<?> c = Class.forName(consolidatorClassFullyQualifiedName);
-		Constructor<?> ctor = c.getConstructor(Fits.class);
-		consolidator = (ToolOutputConsolidator)ctor.newInstance(this);
-    } catch (Exception e) {
-      throw new FitsConfigurationException( "Error initializing " + consolidatorClassFullyQualifiedName, e );
-    }
-
-    toolbelt = new ToolBelt( config, this );
-
-  }
-
-  public static void main( String[] args ) throws FitsException, IOException, ParseException, XMLStreamException {
-
-    setFitsVersionFromFile();
-
-    Options options = new Options();
-    options.addOption( "i", true, "input file or directory (required)" );
-    options.addOption( "r", false, "process directories recursively when -i is a directory " );
-    options.addOption( "n", false, "output directories are nested when recursively processing nested directories (when -r is set and -i is a directory) (optional)" );
-    options.addOption( "o", true, "Directs the FITS output to a file or directory (if -i is a directory) rather than console" );
-    options.addOption( "h", false, "print this message" );
-    options.addOption( "v", false, "print version information" );
-    options.addOption( "f", true, "alternate fits.xml configuration file location (optional)" );
-    options.addOption( "t", false, "include all raw tool output" );
-    OptionGroup outputOptions = new OptionGroup();
-    Option stdxml = new Option( "x", false, "convert FITS output to a standard metadata schema -- note: only standard schema metadata is output" );
-    Option combinedStd = new Option( "xc", false, "output using a standard metadata schema and include FITS xml" );
-    outputOptions.addOption( stdxml );
-    outputOptions.addOption( combinedStd );
-    options.addOptionGroup( outputOptions );
-
-    CommandLineParser parser = new DefaultParser();
-    CommandLine cmd = null;
-    try {
-    	cmd = parser.parse( options, args );
-    } catch (Exception e) {
-    	System.err.println(e.getMessage());
-    	System.exit( 1 );
-    }
-
-    if (cmd.hasOption( "h" )) {
-      printHelp( options );
-      System.exit( 0 );
-    }
-    if (cmd.hasOption( "v" )) {
-      System.out.println( Fits.VERSION );
-      System.exit( 0 );
-    }
-    if (cmd.hasOption( "r" )) {
-      traverseDirs = true;
-    } else {
-      traverseDirs = false;
-    }
-    if (cmd.hasOption( "n" ) ) {
-      nestDirs = true;
-    } else {
-      nestDirs = false;
-    }
-    rawToolOutput = cmd.hasOption( "t" );
-    
-    File fitsConfigFile = null;
-    try {
-    	if (cmd.hasOption( 'f' )) {
-    		String input = cmd.getOptionValue( 'f' );
-    		if (StringUtils.isEmpty(input)) {
-    			throw new FitsException("When using the -f option there must be an associated value." );
-    		}
-    		fitsConfigFile = new File(input);
-    		if ( !fitsConfigFile.isFile() || !fitsConfigFile.canRead() ) {
-    			throw new FitsException("The FITS configuration file: " + input + " cannot be read." );
-    		}
-    	}
-    	
-    	if (cmd.hasOption( "i" )) {
-    		String input = cmd.getOptionValue( "i" );
-    		File inputFile = new File( input );
-    		
-    		if (inputFile.isDirectory()) {
-    			String outputDir = cmd.getOptionValue( "o" );
-    			if (outputDir == null || !(new File( outputDir ).isDirectory())) {
-    				throw new FitsException(
-    						"When FITS is run in directory processing mode the output location must be a directory." );
-    			}
-    			Fits fits = constructFits(fitsConfigFile);
-    			fits.doDirectory( inputFile, new File( outputDir ), cmd.hasOption( "x" ), cmd.hasOption( "xc" ) );
-    		} else { // inputFile is a file so output -o must either be a file or not set at all
-    			String outputFile = cmd.getOptionValue( "o" );
-    			if (outputFile != null && (new File( outputFile ).isDirectory())) {
-    				throw new FitsException(
-    						"When FITS is processing a single file the output location must also be a file." );
-    			}
-    			Fits fits = constructFits(fitsConfigFile);
-    			FitsOutput result = fits.doSingleFile( inputFile );
-    			fits.outputResults( result, cmd.getOptionValue( "o" ), cmd.hasOption( "x" ), cmd.hasOption( "xc" ), false );
-    		}
-    	} else {
-    		System.err.println( "Invalid CLI options: -i <arg> is required." );
-    		printHelp( options );
-    		System.exit( 1 );
-    	}
-    } catch (FitsException fe) {
-    	System.err.println( fe.getMessage() );
-    	System.exit( 1 );
-    }
-
-    System.exit( 0 );
-  }
-  
-  private static Fits constructFits(File fitsConfigFile) throws FitsConfigurationException {
-      Fits fits = null;
-      if (fitsConfigFile != null) {
-      	fits = new Fits(null, fitsConfigFile);
-      } else {
-      	fits = new Fits();
-      }
-      return fits;
-  }
-
-  /*
-   * Called from either main() for stand-alone application usage or constructor
-   * when used by another program, this reads the properties file containing the
-   * current version of FITS.
-   *
-   * Precondition of this method is that the static FITS_HOME has been set via
-   * an environment variable, being passed into a constructor, or is just the current directory.
-   */
-  private static void setFitsVersionFromFile() {
-
-      // If fits home is not an empty string and doesn't end with a file
-      // separator character, add one
-      if (FITS_HOME.length() > 0 && !FITS_HOME.endsWith( File.separator )) {
-          FITS_HOME = FITS_HOME + File.separator;
-      }
-
-      // get version from properties file and set in class
-      String versionPropFileFullPath = "";
-      if ( !StringUtils.isEmpty(FITS_HOME) ) {
-          versionPropFileFullPath = FITS_HOME;
-      }
-
-      File versionFile = new File( versionPropFileFullPath + VERSION_PROPERTIES_FILE );
-      Properties versionProps = new Properties();
-      try {
-          versionProps.load(new FileInputStream(versionFile));
-          String version = versionProps.getProperty("build.version");
-          if (version != null && !version.isEmpty()) {
-              Fits.VERSION = version;
-          }
-      } catch (IOException e) {
-          System.err.println("Problem loading [" + VERSION_PROPERTIES_FILE + "]: " + "Cannot display FITS version information.");
-      }
-  }
-
-  /**
-   * Recursively processes all files in the directory.
-   *
-   * @param intputFile
-   * @param useStandardSchemas
-   * @throws IOException
-   * @throws XMLStreamException
-   * @throws FitsException
-   */
-	private void doDirectory(File inputDir, File outputDir, boolean useStandardSchemas, boolean standardCombinedFormat) throws FitsException, XMLStreamException, IOException {
-		if(inputDir.listFiles() == null) {
-			return;
-		}
-
-		logger.info("Processing directory " + inputDir.getAbsolutePath());
-
-		for (File f : inputDir.listFiles()) {
-
-			if(f == null || !f.exists() || !f.canRead()) {
-				continue;
-			}
-
-			logger.info("processing " + f.getPath());
-
-			if (f.isDirectory() && traverseDirs) {
-				// need to reset original directory after return from recursive call when nesting output
-				File savedDir = outputDir;
-				if (nestDirs) {
-					outputDir = new File(outputDir, f.getName());
-					if ( !outputDir.exists()) {
-						outputDir.mkdir();
-					}
-				}
-				doDirectory(f, outputDir, useStandardSchemas, standardCombinedFormat);
-				outputDir = savedDir;
-			} else if (f.isFile()) {
-				if (".DS_Store".equals(f.getName())) {
-					// Mac hidden directory services file, ignore
-					logger.debug("Skipping .DS_Store");
-					continue;
-				}
-				FitsOutput result = doSingleFile(f);
-				String outputFile = outputDir.getPath() + File.separator + f.getName() + "." + FITS_CONFIG_FILE_NAME;
-				File output = new File(outputFile);
-				if (output.exists()) {
-					int cnt = 1;
-					while (true) {
-						outputFile = outputDir.getPath() + File.separator + f.getName() + "-" + cnt + "." + FITS_CONFIG_FILE_NAME;
-						output = new File(outputFile);
-						if (!output.exists()) {
-							break;
-						}
-						cnt++;
-					}
-				}
-				outputResults(result, outputFile, useStandardSchemas,
-						standardCombinedFormat, true);
-			}
-		}
-	}
-
-  /**
-   * processes a single file and outputs to the provided output location.
-   * Outputs to standard out if outputLocation is null
-   *
-   * @param inputFile
-   * @param outputLocation
-   * @param useStandardSchemas
-   *          - use standard schemas if available for output type
-   * @throws FitsException
-   * @throws XMLStreamException
-   * @throws IOException
-   */
-	private FitsOutput doSingleFile( File inputFile ) throws FitsException, XMLStreamException, IOException {
-
-    logger.debug( "Processing file " + inputFile.getAbsolutePath() );
-    FitsOutput result = this.examine( inputFile );
-    return result;
-  }
-
-  private void outputResults( FitsOutput result, String outputLocation, boolean standardSchema,
-      boolean standardCombinedFormat, boolean dirMode ) throws XMLStreamException, IOException, FitsException {
-    OutputStream out = null;
-    logger.debug( "Outputting results" );
-    try {
-      // figure out the output location
-      if (outputLocation != null) {
-        out = new FileOutputStream( outputLocation );
-      } else if (!dirMode) {
-        out = System.out;
-      } else {
-        throw new FitsException( "The output location must be provided when running FITS in directory mode" );
-      }
-
-      // if -x is set, then convert to standard metadata schema and output to -o
-      if (standardSchema) {
-        outputStandardSchemaXml( result, out );
-      }
-      // if we are using -xc output FITS xml and standard format
-      else if (standardCombinedFormat) {
-        outputStandardCombinedFormat( result, out );
-      }
-      // else output FITS XML to -o
-      else {
-        Document doc = result.getFitsXml();
-        XMLOutputter serializer = new XMLOutputter( Format.getPrettyFormat() );
-        serializer.output( doc, out );
-      }
-
-    } finally {
-      if (out != null) {
-        out.close();
-      }
-    }
-  }
-
-  public static void outputStandardCombinedFormat( FitsOutput result, OutputStream out ) throws XMLStreamException,
-      IOException, FitsException {
-    // add the normal fits xml output
-    result.addStandardCombinedFormat();
-
-    // output the merged JDOM Document
-    XMLOutputter serializer = new XMLOutputter( Format.getPrettyFormat() );
-    serializer.output( result.getFitsXml(), out );
-
-  }
-
-  public static void outputStandardSchemaXml( FitsOutput fitsOutput, OutputStream out ) throws XMLStreamException,
-      IOException, FitsException {
-    XmlContent xml = fitsOutput.getStandardXmlContent();
-	FitsMetadataElement fileNameElement = fitsOutput.getFileInfoElement("filename");
-	String inputFilename = fileNameElement == null ? null : fileNameElement.getValue();
-
-    // create an xml output factory
-    Transformer transformer = null;
-
-    // initialize transformer for pretty print xslt
-    TransformerFactory tFactory = null;
-	String factoryImpl = "net.sf.saxon.TransformerFactoryImpl";
-	try {
-		Class<?> clazz = Class.forName(factoryImpl);
-		tFactory = (TransformerFactory)clazz.getDeclaredConstructor().newInstance();
-	} catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-		throw new FitsToolException("Could not access or instantiate class: " + factoryImpl, e);
-	}
-
-    String prettyPrintXslt = FITS_XML_DIR + "prettyprint.xslt";
-    try {
-      Templates template = tFactory.newTemplates( new StreamSource( prettyPrintXslt ) );
-      transformer = template.newTransformer();
-    } catch (Exception e) {
-      transformer = null;
-    }
-
-    if (xml != null && transformer != null) {
-
-      xml.setRoot( true );
-      ByteArrayOutputStream xmlOutStream = new ByteArrayOutputStream();
-      OutputStream xsltOutStream = new ByteArrayOutputStream();
-
-      try {
-        // send standard xml to the output stream
-        XMLStreamWriter sw = xmlOutputFactory.createXMLStreamWriter( xmlOutStream );
-        xml.output( sw );
-
-        // convert output stream to byte array and read back in as inputstream
-        Source source = new StreamSource( new ByteArrayInputStream( xmlOutStream.toByteArray() ) );
-        Result rstream = new StreamResult( xsltOutStream );
-
-        // apply the xslt
-        transformer.transform( source, rstream );
-
-        // send to the providedOutpuStream
-        out.write( xsltOutStream.toString().getBytes( "UTF-8" ) );
-        out.flush();
-
-      } catch (Exception e) {
-        System.err.println( "error converting output to a standard schema format for input file: [" + inputFilename + "]");
-      } finally {
-        xmlOutStream.close();
-        xsltOutStream.close();
-      }
-
-    } else {
-      System.err.println( "Error: output cannot be converted to a standard schema format for input file: [" + inputFilename + "]");
-    }
-  }
-
-  private static void printHelp( Options opts ) {
-    HelpFormatter formatter = new HelpFormatter();
-    formatter.printHelp( "fits", null, opts, null );
-  }
-
-  public FitsOutput examine( File input ) throws FitsException {
-    long t1 = System.currentTimeMillis();
-    if (!input.exists()) {
-      throw new FitsConfigurationException( input.getAbsolutePath() + " does not exist or is not readable" );
-    }
-
-    List<ToolOutput> toolResults = new ArrayList<ToolOutput>();
-
-    // run file through each tool, catching exceptions thrown by tools
-    List<Throwable> caughtThrowables = new ArrayList<Throwable>();
-    String path = input.getPath().toLowerCase();
-    String ext = path.substring( path.lastIndexOf( "." ) + 1 );
-
-    ArrayList<Thread> threads = new ArrayList<Thread>();
-    // GDM 16-Nov-12: Implement limit on maximum threads
-    for (Tool t : toolbelt.getTools()) {
-      if (t.isEnabled()) {
-
-        // figure out of the tool should be run against the file depending on
-        // the include and exclude extension lists
-        RunStatus runStatus = RunStatus.SHOULDNOTRUN;
-        // if the tool has an include-exts list and it has the extension in it,
-        // then run
-        if (t.hasIncludedExtensions()) {
-          if (t.hasIncludedExtension( ext )) {
-            runStatus = RunStatus.SHOULDRUN;
-          }
-        }
-        // if the tool has an exclude-exts list and it does NOT have the
-        // extension in it, then run
-        else if (t.hasExcludedExtensions()) {
-          if (!t.hasExcludedExtension( ext )) {
-            runStatus = RunStatus.SHOULDRUN;
-          }
-        }
-        // if the tool does not have an include-exts or exclude-exts list then
-        // run
-        else if (!t.hasIncludedExtensions() && !t.hasExcludedExtensions()) {
-          runStatus = RunStatus.SHOULDRUN;
-        }
-
-        t.setRunStatus( runStatus );
-
-        if (runStatus == RunStatus.SHOULDRUN) {
-          // Don't exceed the maximum thread count
-          while (countActiveTools( threads ) >= maxThreads) {
-            try {
-              Thread.sleep( 200 );
-            } catch (InterruptedException e) {
+        // NOTE: a "FITS_HOME" environment variable (see initial static block of this class)
+        // "wins" over a FITS home value passed into the constructor.
+        if (StringUtils.isEmpty(FITS_HOME)) {
+            // if env variable not set check for fits_home passed into constructor
+            if (fits_home != null) {
+                FITS_HOME = fits_home;
             }
-          }
-          // spin up new threads
-          t.setInputFile( input );
-          // GDM 16-Nov-12: Name the threads as a debugging aid
-          Thread thread = new Thread( t, t.getToolInfo().getName() );
-          threads.add( thread );
-          logger.debug( "Starting thread " + thread.getName() );
-          thread.start();
         }
-      }
-    }
 
-    // wait for them all to finish
-    for (Thread thread : threads) {
-      try {
-        thread.join();
-      } catch (InterruptedException e) {
-        logger.error("Caught exception while waiting for tools to finish running: " + e.getMessage(), e);
-      }
-    }
+        setFitsVersionFromFile();
 
-    // get all output from the tools
-    for (Tool t : toolbelt.getTools()) {
-      toolResults.add( t.getOutput() );
-      if (t.getCaughtThrowable() != null) {
-    	  caughtThrowables.add( t.getCaughtThrowable() );
-      }
-    }
+        FITS_XML_DIR = FITS_HOME + "xml" + File.separator;
+        FITS_TOOLS_DIR = FITS_HOME + "tools" + File.separator;
 
-    // consolidate the results into a single DOM
-    FitsOutput result = consolidator.processResults( toolResults );
-    result.setCaughtThrowables( caughtThrowables );
-
-    long t2 = System.currentTimeMillis();
-    if (enableStatistics) {
-      result.createStatistics( toolbelt, t2 - t1 );
-    }
-
-    if (resetToolOutput) {
-    	for (Tool t : toolbelt.getTools()) {
-    		t.resetOutput();
-    	}
-    }
-
-    if (result.getCaughtThrowables().size() > 0) {
-        for (Throwable e : result.getCaughtThrowables()) {
-          logger.error( "Tool error processing file: " + input.getName() + "\n" + e.getMessage(), e );
+        // Set up logging explicitly so one of the tools aggregated into FITS does not circumvent this.
+        //
+        // First look for a system property (the Log4j preferred way of configuration) at the Log4j expected value,
+        // "log4j2.configurationFile".
+        // This value can be either a file path, file protocol (e.g. - file:/path/to/log4j2.xml), or a URL
+        // (http://some/server/log4j2.xml).
+        // If this value either is does not, the default file that comes with FITS will be used for initialization.
+        String log4jSystemProp = System.getProperty("log4j2.configurationFile");
+        if (log4jSystemProp == null) {
+            File log4jProperties = new File(FITS_HOME + "log4j2.xml");
+            System.setProperty("log4j2.configurationFile", log4jProperties.getPath());
         }
-      }
+        logger = LoggerFactory.getLogger(Fits.class);
+        logger.info("Logging initialized with: " + System.getProperty("log4j2.configurationFile"));
+        try {
+            if (fitsXmlConfig != null) {
+                config = new XMLConfiguration(fitsXmlConfig);
+            } else {
+                config = new XMLConfiguration(FITS_XML_DIR + FITS_CONFIG_FILE_NAME);
+            }
+        } catch (ConfigurationException e) {
+            logger.error(
+                    "Error reading {}{}: {}",
+                    FITS_XML_DIR,
+                    FITS_CONFIG_FILE_NAME,
+                    e.getClass().getName());
+            throw new FitsConfigurationException("Error reading " + FITS_XML_DIR + FITS_CONFIG_FILE_NAME, e);
+        }
+        try {
+            mapper = new FitsXmlMapper();
+        } catch (Exception e) {
+            logger.error("Error creating FITS XML Mapper: {}", e.getClass().getName());
+            throw new FitsConfigurationException("Error creating FITS XML Mapper", e);
+        }
+        // required config values
+        try {
+            validateToolOutput = config.getBoolean("output.validate-tool-output");
+            externalOutputSchema = config.getString("output.external-output-schema");
+            internalOutputSchema = config.getString("output.internal-output-schema");
+            enableStatistics = config.getBoolean("output.enable-statistics");
+            consolidateFirstIdentity = config.getBoolean("output.consolidate-first-identity", true);
+        } catch (NoSuchElementException e) {
+            logger.error("Error in configuration file: {}", e.getClass().getName());
+            System.out.println("Error inconfiguration file: " + e.getMessage());
+            return;
+        }
 
-    return result;
-  }
+        // optional config values GDM 16-Nov-2012
+        try {
+            maxThreads = config.getShort("process.max-threads");
+        } catch (NoSuchElementException e) {
+            logger.warn("'max-threads' value not set in fit.xml. Setting to default: {}", DEFAULT_MAX_THREADS);
+            maxThreads = DEFAULT_MAX_THREADS;
+        }
+        if (maxThreads < 1) {
+            // If invalid number specified, use a default.
+            logger.warn(
+                    "Invalid number of threads specified: {} -- Resetting to default: {}",
+                    maxThreads,
+                    DEFAULT_MAX_THREADS);
+            maxThreads = DEFAULT_MAX_THREADS;
+        }
+        logger.debug("Maximum threads = " + maxThreads);
 
-  /**
-   * Default is that the output of each tool is reset after gathering the results
-   * in the examine() method. This method should only be used for testing purposes.
-   *
-   * @param resetToolOutput <code>false</code> will change default functionality of
-   * 		resetting each tool's output after running examine().
-   * @see edu.harvard.hul.ois.fits.tools.Tool#resetOutput()
-   */
-  protected void resetToolOutputAfterExaminingInput(boolean resetToolOutput) {
-	  this.resetToolOutput = resetToolOutput;
-  }
+        String consolidatorClassFullyQualifiedName = config.getString("output.dataConsolidator[@class]");
+        try {
+            // Instantiate the Consolidator class using Reflection by passing Fits into the constructor.
+            Class<?> c = Class.forName(consolidatorClassFullyQualifiedName);
+            Constructor<?> ctor = c.getConstructor(Fits.class);
+            consolidator = (ToolOutputConsolidator) ctor.newInstance(this);
+        } catch (Exception e) {
+            throw new FitsConfigurationException("Error initializing " + consolidatorClassFullyQualifiedName, e);
+        }
 
-  public ToolBelt getToolbelt() {
-    return toolbelt;
-  }
-  
-  public XMLConfiguration getConfig() {
-	  return config;
-  }
-  
-  public FitsXmlMapper getFitsXmlMapper() {
-	  return mapper;
-  }
-  
-  public String getExternalOutputSchema() {
-	  return externalOutputSchema;
-  }
-
-  public String getInternalOutputSchema() {
-	  return internalOutputSchema;
-  }
-  
-  public boolean validateToolOutput() {
-	  return validateToolOutput;
-  }
-
-  /**
-   * @return true if tool output should be consolidated to only include output from tools in the first identity block
-   */
-  public boolean isConsolidateFirstIdentity() {
-    return consolidateFirstIdentity;
-  }
-  
-  public boolean isRawToolOutput() {
-      return rawToolOutput;
-  }
-
-  /* Count up all the threads that are still running */
-  private int countActiveTools( List<Thread> threads ) {
-    int count = 0;
-    for (Thread t : threads) {
-      if (t.isAlive()) {
-        ++count;
-      }
+        toolbelt = new ToolBelt(config, this);
     }
-    return count;
-  }
+
+    public static void main(String[] args) throws FitsException, IOException, ParseException, XMLStreamException {
+
+        setFitsVersionFromFile();
+
+        Options options = new Options();
+        options.addOption("i", true, "input file or directory (required)");
+        options.addOption("r", false, "process directories recursively when -i is a directory ");
+        options.addOption(
+                "n",
+                false,
+                "output directories are nested when recursively processing nested directories (when -r is set and -i is a directory) (optional)");
+        options.addOption(
+                "o", true, "Directs the FITS output to a file or directory (if -i is a directory) rather than console");
+        options.addOption("h", false, "print this message");
+        options.addOption("v", false, "print version information");
+        options.addOption("f", true, "alternate fits.xml configuration file location (optional)");
+        options.addOption("t", false, "include all raw tool output");
+        OptionGroup outputOptions = new OptionGroup();
+        Option stdxml = new Option(
+                "x",
+                false,
+                "convert FITS output to a standard metadata schema -- note: only standard schema metadata is output");
+        Option combinedStd = new Option("xc", false, "output using a standard metadata schema and include FITS xml");
+        outputOptions.addOption(stdxml);
+        outputOptions.addOption(combinedStd);
+        options.addOptionGroup(outputOptions);
+
+        CommandLineParser parser = new DefaultParser();
+        CommandLine cmd = null;
+        try {
+            cmd = parser.parse(options, args);
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
+
+        if (cmd.hasOption("h")) {
+            printHelp(options);
+            System.exit(0);
+        }
+        if (cmd.hasOption("v")) {
+            System.out.println(Fits.VERSION);
+            System.exit(0);
+        }
+        if (cmd.hasOption("r")) {
+            traverseDirs = true;
+        } else {
+            traverseDirs = false;
+        }
+        if (cmd.hasOption("n")) {
+            nestDirs = true;
+        } else {
+            nestDirs = false;
+        }
+        rawToolOutput = cmd.hasOption("t");
+
+        File fitsConfigFile = null;
+        try {
+            if (cmd.hasOption('f')) {
+                String input = cmd.getOptionValue('f');
+                if (StringUtils.isEmpty(input)) {
+                    throw new FitsException("When using the -f option there must be an associated value.");
+                }
+                fitsConfigFile = new File(input);
+                if (!fitsConfigFile.isFile() || !fitsConfigFile.canRead()) {
+                    throw new FitsException("The FITS configuration file: " + input + " cannot be read.");
+                }
+            }
+
+            if (cmd.hasOption("i")) {
+                String input = cmd.getOptionValue("i");
+                File inputFile = new File(input);
+
+                if (inputFile.isDirectory()) {
+                    String outputDir = cmd.getOptionValue("o");
+                    if (outputDir == null || !(new File(outputDir).isDirectory())) {
+                        throw new FitsException(
+                                "When FITS is run in directory processing mode the output location must be a directory.");
+                    }
+                    Fits fits = constructFits(fitsConfigFile);
+                    fits.doDirectory(inputFile, new File(outputDir), cmd.hasOption("x"), cmd.hasOption("xc"));
+                } else { // inputFile is a file so output -o must either be a file or not set at all
+                    String outputFile = cmd.getOptionValue("o");
+                    if (outputFile != null && (new File(outputFile).isDirectory())) {
+                        throw new FitsException(
+                                "When FITS is processing a single file the output location must also be a file.");
+                    }
+                    Fits fits = constructFits(fitsConfigFile);
+                    FitsOutput result = fits.doSingleFile(inputFile);
+                    fits.outputResults(result, cmd.getOptionValue("o"), cmd.hasOption("x"), cmd.hasOption("xc"), false);
+                }
+            } else {
+                System.err.println("Invalid CLI options: -i <arg> is required.");
+                printHelp(options);
+                System.exit(1);
+            }
+        } catch (FitsException fe) {
+            System.err.println(fe.getMessage());
+            System.exit(1);
+        }
+
+        System.exit(0);
+    }
+
+    private static Fits constructFits(File fitsConfigFile) throws FitsConfigurationException {
+        Fits fits = null;
+        if (fitsConfigFile != null) {
+            fits = new Fits(null, fitsConfigFile);
+        } else {
+            fits = new Fits();
+        }
+        return fits;
+    }
+
+    /*
+     * Called from either main() for stand-alone application usage or constructor
+     * when used by another program, this reads the properties file containing the
+     * current version of FITS.
+     *
+     * Precondition of this method is that the static FITS_HOME has been set via
+     * an environment variable, being passed into a constructor, or is just the current directory.
+     */
+    private static void setFitsVersionFromFile() {
+
+        // If fits home is not an empty string and doesn't end with a file
+        // separator character, add one
+        if (FITS_HOME.length() > 0 && !FITS_HOME.endsWith(File.separator)) {
+            FITS_HOME = FITS_HOME + File.separator;
+        }
+
+        // get version from properties file and set in class
+        String versionPropFileFullPath = "";
+        if (!StringUtils.isEmpty(FITS_HOME)) {
+            versionPropFileFullPath = FITS_HOME;
+        }
+
+        File versionFile = new File(versionPropFileFullPath + VERSION_PROPERTIES_FILE);
+        Properties versionProps = new Properties();
+        try {
+            versionProps.load(new FileInputStream(versionFile));
+            String version = versionProps.getProperty("build.version");
+            if (version != null && !version.isEmpty()) {
+                Fits.VERSION = version;
+            }
+        } catch (IOException e) {
+            System.err.println(
+                    "Problem loading [" + VERSION_PROPERTIES_FILE + "]: " + "Cannot display FITS version information.");
+        }
+    }
+
+    /**
+     * Recursively processes all files in the directory.
+     *
+     * @param intputFile
+     * @param useStandardSchemas
+     * @throws IOException
+     * @throws XMLStreamException
+     * @throws FitsException
+     */
+    private void doDirectory(File inputDir, File outputDir, boolean useStandardSchemas, boolean standardCombinedFormat)
+            throws FitsException, XMLStreamException, IOException {
+        if (inputDir.listFiles() == null) {
+            return;
+        }
+
+        logger.info("Processing directory " + inputDir.getAbsolutePath());
+
+        for (File f : inputDir.listFiles()) {
+
+            if (f == null || !f.exists() || !f.canRead()) {
+                continue;
+            }
+
+            logger.info("processing " + f.getPath());
+
+            if (f.isDirectory() && traverseDirs) {
+                // need to reset original directory after return from recursive call when nesting output
+                File savedDir = outputDir;
+                if (nestDirs) {
+                    outputDir = new File(outputDir, f.getName());
+                    if (!outputDir.exists()) {
+                        outputDir.mkdir();
+                    }
+                }
+                doDirectory(f, outputDir, useStandardSchemas, standardCombinedFormat);
+                outputDir = savedDir;
+            } else if (f.isFile()) {
+                if (".DS_Store".equals(f.getName())) {
+                    // Mac hidden directory services file, ignore
+                    logger.debug("Skipping .DS_Store");
+                    continue;
+                }
+                FitsOutput result = doSingleFile(f);
+                String outputFile = outputDir.getPath() + File.separator + f.getName() + "." + FITS_CONFIG_FILE_NAME;
+                File output = new File(outputFile);
+                if (output.exists()) {
+                    int cnt = 1;
+                    while (true) {
+                        outputFile = outputDir.getPath() + File.separator + f.getName() + "-" + cnt + "."
+                                + FITS_CONFIG_FILE_NAME;
+                        output = new File(outputFile);
+                        if (!output.exists()) {
+                            break;
+                        }
+                        cnt++;
+                    }
+                }
+                outputResults(result, outputFile, useStandardSchemas, standardCombinedFormat, true);
+            }
+        }
+    }
+
+    /**
+     * processes a single file and outputs to the provided output location.
+     * Outputs to standard out if outputLocation is null
+     *
+     * @param inputFile
+     * @param outputLocation
+     * @param useStandardSchemas
+     *          - use standard schemas if available for output type
+     * @throws FitsException
+     * @throws XMLStreamException
+     * @throws IOException
+     */
+    private FitsOutput doSingleFile(File inputFile) throws FitsException, XMLStreamException, IOException {
+
+        logger.debug("Processing file " + inputFile.getAbsolutePath());
+        FitsOutput result = this.examine(inputFile);
+        return result;
+    }
+
+    private void outputResults(
+            FitsOutput result,
+            String outputLocation,
+            boolean standardSchema,
+            boolean standardCombinedFormat,
+            boolean dirMode)
+            throws XMLStreamException, IOException, FitsException {
+        OutputStream out = null;
+        logger.debug("Outputting results");
+        try {
+            // figure out the output location
+            if (outputLocation != null) {
+                out = new FileOutputStream(outputLocation);
+            } else if (!dirMode) {
+                out = System.out;
+            } else {
+                throw new FitsException("The output location must be provided when running FITS in directory mode");
+            }
+
+            // if -x is set, then convert to standard metadata schema and output to -o
+            if (standardSchema) {
+                outputStandardSchemaXml(result, out);
+            }
+            // if we are using -xc output FITS xml and standard format
+            else if (standardCombinedFormat) {
+                outputStandardCombinedFormat(result, out);
+            }
+            // else output FITS XML to -o
+            else {
+                Document doc = result.getFitsXml();
+                XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+                serializer.output(doc, out);
+            }
+
+        } finally {
+            if (out != null) {
+                out.close();
+            }
+        }
+    }
+
+    public static void outputStandardCombinedFormat(FitsOutput result, OutputStream out)
+            throws XMLStreamException, IOException, FitsException {
+        // add the normal fits xml output
+        result.addStandardCombinedFormat();
+
+        // output the merged JDOM Document
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        serializer.output(result.getFitsXml(), out);
+    }
+
+    public static void outputStandardSchemaXml(FitsOutput fitsOutput, OutputStream out)
+            throws XMLStreamException, IOException, FitsException {
+        XmlContent xml = fitsOutput.getStandardXmlContent();
+        FitsMetadataElement fileNameElement = fitsOutput.getFileInfoElement("filename");
+        String inputFilename = fileNameElement == null ? null : fileNameElement.getValue();
+
+        // create an xml output factory
+        Transformer transformer = null;
+
+        // initialize transformer for pretty print xslt
+        TransformerFactory tFactory = null;
+        String factoryImpl = "net.sf.saxon.TransformerFactoryImpl";
+        try {
+            Class<?> clazz = Class.forName(factoryImpl);
+            tFactory = (TransformerFactory) clazz.getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException
+                | InstantiationException
+                | IllegalAccessException
+                | NoSuchMethodException
+                | InvocationTargetException e) {
+            throw new FitsToolException("Could not access or instantiate class: " + factoryImpl, e);
+        }
+
+        String prettyPrintXslt = FITS_XML_DIR + "prettyprint.xslt";
+        try {
+            Templates template = tFactory.newTemplates(new StreamSource(prettyPrintXslt));
+            transformer = template.newTransformer();
+        } catch (Exception e) {
+            transformer = null;
+        }
+
+        if (xml != null && transformer != null) {
+
+            xml.setRoot(true);
+            ByteArrayOutputStream xmlOutStream = new ByteArrayOutputStream();
+            OutputStream xsltOutStream = new ByteArrayOutputStream();
+
+            try {
+                // send standard xml to the output stream
+                XMLStreamWriter sw = xmlOutputFactory.createXMLStreamWriter(xmlOutStream);
+                xml.output(sw);
+
+                // convert output stream to byte array and read back in as inputstream
+                Source source = new StreamSource(new ByteArrayInputStream(xmlOutStream.toByteArray()));
+                Result rstream = new StreamResult(xsltOutStream);
+
+                // apply the xslt
+                transformer.transform(source, rstream);
+
+                // send to the providedOutpuStream
+                out.write(xsltOutStream.toString().getBytes("UTF-8"));
+                out.flush();
+
+            } catch (Exception e) {
+                System.err.println(
+                        "error converting output to a standard schema format for input file: [" + inputFilename + "]");
+            } finally {
+                xmlOutStream.close();
+                xsltOutStream.close();
+            }
+
+        } else {
+            System.err.println("Error: output cannot be converted to a standard schema format for input file: ["
+                    + inputFilename + "]");
+        }
+    }
+
+    private static void printHelp(Options opts) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp("fits", null, opts, null);
+    }
+
+    public FitsOutput examine(File input) throws FitsException {
+        long t1 = System.currentTimeMillis();
+        if (!input.exists()) {
+            throw new FitsConfigurationException(input.getAbsolutePath() + " does not exist or is not readable");
+        }
+
+        List<ToolOutput> toolResults = new ArrayList<ToolOutput>();
+
+        // run file through each tool, catching exceptions thrown by tools
+        List<Throwable> caughtThrowables = new ArrayList<Throwable>();
+        String path = input.getPath().toLowerCase();
+        String ext = path.substring(path.lastIndexOf(".") + 1);
+
+        ArrayList<Thread> threads = new ArrayList<Thread>();
+        // GDM 16-Nov-12: Implement limit on maximum threads
+        for (Tool t : toolbelt.getTools()) {
+            if (t.isEnabled()) {
+
+                // figure out of the tool should be run against the file depending on
+                // the include and exclude extension lists
+                RunStatus runStatus = RunStatus.SHOULDNOTRUN;
+                // if the tool has an include-exts list and it has the extension in it,
+                // then run
+                if (t.hasIncludedExtensions()) {
+                    if (t.hasIncludedExtension(ext)) {
+                        runStatus = RunStatus.SHOULDRUN;
+                    }
+                }
+                // if the tool has an exclude-exts list and it does NOT have the
+                // extension in it, then run
+                else if (t.hasExcludedExtensions()) {
+                    if (!t.hasExcludedExtension(ext)) {
+                        runStatus = RunStatus.SHOULDRUN;
+                    }
+                }
+                // if the tool does not have an include-exts or exclude-exts list then
+                // run
+                else if (!t.hasIncludedExtensions() && !t.hasExcludedExtensions()) {
+                    runStatus = RunStatus.SHOULDRUN;
+                }
+
+                t.setRunStatus(runStatus);
+
+                if (runStatus == RunStatus.SHOULDRUN) {
+                    // Don't exceed the maximum thread count
+                    while (countActiveTools(threads) >= maxThreads) {
+                        try {
+                            Thread.sleep(200);
+                        } catch (InterruptedException e) {
+                        }
+                    }
+                    // spin up new threads
+                    t.setInputFile(input);
+                    // GDM 16-Nov-12: Name the threads as a debugging aid
+                    Thread thread = new Thread(t, t.getToolInfo().getName());
+                    threads.add(thread);
+                    logger.debug("Starting thread " + thread.getName());
+                    thread.start();
+                }
+            }
+        }
+
+        // wait for them all to finish
+        for (Thread thread : threads) {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                logger.error("Caught exception while waiting for tools to finish running: " + e.getMessage(), e);
+            }
+        }
+
+        // get all output from the tools
+        for (Tool t : toolbelt.getTools()) {
+            toolResults.add(t.getOutput());
+            if (t.getCaughtThrowable() != null) {
+                caughtThrowables.add(t.getCaughtThrowable());
+            }
+        }
+
+        // consolidate the results into a single DOM
+        FitsOutput result = consolidator.processResults(toolResults);
+        result.setCaughtThrowables(caughtThrowables);
+
+        long t2 = System.currentTimeMillis();
+        if (enableStatistics) {
+            result.createStatistics(toolbelt, t2 - t1);
+        }
+
+        if (resetToolOutput) {
+            for (Tool t : toolbelt.getTools()) {
+                t.resetOutput();
+            }
+        }
+
+        if (result.getCaughtThrowables().size() > 0) {
+            for (Throwable e : result.getCaughtThrowables()) {
+                logger.error("Tool error processing file: " + input.getName() + "\n" + e.getMessage(), e);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Default is that the output of each tool is reset after gathering the results
+     * in the examine() method. This method should only be used for testing purposes.
+     *
+     * @param resetToolOutput <code>false</code> will change default functionality of
+     * 		resetting each tool's output after running examine().
+     * @see edu.harvard.hul.ois.fits.tools.Tool#resetOutput()
+     */
+    protected void resetToolOutputAfterExaminingInput(boolean resetToolOutput) {
+        this.resetToolOutput = resetToolOutput;
+    }
+
+    public ToolBelt getToolbelt() {
+        return toolbelt;
+    }
+
+    public XMLConfiguration getConfig() {
+        return config;
+    }
+
+    public FitsXmlMapper getFitsXmlMapper() {
+        return mapper;
+    }
+
+    public String getExternalOutputSchema() {
+        return externalOutputSchema;
+    }
+
+    public String getInternalOutputSchema() {
+        return internalOutputSchema;
+    }
+
+    public boolean validateToolOutput() {
+        return validateToolOutput;
+    }
+
+    /**
+     * @return true if tool output should be consolidated to only include output from tools in the first identity block
+     */
+    public boolean isConsolidateFirstIdentity() {
+        return consolidateFirstIdentity;
+    }
+
+    public boolean isRawToolOutput() {
+        return rawToolOutput;
+    }
+
+    /* Count up all the threads that are still running */
+    private int countActiveTools(List<Thread> threads) {
+        int count = 0;
+        for (Thread t : threads) {
+            if (t.isAlive()) {
+                ++count;
+            }
+        }
+        return count;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/FitsMetadataElement.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/FitsMetadataElement.java
@@ -12,79 +12,76 @@ package edu.harvard.hul.ois.fits;
 
 public class FitsMetadataElement {
 
-	private String name;
-	private String value;
-	private String reportingToolName;
-	private String reportingToolVersion;
-	private String status;
+    private String name;
+    private String value;
+    private String reportingToolName;
+    private String reportingToolVersion;
+    private String status;
 
-	public FitsMetadataElement() {
+    public FitsMetadataElement() {}
 
-	}
+    public FitsMetadataElement(String name, String value, String tName, String tVersion, String status) {
+        this.name = name;
+        this.value = value;
+        this.reportingToolName = tName;
+        this.reportingToolVersion = tVersion;
+        this.status = status;
+    }
 
-	public FitsMetadataElement(String name, String value, String tName, String tVersion, String status) {
-		this.name = name;
-		this.value = value;
-		this.reportingToolName = tName;
-		this.reportingToolVersion = tVersion;
-		this.status = status;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public String getName() {
-		return name;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public String getValue() {
+        return value;
+    }
 
-	public String getValue() {
-		return value;
-	}
+    public void setValue(String value) {
+        this.value = value;
+    }
 
-	public void setValue(String value) {
-		this.value = value;
-	}
+    public String getReportingToolName() {
+        return reportingToolName;
+    }
 
-	public String getReportingToolName() {
-		return reportingToolName;
-	}
+    public void setReportingToolName(String reportingToolName) {
+        this.reportingToolName = reportingToolName;
+    }
 
-	public void setReportingToolName(String reportingToolName) {
-		this.reportingToolName = reportingToolName;
-	}
+    public String getReportingToolVersion() {
+        return reportingToolVersion;
+    }
 
-	public String getReportingToolVersion() {
-		return reportingToolVersion;
-	}
+    public void setReportingToolVersion(String reportingToolVersion) {
+        this.reportingToolVersion = reportingToolVersion;
+    }
 
-	public void setReportingToolVersion(String reportingToolVersion) {
-		this.reportingToolVersion = reportingToolVersion;
-	}
+    public String getStatus() {
+        return status;
+    }
 
-	public String getStatus() {
-		return status;
-	}
+    public void setStatus(String status) {
+        this.status = status;
+    }
 
-	public void setStatus(String status) {
-		this.status = status;
-	}
-
-	@Override
-	public String toString() {
-		StringBuilder builder = new StringBuilder();
-		builder.append("FitsMetadataElement [name=");
-		builder.append(name);
-		builder.append(", value=");
-		builder.append(value);
-		builder.append(", reportingToolName=");
-		builder.append(reportingToolName);
-		builder.append(", reportingToolVersion=");
-		builder.append(reportingToolVersion);
-		builder.append(", status=");
-		builder.append(status);
-		builder.append("]");
-		return builder.toString();
-	}
-
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("FitsMetadataElement [name=");
+        builder.append(name);
+        builder.append(", value=");
+        builder.append(value);
+        builder.append(", reportingToolName=");
+        builder.append(reportingToolName);
+        builder.append(", reportingToolVersion=");
+        builder.append(reportingToolVersion);
+        builder.append(", status=");
+        builder.append(status);
+        builder.append("]");
+        return builder.toString();
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/FitsMetadataValues.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/FitsMetadataValues.java
@@ -17,198 +17,197 @@ import java.util.HashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /** This class holds standard element names for FITS metadata output, as well
  *  as some standard values. All components are static.
  */
 public class FitsMetadataValues {
 
-	private static FitsMetadataValues instance;
+    private static FitsMetadataValues instance;
 
     private static final Logger logger = LoggerFactory.getLogger(FitsMetadataValues.class);
 
-	private String mimeMapProperties = Fits.FITS_XML_DIR + "mime_map.txt";
-	private String formatMapProperties = Fits.FITS_XML_DIR + "format_map.txt";
-	private String mimeToFormatMapProperties = Fits.FITS_XML_DIR + "mime_to_format_map.txt";
+    private String mimeMapProperties = Fits.FITS_XML_DIR + "mime_map.txt";
+    private String formatMapProperties = Fits.FITS_XML_DIR + "format_map.txt";
+    private String mimeToFormatMapProperties = Fits.FITS_XML_DIR + "mime_to_format_map.txt";
 
     private HashMap<String, String> mimeMap = new HashMap<String, String>();
     private HashMap<String, String> formatMap = new HashMap<String, String>();
     private HashMap<String, String> mimeToFormatMap = new HashMap<String, String>();
 
-	public final static String DEFAULT_MIMETYPE="application/octet-stream";
-	public final static String DEFAULT_FORMAT="Unknown Binary";
+    public static final String DEFAULT_MIMETYPE = "application/octet-stream";
+    public static final String DEFAULT_FORMAT = "Unknown Binary";
 
     /** Standard document element names. */
-    public final static String AUDIO = "audio";
-    public final static String DOCUMENT = "document";
-    public final static String IMAGE = "image";
-    public final static String TEXT = "text";
-    public final static String VIDEO = "video";
+    public static final String AUDIO = "audio";
+
+    public static final String DOCUMENT = "document";
+    public static final String IMAGE = "image";
+    public static final String TEXT = "text";
+    public static final String VIDEO = "video";
 
     /** Standard property element names. The idea is to include them
      *  all here, even the ones that are generated only by
      *  XSLT. */
-    public final static String APERTURE_VALUE = "apertureValue";
-    public final static String AUDIO_BITS_PER_SAMPLE = "audioBitsPerSample";  // 11-Apr-2013
-    public final static String AUDIO_CHANNEL_TYPE = "audioChannelType";  // 11-Apr-2013
-    public final static String AUDIO_COMPRESSOR = "audioCompressor";   // 11-Apr-2013
-    public final static String AUDIO_DATA_ENCODING = "audioDataEncoding";
-    //public final static String AUDIO_ENCODING = "audioEncoding";
-    public final static String AUDIO_SAMPLE_RATE = "audioSampleRate";  // 11-Apr-2013
-    public final static String AUDIO_SAMPLE_TYPE = "audioSampleType";  // 12-Apr-2013
-    public final static String AUTHOR = "author";
-    public final static String AVG_BIT_RATE = "avgBitRate";       // audio
-    public final static String AVG_PACKET_SIZE = "avgPacketSize";
-    public final static String BIT_DEPTH = "bitDepth";            // video, audio
-    public final static String BIT_RATE = "bitRate";              // video, audio
-    public final static String BITS_PER_SAMPLE = "bitsPerSample"; // image
-    public final static String BLOCK_SIZE_MAX = "blockSizeMax";
-    public final static String BLOCK_SIZE_MIN = "blockSizeMin";
-    public final static String BRIGHTNESS_VALUE = "brightnessValue";
-    public final static String BYTE_ORDER = "byteOrder";      // for possible future use
-    public final static String CATEGORY = "category";
-    public final static String CFA_PATTERN = "cfaPattern";    // image
-    public final static String CFA_PATTERN2 = "cfaPattern2";  // image
-    public final static String CHANNELS = "channels";          // audio, maybe video
-    public final static String CHARACTER_COUNT = "characterCount";
-    public final static String CHARSET = "charset";            // text
-    public final static String COLOR_SPACE = "colorSpace";
-    public final static String COMPANY = "company";
-    public final static String COMPRESSION_SCHEME = "compressionScheme";
-    public final static String COPYRIGHT_NOTE = "copyrightNote";
-    public final static String CREATED = "created";
-    public final static String CREATING_APPLICATION_NAME = "creatingApplicationName";
-    public final static String CREATING_APPLICATION_VERSION = "creatingApplicationVersion";
-    public final static String DATA_FORMAT_TYPE = "dataFormatType";
-    public final static String DESCRIPTION = "description";
-    public final static String DIGITAL_CAMERA_MANUFACTURER = "digitalCameraManufacturer";
-    public final static String DIGITAL_CAMERA_MODEL_NAME = "digitalCameraModelName";
-    public final static String DIGITAL_CAMERA_SERIAL_NO = "digitalCameraSerialNo";
-    public final static String DURATION = "duration";
-    public final static String EXIF_VERSION = "exifVersion";
-    public final static String HAS_EMBEDDED_RESOURCES = "hasEmbeddedResources";
-    public final static String EXPOSURE_BIAS_VALUE = "exposureBiasValue";
-    public final static String EXPOSURE_INDEX = "exposureIndex";
-    public final static String EXPOSURE_PROGRAM = "exposureProgram";
-    public final static String EXPOSURE_TIME = "exposureTime";
-    public final static String FLASH = "flash";
-    public final static String FLASH_ENERGY = "flashEnergy";
-    public final static String FNUMBER = "fNumber";
-    public final static String FOCAL_LENGTH = "focalLength";
-    public final static String FRAME_RATE = "frameRate";
-    public final static String GRAY_RESPONSE_UNIT = "grayResponseUnit";
-    public final static String ICC_PROFILE_NAME = "iccProfileName";
-    public final static String ICC_PROFILE_VERSION = "iccProfileVersion";
-    public final static String IDENTIFIER = "identifier";
-    public final static String IMAGE_COUNT = "graphicsCount";
-    public final static String IMAGE_HEIGHT = "imageHeight";
-    public final static String IMAGE_WIDTH = "imageWidth";
-    public final static String IMAGE_PRODUCER = "imageProducer";
-    public final static String ISO_SPEED_RATING = "isoSpeedRating";
-    public final static String LANGUAGE = "language";      // may be useful someday
-    public final static String LAST_MODIFIED = "lastmodified";
-    public final static String LIGHT_SOURCE = "lightSource";
-    public final static String LINE_COUNT = "lineCount";     // document
-    public final static String MARKUP_BASIS = "markupBasis";
-    public final static String MARKUP_BASIS_VERSION = "markupBasisVersion";
-    public final static String MARKUP_LANGUAGE = "markupLanguage";
-    public final static String MAX_APERTURE_VALUE = "maxApertureValue";
-    public final static String MAX_BIT_RATE = "maxBitRate";      // audio
-    public final static String MAX_PACKET_SIZE = "maxPacketSize";
-    public final static String METERING_MODE = "meteringMode";   // image
-    public final static String NUM_SAMPLES = "numSamples";       // audio
-    public final static String OFFSET = "offset";
-    public final static String ORIENTATION = "orientation";       // image, video
-    public final static String PUBLISHER = "publisher";
-    public final static String PIXEL_ASPECT_RATIO = "pixelAspectRatio";  // video
-    public final static String ROTATION = "rotation";        // image, video
-    public final static String PAGE_COUNT = "pageCount";     // document
-    public final static String PARAGRAPH_COUNT = "paragraphCount";     // document
-    public final static String IS_RIGHTS_MANAGED = "isRightsManaged";
-    public final static String IS_PROTECTED = "isProtected";
-    public final static String PRIMARY_CHROMATICITIES_BLUE_X = "primaryChromaticitiesBlueX";
-    public final static String PRIMARY_CHROMATICITIES_BLUE_Y = "primaryChromaticitiesBlueY";
-    public final static String PRIMARY_CHROMATICITIES_GREEN_X = "primaryChromaticitiesGreenX";
-    public final static String PRIMARY_CHROMATICITIES_GREEN_Y = "primaryChromaticitiesGreenY";
-    public final static String PRIMARY_CHROMATICITIES_RED_X = "primaryChromaticitiesRedX";
-    public final static String PRIMARY_CHROMATICITIES_RED_Y = "primaryChromaticitiesRedY";
-    public final static String QUALITY_LAYERS = "qualityLayers";    // JP2
-    public final static String REFERENCE_BLACK_WHITE = "referenceBlackWhite";
-    public final static String RESOLUTION_LEVELS = "resolutionLevels";   // JP2
-    public final static String SAMPLE_RATE = "sampleRate";        // audio
-    public final static String SAMPLES_PER_PIXEL = "samplesPerPixel";
-    public final static String SAMPLING_FREQUENCY_UNIT = "samplingFrequencyUnit";
-    public final static String SCANNER_MANUFACTURER = "scannerManufacturer";
-    public final static String SCANNER_MODEL_NAME = "scannerModelName";
-    public final static String SCANNER_MODEL_SERIAL_NO = "scannerModelSerialNo";
-    public final static String SCANNING_SOFTWARE_NAME = "scanningSoftwareName";
-    public final static String SENSING_METHOD = "sensingMethod";
-    public final static String SHUTTER_SPEED_VALUE = "shutterSpeedValue";
-    public final static String SIZE = "size";
-    public final static String SPECTRAL_SENSITIVITY = "spectralSensitivity";
-    public final static String SOFTWARE = "software";
-    public final static String SUBJECT = "subject";
-    public final static String TABLE_COUNT = "tableCount";
-    public final static String TIMECODE = "timecode";   // SMPTE timecode, for future use
-    public final static String TILE_HEIGHT = "tileHeight";   // image, esp. TIFF
-    public final static String TILE_WIDTH = "tileWidth";
-    public final static String TIME_SCALE = "timeScale"; // 11-Apr-2013
-    public final static String TITLE = "title";
-    public final static String VIDEO_COMPRESSOR = "videoCompressor";
-    public final static String WORD_COUNT = "wordCount";
-    public final static String X_SAMPLING_FREQUENCY = "xSamplingFrequency";
-    public final static String Y_SAMPLING_FREQUENCY = "ySamplingFrequency";
-    public final static String YCBCR_COEFFICIENTS = "YCbCrCoefficients";
-    public final static String YCBCR_POSITIONING = "YCbCrPositioning";
-    public final static String YCBCR_SUBSAMPLING = "YCbCrSubSampling";
+    public static final String APERTURE_VALUE = "apertureValue";
+
+    public static final String AUDIO_BITS_PER_SAMPLE = "audioBitsPerSample"; // 11-Apr-2013
+    public static final String AUDIO_CHANNEL_TYPE = "audioChannelType"; // 11-Apr-2013
+    public static final String AUDIO_COMPRESSOR = "audioCompressor"; // 11-Apr-2013
+    public static final String AUDIO_DATA_ENCODING = "audioDataEncoding";
+    // public final static String AUDIO_ENCODING = "audioEncoding";
+    public static final String AUDIO_SAMPLE_RATE = "audioSampleRate"; // 11-Apr-2013
+    public static final String AUDIO_SAMPLE_TYPE = "audioSampleType"; // 12-Apr-2013
+    public static final String AUTHOR = "author";
+    public static final String AVG_BIT_RATE = "avgBitRate"; // audio
+    public static final String AVG_PACKET_SIZE = "avgPacketSize";
+    public static final String BIT_DEPTH = "bitDepth"; // video, audio
+    public static final String BIT_RATE = "bitRate"; // video, audio
+    public static final String BITS_PER_SAMPLE = "bitsPerSample"; // image
+    public static final String BLOCK_SIZE_MAX = "blockSizeMax";
+    public static final String BLOCK_SIZE_MIN = "blockSizeMin";
+    public static final String BRIGHTNESS_VALUE = "brightnessValue";
+    public static final String BYTE_ORDER = "byteOrder"; // for possible future use
+    public static final String CATEGORY = "category";
+    public static final String CFA_PATTERN = "cfaPattern"; // image
+    public static final String CFA_PATTERN2 = "cfaPattern2"; // image
+    public static final String CHANNELS = "channels"; // audio, maybe video
+    public static final String CHARACTER_COUNT = "characterCount";
+    public static final String CHARSET = "charset"; // text
+    public static final String COLOR_SPACE = "colorSpace";
+    public static final String COMPANY = "company";
+    public static final String COMPRESSION_SCHEME = "compressionScheme";
+    public static final String COPYRIGHT_NOTE = "copyrightNote";
+    public static final String CREATED = "created";
+    public static final String CREATING_APPLICATION_NAME = "creatingApplicationName";
+    public static final String CREATING_APPLICATION_VERSION = "creatingApplicationVersion";
+    public static final String DATA_FORMAT_TYPE = "dataFormatType";
+    public static final String DESCRIPTION = "description";
+    public static final String DIGITAL_CAMERA_MANUFACTURER = "digitalCameraManufacturer";
+    public static final String DIGITAL_CAMERA_MODEL_NAME = "digitalCameraModelName";
+    public static final String DIGITAL_CAMERA_SERIAL_NO = "digitalCameraSerialNo";
+    public static final String DURATION = "duration";
+    public static final String EXIF_VERSION = "exifVersion";
+    public static final String HAS_EMBEDDED_RESOURCES = "hasEmbeddedResources";
+    public static final String EXPOSURE_BIAS_VALUE = "exposureBiasValue";
+    public static final String EXPOSURE_INDEX = "exposureIndex";
+    public static final String EXPOSURE_PROGRAM = "exposureProgram";
+    public static final String EXPOSURE_TIME = "exposureTime";
+    public static final String FLASH = "flash";
+    public static final String FLASH_ENERGY = "flashEnergy";
+    public static final String FNUMBER = "fNumber";
+    public static final String FOCAL_LENGTH = "focalLength";
+    public static final String FRAME_RATE = "frameRate";
+    public static final String GRAY_RESPONSE_UNIT = "grayResponseUnit";
+    public static final String ICC_PROFILE_NAME = "iccProfileName";
+    public static final String ICC_PROFILE_VERSION = "iccProfileVersion";
+    public static final String IDENTIFIER = "identifier";
+    public static final String IMAGE_COUNT = "graphicsCount";
+    public static final String IMAGE_HEIGHT = "imageHeight";
+    public static final String IMAGE_WIDTH = "imageWidth";
+    public static final String IMAGE_PRODUCER = "imageProducer";
+    public static final String ISO_SPEED_RATING = "isoSpeedRating";
+    public static final String LANGUAGE = "language"; // may be useful someday
+    public static final String LAST_MODIFIED = "lastmodified";
+    public static final String LIGHT_SOURCE = "lightSource";
+    public static final String LINE_COUNT = "lineCount"; // document
+    public static final String MARKUP_BASIS = "markupBasis";
+    public static final String MARKUP_BASIS_VERSION = "markupBasisVersion";
+    public static final String MARKUP_LANGUAGE = "markupLanguage";
+    public static final String MAX_APERTURE_VALUE = "maxApertureValue";
+    public static final String MAX_BIT_RATE = "maxBitRate"; // audio
+    public static final String MAX_PACKET_SIZE = "maxPacketSize";
+    public static final String METERING_MODE = "meteringMode"; // image
+    public static final String NUM_SAMPLES = "numSamples"; // audio
+    public static final String OFFSET = "offset";
+    public static final String ORIENTATION = "orientation"; // image, video
+    public static final String PUBLISHER = "publisher";
+    public static final String PIXEL_ASPECT_RATIO = "pixelAspectRatio"; // video
+    public static final String ROTATION = "rotation"; // image, video
+    public static final String PAGE_COUNT = "pageCount"; // document
+    public static final String PARAGRAPH_COUNT = "paragraphCount"; // document
+    public static final String IS_RIGHTS_MANAGED = "isRightsManaged";
+    public static final String IS_PROTECTED = "isProtected";
+    public static final String PRIMARY_CHROMATICITIES_BLUE_X = "primaryChromaticitiesBlueX";
+    public static final String PRIMARY_CHROMATICITIES_BLUE_Y = "primaryChromaticitiesBlueY";
+    public static final String PRIMARY_CHROMATICITIES_GREEN_X = "primaryChromaticitiesGreenX";
+    public static final String PRIMARY_CHROMATICITIES_GREEN_Y = "primaryChromaticitiesGreenY";
+    public static final String PRIMARY_CHROMATICITIES_RED_X = "primaryChromaticitiesRedX";
+    public static final String PRIMARY_CHROMATICITIES_RED_Y = "primaryChromaticitiesRedY";
+    public static final String QUALITY_LAYERS = "qualityLayers"; // JP2
+    public static final String REFERENCE_BLACK_WHITE = "referenceBlackWhite";
+    public static final String RESOLUTION_LEVELS = "resolutionLevels"; // JP2
+    public static final String SAMPLE_RATE = "sampleRate"; // audio
+    public static final String SAMPLES_PER_PIXEL = "samplesPerPixel";
+    public static final String SAMPLING_FREQUENCY_UNIT = "samplingFrequencyUnit";
+    public static final String SCANNER_MANUFACTURER = "scannerManufacturer";
+    public static final String SCANNER_MODEL_NAME = "scannerModelName";
+    public static final String SCANNER_MODEL_SERIAL_NO = "scannerModelSerialNo";
+    public static final String SCANNING_SOFTWARE_NAME = "scanningSoftwareName";
+    public static final String SENSING_METHOD = "sensingMethod";
+    public static final String SHUTTER_SPEED_VALUE = "shutterSpeedValue";
+    public static final String SIZE = "size";
+    public static final String SPECTRAL_SENSITIVITY = "spectralSensitivity";
+    public static final String SOFTWARE = "software";
+    public static final String SUBJECT = "subject";
+    public static final String TABLE_COUNT = "tableCount";
+    public static final String TIMECODE = "timecode"; // SMPTE timecode, for future use
+    public static final String TILE_HEIGHT = "tileHeight"; // image, esp. TIFF
+    public static final String TILE_WIDTH = "tileWidth";
+    public static final String TIME_SCALE = "timeScale"; // 11-Apr-2013
+    public static final String TITLE = "title";
+    public static final String VIDEO_COMPRESSOR = "videoCompressor";
+    public static final String WORD_COUNT = "wordCount";
+    public static final String X_SAMPLING_FREQUENCY = "xSamplingFrequency";
+    public static final String Y_SAMPLING_FREQUENCY = "ySamplingFrequency";
+    public static final String YCBCR_COEFFICIENTS = "YCbCrCoefficients";
+    public static final String YCBCR_POSITIONING = "YCbCrPositioning";
+    public static final String YCBCR_SUBSAMPLING = "YCbCrSubSampling";
 
     /** Standard compression values. */
-    public final static String CMPR_NONE = "Uncompressed";
-    public final static String CMPR_JP2 = "JPEG 2000";
-    public final static String CMPR_JP2_LOSSY = "JPEG 2000 Lossy";
-    public final static String CMPR_JP2_LOSSLESS = "JPEG 2000 Lossless";
-    public final static String CMPR_CCITT1D = "CCITT 1D";
-    public final static String CMPR_T4G3FAX = "T4/Group 3 Fax";
-    public final static String CMPR_T6G4FAX = "T6/Group 4 Fax";
-    public final static String CMPR_LZW = "LZW";
-    public final static String CMPR_JPEG_OLD = "JPEG (old-style)";
-    public final static String CMPR_JPEG = "JPEG";
-    public final static String CMPR_ADOBE_DEFLATE = "Adobe Deflate";
-    public final static String CMPR_JBIG = "JBIG";
-    public final static String CMPR_CCITTRLEW = "CCITTRLEW";
-    public final static String CMPR_PACKBITS = "PackBits";
-    public final static String CMPR_NEXT = "NeXT";
-    public final static String CMPR_THUNDERSCAN = "ThunderScan";
-    public final static String CMPR_IT8CTPAD = "IT8CTPAD";
-    public final static String CMPR_IT8LW = "IT8LW";
-    public final static String CMPR_IT8MP = "IT8MP";
-    public final static String CMPR_IT8BL = "IT8BL";
-    public final static String CMPR_PIXAR_FILM = "PixarFilm";
-    public final static String CMPR_PIXAR_LOG = "PixarLog";
-    public final static String CMPR_DEFLATE = "Deflate";
-    public final static String CMPR_DCS = "DCS";
-    public final static String CMPR_SGILOG = "SGILog";
-    public final static String CMPR_SGILOG24 = "SGILog24";
+    public static final String CMPR_NONE = "Uncompressed";
 
+    public static final String CMPR_JP2 = "JPEG 2000";
+    public static final String CMPR_JP2_LOSSY = "JPEG 2000 Lossy";
+    public static final String CMPR_JP2_LOSSLESS = "JPEG 2000 Lossless";
+    public static final String CMPR_CCITT1D = "CCITT 1D";
+    public static final String CMPR_T4G3FAX = "T4/Group 3 Fax";
+    public static final String CMPR_T6G4FAX = "T6/Group 4 Fax";
+    public static final String CMPR_LZW = "LZW";
+    public static final String CMPR_JPEG_OLD = "JPEG (old-style)";
+    public static final String CMPR_JPEG = "JPEG";
+    public static final String CMPR_ADOBE_DEFLATE = "Adobe Deflate";
+    public static final String CMPR_JBIG = "JBIG";
+    public static final String CMPR_CCITTRLEW = "CCITTRLEW";
+    public static final String CMPR_PACKBITS = "PackBits";
+    public static final String CMPR_NEXT = "NeXT";
+    public static final String CMPR_THUNDERSCAN = "ThunderScan";
+    public static final String CMPR_IT8CTPAD = "IT8CTPAD";
+    public static final String CMPR_IT8LW = "IT8LW";
+    public static final String CMPR_IT8MP = "IT8MP";
+    public static final String CMPR_IT8BL = "IT8BL";
+    public static final String CMPR_PIXAR_FILM = "PixarFilm";
+    public static final String CMPR_PIXAR_LOG = "PixarLog";
+    public static final String CMPR_DEFLATE = "Deflate";
+    public static final String CMPR_DCS = "DCS";
+    public static final String CMPR_SGILOG = "SGILog";
+    public static final String CMPR_SGILOG24 = "SGILog24";
 
     private FitsMetadataValues() {
 
-    	mimeMap = parseFile(mimeMapProperties);
-    	formatMap = parseFile(formatMapProperties);
-    	mimeToFormatMap = parseFile(mimeToFormatMapProperties);
-
+        mimeMap = parseFile(mimeMapProperties);
+        formatMap = parseFile(formatMapProperties);
+        mimeToFormatMap = parseFile(mimeToFormatMapProperties);
     }
 
-	public static synchronized FitsMetadataValues getInstance() {
-		if (instance == null)
-			instance = new FitsMetadataValues();
+    public static synchronized FitsMetadataValues getInstance() {
+        if (instance == null) instance = new FitsMetadataValues();
 
-		return instance;
-	}
+        return instance;
+    }
 
     /** Do some normalization on variant MIME types. */
     public String normalizeMimeType(String mime) {
-        if (mime == null || mime.length()==0) {
+        if (mime == null || mime.length() == 0) {
             return DEFAULT_MIMETYPE;
         }
 
@@ -220,54 +219,55 @@ public class FitsMetadataValues {
         String normMime = mimeMap.get(mime);
         if (normMime != null) {
             return normMime;
-        }
-        else {
+        } else {
             return mime;
         }
     }
 
     public String normalizeFormat(String format) {
-        if (format == null || format.length()==0) {
+        if (format == null || format.length() == 0) {
             return DEFAULT_FORMAT;
         }
         String normformat = formatMap.get(format);
         if (normformat != null) {
             return normformat;
-        }
-        else {
+        } else {
             return format;
         }
     }
 
     public String getFormatForMime(String mime) {
-        if (mime == null || mime.length()==0) {
+        if (mime == null || mime.length() == 0) {
             return DEFAULT_FORMAT;
         }
         return mimeToFormatMap.get(mime);
     }
 
-    private HashMap<String,String> parseFile(String inputFile) {
-    	HashMap<String,String> map = new HashMap<String,String>();
-    	BufferedReader in = null;
-		try {
-			in = new BufferedReader(new FileReader(inputFile));
-			String line;
-			while ((line = in.readLine()) != null) {
-				if(!line.startsWith("#") && !line.startsWith("\"#") ) {
-					String[] parts = line.split("=");
-					if(parts.length != 2) {
-						logger.debug("Invalid map entry: " + line);
-						continue;
-					}
-					map.put(parts[0], parts[1]);
-				}
-			}
-		} catch (IOException e) {
-			logger.error("Error reading or parsing input file: " + inputFile, e);
-		}
-		finally {
-			if(in != null) try {in.close(); } catch (IOException e) { } // nothing to do if exception when closing file
-		}
-		return map;
+    private HashMap<String, String> parseFile(String inputFile) {
+        HashMap<String, String> map = new HashMap<String, String>();
+        BufferedReader in = null;
+        try {
+            in = new BufferedReader(new FileReader(inputFile));
+            String line;
+            while ((line = in.readLine()) != null) {
+                if (!line.startsWith("#") && !line.startsWith("\"#")) {
+                    String[] parts = line.split("=");
+                    if (parts.length != 2) {
+                        logger.debug("Invalid map entry: " + line);
+                        continue;
+                    }
+                    map.put(parts[0], parts[1]);
+                }
+            }
+        } catch (IOException e) {
+            logger.error("Error reading or parsing input file: " + inputFile, e);
+        } finally {
+            if (in != null)
+                try {
+                    in.close();
+                } catch (IOException e) {
+                } // nothing to do if exception when closing file
+        }
+        return map;
     }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/FitsOutput.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/FitsOutput.java
@@ -10,34 +10,6 @@
 
 package edu.harvard.hul.ois.fits;
 
-import java.io.ByteArrayOutputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-
-import org.jdom2.Attribute;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.JDOMException;
-import org.jdom2.Namespace;
-import org.jdom2.filter.Filters;
-import org.jdom2.input.SAXBuilder;
-import org.jdom2.output.Format;
-import org.jdom2.output.XMLOutputter;
-import org.jdom2.xpath.XPathExpression;
-import org.jdom2.xpath.XPathFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import edu.harvard.hul.ois.fits.exceptions.FitsException;
 import edu.harvard.hul.ois.fits.identity.ExternalIdentifier;
 import edu.harvard.hul.ois.fits.identity.FitsIdentity;
@@ -53,7 +25,31 @@ import edu.harvard.hul.ois.ots.schemas.Ebucore.EbuCoreMain;
 import edu.harvard.hul.ois.ots.schemas.MIX.Mix;
 import edu.harvard.hul.ois.ots.schemas.TextMD.TextMD;
 import edu.harvard.hul.ois.ots.schemas.XmlContent.XmlContent;
-
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import org.jdom2.Attribute;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.Namespace;
+import org.jdom2.filter.Filters;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class acts as a wrapper around the fitsXML JDOM Document and provides
@@ -64,420 +60,411 @@ import edu.harvard.hul.ois.ots.schemas.XmlContent.XmlContent;
  */
 public class FitsOutput {
 
-	private Document fitsXml;          // This is in the FITS XML format
-	private List<Throwable> caughtThrowables = new ArrayList<Throwable>();
-	private XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
-	private Namespace fitsNamespace = Namespace.getNamespace(Fits.XML_NAMESPACE);
-	private XPathFactory xFactory = XPathFactory.instance();
-	
-	private static final Logger logger = LoggerFactory.getLogger(FitsOutput.class);
+    private Document fitsXml; // This is in the FITS XML format
+    private List<Throwable> caughtThrowables = new ArrayList<Throwable>();
+    private XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
+    private Namespace fitsNamespace = Namespace.getNamespace(Fits.XML_NAMESPACE);
+    private XPathFactory xFactory = XPathFactory.instance();
 
-	public FitsOutput(String fitsXmlStr) throws JDOMException, IOException {
-		SAXBuilder builder = new SAXBuilder();
-		Reader in = new StringReader(fitsXmlStr);
-		Document fitsXml = builder.build(in);
-		this.fitsXml = fitsXml;
-	}
+    private static final Logger logger = LoggerFactory.getLogger(FitsOutput.class);
 
-	public FitsOutput(Document fitsXml) {
-		this.fitsXml = fitsXml;
-	}
+    public FitsOutput(String fitsXmlStr) throws JDOMException, IOException {
+        SAXBuilder builder = new SAXBuilder();
+        Reader in = new StringReader(fitsXmlStr);
+        Document fitsXml = builder.build(in);
+        this.fitsXml = fitsXml;
+    }
 
-	public void setFitsXml(Document fitsXml) {
-		this.fitsXml = fitsXml;
-	}
+    public FitsOutput(Document fitsXml) {
+        this.fitsXml = fitsXml;
+    }
 
-	public Document getFitsXml() {
-		return fitsXml;
-	}
+    public void setFitsXml(Document fitsXml) {
+        this.fitsXml = fitsXml;
+    }
 
-	public List<Throwable> getCaughtThrowables() {
-		return caughtThrowables;
-	}
+    public Document getFitsXml() {
+        return fitsXml;
+    }
 
-	public void setCaughtThrowables(List<Throwable> caughtThrowables) {
-		this.caughtThrowables = caughtThrowables;
-	}
+    public List<Throwable> getCaughtThrowables() {
+        return caughtThrowables;
+    }
 
-	@SuppressWarnings("unchecked")
-	public List<FitsMetadataElement> getFileInfoElements() {
-		Element root = fitsXml.getRootElement();
-		Element fileInfo = root.getChild("fileinfo",fitsNamespace);
-		return buildMetadataList(fileInfo);
-	}
+    public void setCaughtThrowables(List<Throwable> caughtThrowables) {
+        this.caughtThrowables = caughtThrowables;
+    }
 
-	@SuppressWarnings("unchecked")
-	public List<FitsMetadataElement> getFileStatusElements() {
-		Element root = fitsXml.getRootElement();
-		Element fileStatus = root.getChild("filestatus",fitsNamespace);
-		return buildMetadataList(fileStatus);
-	}
-
-	@SuppressWarnings("unchecked")
-	public List<FitsMetadataElement> getTechMetadataElements() {
-		Element root = fitsXml.getRootElement();
-		Element metadata = (Element)root.getChild("metadata",fitsNamespace);
-		if(metadata.getChildren().size() > 0) {
-			Element techMetadata = (Element)root.getChild("metadata",fitsNamespace).getChildren().get(0);
-			return buildMetadataList(techMetadata);
-		}
-		else {
-			return null;
-		}
-	}
-
-	public String getTechMetadataType() {
-		Element root = fitsXml.getRootElement();
-		Element metadata = (Element)root.getChild("metadata",fitsNamespace);
-		if(metadata.getChildren().size() > 0) {
-			Element techMetadata = (Element)root.getChild("metadata",fitsNamespace).getChildren().get(0);
-			return techMetadata.getName();
-		}
-		else {
-			return null;
-		}
-	}
-	
-	public FitsMetadataElement getFileInfoElement(String name) {
+    @SuppressWarnings("unchecked")
+    public List<FitsMetadataElement> getFileInfoElements() {
         Element root = fitsXml.getRootElement();
-        Element fileInfo = (Element)root.getChild("fileinfo", fitsNamespace);
-        if(fileInfo.getChildren().size() > 0) {
-            Element element = (Element)fileInfo.getChild(name,fitsNamespace);
-            if (element != null) {
-                return buildMetdataIElements(element);
-            }
-            else {
-                return null;
-            }
-        }
-        else {
+        Element fileInfo = root.getChild("fileinfo", fitsNamespace);
+        return buildMetadataList(fileInfo);
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<FitsMetadataElement> getFileStatusElements() {
+        Element root = fitsXml.getRootElement();
+        Element fileStatus = root.getChild("filestatus", fitsNamespace);
+        return buildMetadataList(fileStatus);
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<FitsMetadataElement> getTechMetadataElements() {
+        Element root = fitsXml.getRootElement();
+        Element metadata = (Element) root.getChild("metadata", fitsNamespace);
+        if (metadata.getChildren().size() > 0) {
+            Element techMetadata = (Element)
+                    root.getChild("metadata", fitsNamespace).getChildren().get(0);
+            return buildMetadataList(techMetadata);
+        } else {
             return null;
         }
     }
 
-	public FitsMetadataElement getMetadataElement(String name) {
-		XPathExpression<Element> expr = xFactory.compile("//fits:"+name, Filters.element(), null, fitsNamespace);
-		Element node = expr.evaluateFirst(fitsXml);
-		if(node != null) {
-			FitsMetadataElement element = buildMetdataIElements(node);
-			return element;
-		}
-		return null;
-	}
+    public String getTechMetadataType() {
+        Element root = fitsXml.getRootElement();
+        Element metadata = (Element) root.getChild("metadata", fitsNamespace);
+        if (metadata.getChildren().size() > 0) {
+            Element techMetadata = (Element)
+                    root.getChild("metadata", fitsNamespace).getChildren().get(0);
+            return techMetadata.getName();
+        } else {
+            return null;
+        }
+    }
 
-	public List<FitsMetadataElement> getMetadataElements(String name) {
-		List<FitsMetadataElement> elements = new ArrayList<FitsMetadataElement>();
-        XPathExpression<Element> expr = xFactory.compile("//fits:"+name, Filters.element(), null, fitsNamespace);
+    public FitsMetadataElement getFileInfoElement(String name) {
+        Element root = fitsXml.getRootElement();
+        Element fileInfo = (Element) root.getChild("fileinfo", fitsNamespace);
+        if (fileInfo.getChildren().size() > 0) {
+            Element element = (Element) fileInfo.getChild(name, fitsNamespace);
+            if (element != null) {
+                return buildMetdataIElements(element);
+            } else {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    public FitsMetadataElement getMetadataElement(String name) {
+        XPathExpression<Element> expr = xFactory.compile("//fits:" + name, Filters.element(), null, fitsNamespace);
+        Element node = expr.evaluateFirst(fitsXml);
+        if (node != null) {
+            FitsMetadataElement element = buildMetdataIElements(node);
+            return element;
+        }
+        return null;
+    }
+
+    public List<FitsMetadataElement> getMetadataElements(String name) {
+        List<FitsMetadataElement> elements = new ArrayList<FitsMetadataElement>();
+        XPathExpression<Element> expr = xFactory.compile("//fits:" + name, Filters.element(), null, fitsNamespace);
         List<Element> nodes = expr.evaluate(fitsXml);
-		for(Element e : nodes) {
-			elements.add(buildMetdataIElements(e));
-		}
-		return elements;
-	}
+        for (Element e : nodes) {
+            elements.add(buildMetdataIElements(e));
+        }
+        return elements;
+    }
 
-	public boolean hasMetadataElement(String name) {
-		FitsMetadataElement element = getMetadataElement(name);
-		if(element != null) {
-			return true;
-		}
-		else {
-			return false;
-		}
-	}
+    public boolean hasMetadataElement(String name) {
+        FitsMetadataElement element = getMetadataElement(name);
+        if (element != null) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 
-	public Boolean hasConflictingMetadataElements(String name) {
-		List<FitsMetadataElement> elements = getMetadataElements(name);
-		if(elements.size() > 1) {
-			String elementStatus = elements.get(0).getStatus();
-			if(elementStatus != null && elementStatus.equalsIgnoreCase("conflict")) {
-				return true;
-			}
-			else {
-				return false;
-			}
-		}
-		else {
-			return null;
-		}
-	}
+    public Boolean hasConflictingMetadataElements(String name) {
+        List<FitsMetadataElement> elements = getMetadataElements(name);
+        if (elements.size() > 1) {
+            String elementStatus = elements.get(0).getStatus();
+            if (elementStatus != null && elementStatus.equalsIgnoreCase("conflict")) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return null;
+        }
+    }
 
-	private List buildMetadataList(Element parent) {
-		List<FitsMetadataElement> data = new ArrayList<FitsMetadataElement>();
-		if(parent == null) {
-			return null;
-		}
-		for(Element child : (List<Element>)parent.getChildren()) {
-			data.add(buildMetdataIElements(child));
-		}
-		return data;
-	}
+    private List buildMetadataList(Element parent) {
+        List<FitsMetadataElement> data = new ArrayList<FitsMetadataElement>();
+        if (parent == null) {
+            return null;
+        }
+        for (Element child : (List<Element>) parent.getChildren()) {
+            data.add(buildMetdataIElements(child));
+        }
+        return data;
+    }
 
-	private FitsMetadataElement buildMetdataIElements(Element node) {
-		FitsMetadataElement element = new FitsMetadataElement();
-		element.setName(node.getName());
-		element.setValue(node.getValue());
-		Attribute toolName = node.getAttribute("toolname");
-		if(toolName != null) {
-			element.setReportingToolName(toolName.getValue());
-		}
-		Attribute toolVersion = node.getAttribute("toolversion");
-		if(toolVersion != null) {
-			element.setReportingToolVersion(toolVersion.getValue());
-		}
-		Attribute status = node.getAttribute("status");
-		if(status != null) {
-			element.setStatus(status.getValue());
-		}
-		return element;
-	}
+    private FitsMetadataElement buildMetdataIElements(Element node) {
+        FitsMetadataElement element = new FitsMetadataElement();
+        element.setName(node.getName());
+        element.setValue(node.getValue());
+        Attribute toolName = node.getAttribute("toolname");
+        if (toolName != null) {
+            element.setReportingToolName(toolName.getValue());
+        }
+        Attribute toolVersion = node.getAttribute("toolversion");
+        if (toolVersion != null) {
+            element.setReportingToolVersion(toolVersion.getValue());
+        }
+        Attribute status = node.getAttribute("status");
+        if (status != null) {
+            element.setStatus(status.getValue());
+        }
+        return element;
+    }
 
-	public void saveToDisk(String location) throws IOException {
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		OutputStreamWriter out = new OutputStreamWriter(new FileOutputStream(location),"UTF-8");
-		serializer.output(fitsXml, out);
-		out.close();
-	}
+    public void saveToDisk(String location) throws IOException {
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        OutputStreamWriter out = new OutputStreamWriter(new FileOutputStream(location), "UTF-8");
+        serializer.output(fitsXml, out);
+        out.close();
+    }
 
-	public void output(OutputStream outstream) throws IOException {
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		OutputStreamWriter out = new OutputStreamWriter(outstream,"UTF-8");
-		serializer.output(fitsXml, out);
-		out.close();
-	}
+    public void output(OutputStream outstream) throws IOException {
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        OutputStreamWriter out = new OutputStreamWriter(outstream, "UTF-8");
+        serializer.output(fitsXml, out);
+        out.close();
+    }
 
     public Boolean checkWellFormed() {
-		FitsMetadataElement wellFormed = getMetadataElement("well-formed");
-		if(wellFormed != null) {
-			return Boolean.valueOf(wellFormed.getValue());
-		}
-		return null;
+        FitsMetadataElement wellFormed = getMetadataElement("well-formed");
+        if (wellFormed != null) {
+            return Boolean.valueOf(wellFormed.getValue());
+        }
+        return null;
     }
 
     public Boolean checkValid() {
-		FitsMetadataElement valid = getMetadataElement("valid");
-		if(valid != null) {
-			return Boolean.valueOf(valid.getValue());
-		}
-		return null;
+        FitsMetadataElement valid = getMetadataElement("valid");
+        if (valid != null) {
+            return Boolean.valueOf(valid.getValue());
+        }
+        return null;
     }
 
     public String getErrorMessages() {
-    	List<FitsMetadataElement> statusElements = getFileStatusElements();
-    	String errorMessages = new String();
-		for(FitsMetadataElement element : statusElements) {
-			if(element.getName() == "message") {
-				errorMessages = errorMessages+"\n"+element.getValue();
-			}
-		}
-		return errorMessages;
+        List<FitsMetadataElement> statusElements = getFileStatusElements();
+        String errorMessages = new String();
+        for (FitsMetadataElement element : statusElements) {
+            if (element.getName() == "message") {
+                errorMessages = errorMessages + "\n" + element.getValue();
+            }
+        }
+        return errorMessages;
     }
 
     /** Return an XmlContent object representing the data from fitsXml. */
-    public XmlContent getStandardXmlContent () {
+    public XmlContent getStandardXmlContent() {
 
-        Element metadata = fitsXml.getRootElement().getChild("metadata",fitsNamespace);
+        Element metadata = fitsXml.getRootElement().getChild("metadata", fitsNamespace);
 
-        if(metadata == null) {
-        	return null;
+        if (metadata == null) {
+            return null;
         }
 
-        XmlContentConverter conv = new XmlContentConverter ();
+        XmlContentConverter conv = new XmlContentConverter();
 
-        //Element metadata = root.getChild("metadata");
+        // Element metadata = root.getChild("metadata");
         // This can have an image, document, text, or audio subelement.
-        Element subElem = metadata.getChild ("image",fitsNamespace);
+        Element subElem = metadata.getChild("image", fitsNamespace);
         if (subElem != null) {
-        	Element fileinfo = fitsXml.getRootElement().getChild("fileinfo",fitsNamespace);
+            Element fileinfo = fitsXml.getRootElement().getChild("fileinfo", fitsNamespace);
             // Process image metadata...
-        	return (Mix) conv.toMix (subElem,fileinfo);
+            return (Mix) conv.toMix(subElem, fileinfo);
         }
-        subElem = metadata.getChild ("text",fitsNamespace);
+        subElem = metadata.getChild("text", fitsNamespace);
         if (subElem != null) {
-        	// Process text metadata...
-        	return (TextMD) conv.toTextMD (subElem);
+            // Process text metadata...
+            return (TextMD) conv.toTextMD(subElem);
         }
-        subElem = metadata.getChild ("document",fitsNamespace);
+        subElem = metadata.getChild("document", fitsNamespace);
         if (subElem != null) {
             // Process document metadata...
-        	return (DocumentMD)conv.toDocumentMD (subElem);
+            return (DocumentMD) conv.toDocumentMD(subElem);
         }
-        subElem = metadata.getChild ("audio",fitsNamespace);
+        subElem = metadata.getChild("audio", fitsNamespace);
         if (subElem != null) {
             // Process audio metadata...
-        	return (AudioObject)conv.toAES (this,subElem);
+            return (AudioObject) conv.toAES(this, subElem);
         }
-        subElem = metadata.getChild ("video",fitsNamespace);
+        subElem = metadata.getChild("video", fitsNamespace);
         if (subElem != null) {
-        	// Process video metadata...
-        	return (EbuCoreMain)conv.toEbuCoreVideo(this,subElem);
+            // Process video metadata...
+            return (EbuCoreMain) conv.toEbuCoreVideo(this, subElem);
         }
-        subElem = metadata.getChild ("container",fitsNamespace);
+        subElem = metadata.getChild("container", fitsNamespace);
         if (subElem != null) {
-        	// Process container metadata...
-        	return (ContainerMd)conv.toContainerMD(subElem);
+            // Process container metadata...
+            return (ContainerMd) conv.toContainerMD(subElem);
         }
-        
+
         return null;
     }
 
     public void addStandardCombinedFormat() throws XMLStreamException, IOException, FitsException {
-		//get the normal fits xml output
-		Namespace ns = Namespace.getNamespace(Fits.XML_NAMESPACE);
+        // get the normal fits xml output
+        Namespace ns = Namespace.getNamespace(Fits.XML_NAMESPACE);
 
-		Element metadata = (Element) fitsXml.getRootElement().getChild("metadata",ns);
-		Element techmd = null;
-		if(metadata.getChildren().size() > 0) {
-			techmd = (Element) metadata.getChildren().get(0);
-		}
+        Element metadata = (Element) fitsXml.getRootElement().getChild("metadata", ns);
+        Element techmd = null;
+        if (metadata.getChildren().size() > 0) {
+            techmd = (Element) metadata.getChildren().get(0);
+        }
 
-		//if we have technical metadata convert it to the standard form
-		if(techmd != null && techmd.getChildren().size() > 0) {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			XmlContent xml = getStandardXmlContent();
-			if(xml != null) {
-				XMLStreamWriter sw = xmlOutputFactory.createXMLStreamWriter(baos);
-				xml.output(sw);
+        // if we have technical metadata convert it to the standard form
+        if (techmd != null && techmd.getChildren().size() > 0) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            XmlContent xml = getStandardXmlContent();
+            if (xml != null) {
+                XMLStreamWriter sw = xmlOutputFactory.createXMLStreamWriter(baos);
+                xml.output(sw);
 
-				String stdxml = baos.toString("UTF-8");
+                String stdxml = baos.toString("UTF-8");
 
-				//convert the std xml back to a JDOM element so we can insert it back into the fitsXml Document
-				try {
-					StringReader sReader = new StringReader(stdxml);
-					SAXBuilder saxBuilder = new SAXBuilder();
-					Document stdXmlDoc = saxBuilder.build(sReader);
-					Element stdElement = new Element("standard",ns);
-					stdElement.addContent(stdXmlDoc.getRootElement().detach());
-					techmd.addContent(stdElement);
+                // convert the std xml back to a JDOM element so we can insert it back into the fitsXml Document
+                try {
+                    StringReader sReader = new StringReader(stdxml);
+                    SAXBuilder saxBuilder = new SAXBuilder();
+                    Document stdXmlDoc = saxBuilder.build(sReader);
+                    Element stdElement = new Element("standard", ns);
+                    stdElement.addContent(stdXmlDoc.getRootElement().detach());
+                    techmd.addContent(stdElement);
 
-				}
-				catch(JDOMException e) {
-					throw new FitsException("error converting standard XML", e);
-				}
-			}
-		}
+                } catch (JDOMException e) {
+                    throw new FitsException("error converting standard XML", e);
+                }
+            }
+        }
     }
 
-	public List<FitsIdentity> getIdentities() {
-		List<FitsIdentity> identities = new ArrayList<FitsIdentity>();
-	    Namespace ns = Namespace.getNamespace("fits", Fits.XML_NAMESPACE);
+    public List<FitsIdentity> getIdentities() {
+        List<FitsIdentity> identities = new ArrayList<FitsIdentity>();
+        Namespace ns = Namespace.getNamespace("fits", Fits.XML_NAMESPACE);
         XPathExpression<Element> expr = xFactory.compile("//fits:identity", Filters.element(), null, ns);
         List<Element> identElements = (List<Element>) expr.evaluate(fitsXml);
-		for(Element element : identElements) {
-			FitsIdentity fileIdentSect = new FitsIdentity();
+        for (Element element : identElements) {
+            FitsIdentity fileIdentSect = new FitsIdentity();
 
-			//get the identity attributes
-			Attribute formatAttr = element.getAttribute("format");
-			Attribute mimetypeAttr = element.getAttribute("mimetype");
-			if(formatAttr != null) {
-				fileIdentSect.setFormat(formatAttr.getValue());
-			}
-			if(mimetypeAttr != null) {
-				fileIdentSect.setMimetype(mimetypeAttr.getValue());
-			}
+            // get the identity attributes
+            Attribute formatAttr = element.getAttribute("format");
+            Attribute mimetypeAttr = element.getAttribute("mimetype");
+            if (formatAttr != null) {
+                fileIdentSect.setFormat(formatAttr.getValue());
+            }
+            if (mimetypeAttr != null) {
+                fileIdentSect.setMimetype(mimetypeAttr.getValue());
+            }
 
-			//get the tool elements
-			List<Element> toolElements = element.getChildren("tool",fitsNamespace);
-			for(Element toolElement : toolElements) {
-				ToolInfo toolInfo = new ToolInfo();
-				Attribute toolNameAttr = toolElement.getAttribute("toolname");
-				Attribute toolVersionAttr = toolElement.getAttribute("toolversion");
-				if(toolNameAttr != null) {
-					toolInfo.setName(toolNameAttr.getValue());
-				}
-				if(toolVersionAttr != null) {
-					toolInfo.setVersion(toolVersionAttr.getValue());
-				}
-				fileIdentSect.addReportingTool(toolInfo);
-			}
+            // get the tool elements
+            List<Element> toolElements = element.getChildren("tool", fitsNamespace);
+            for (Element toolElement : toolElements) {
+                ToolInfo toolInfo = new ToolInfo();
+                Attribute toolNameAttr = toolElement.getAttribute("toolname");
+                Attribute toolVersionAttr = toolElement.getAttribute("toolversion");
+                if (toolNameAttr != null) {
+                    toolInfo.setName(toolNameAttr.getValue());
+                }
+                if (toolVersionAttr != null) {
+                    toolInfo.setVersion(toolVersionAttr.getValue());
+                }
+                fileIdentSect.addReportingTool(toolInfo);
+            }
 
-			//get the version elements
-			List<Element> versionElements = element.getChildren("version",fitsNamespace);
-			for(Element versionElement : versionElements) {
-				ToolInfo toolInfo = new ToolInfo();
-				Attribute toolNameAttr = versionElement.getAttribute("toolname");
-				Attribute toolVersionAttr = versionElement.getAttribute("toolversion");
-				if(toolNameAttr != null) {
-					toolInfo.setName(toolNameAttr.getValue());
-				}
-				if(toolVersionAttr != null) {
-					toolInfo.setVersion(toolVersionAttr.getValue());
-				}
-				String value = versionElement.getText();
-				FormatVersion formatVersion = new FormatVersion(value,toolInfo);
-				fileIdentSect.addFormatVersion(formatVersion);
-			}
+            // get the version elements
+            List<Element> versionElements = element.getChildren("version", fitsNamespace);
+            for (Element versionElement : versionElements) {
+                ToolInfo toolInfo = new ToolInfo();
+                Attribute toolNameAttr = versionElement.getAttribute("toolname");
+                Attribute toolVersionAttr = versionElement.getAttribute("toolversion");
+                if (toolNameAttr != null) {
+                    toolInfo.setName(toolNameAttr.getValue());
+                }
+                if (toolVersionAttr != null) {
+                    toolInfo.setVersion(toolVersionAttr.getValue());
+                }
+                String value = versionElement.getText();
+                FormatVersion formatVersion = new FormatVersion(value, toolInfo);
+                fileIdentSect.addFormatVersion(formatVersion);
+            }
 
-			//get the externalIdentifier elements
-			List<Element> xIDElements = element.getChildren("externalIdentifier",fitsNamespace);
-			for(Element xIDElement : xIDElements) {
-				String type = xIDElement.getAttributeValue("type");
-				String value = xIDElement.getText();
-				ToolInfo toolInfo = new ToolInfo();
-				Attribute toolNameAttr = xIDElement.getAttribute("toolname");
-				Attribute toolVersionAttr = xIDElement.getAttribute("toolversion");
-				if(toolNameAttr != null) {
-					toolInfo.setName(toolNameAttr.getValue());
-				}
-				if(toolVersionAttr != null) {
-					toolInfo.setVersion(toolVersionAttr.getValue());
-				}
-				ExternalIdentifier xid = new ExternalIdentifier(type,value,toolInfo);
-				fileIdentSect.addExternalID(xid);
-			}
-			identities.add(fileIdentSect);
-		}
-		return identities;
-	}
+            // get the externalIdentifier elements
+            List<Element> xIDElements = element.getChildren("externalIdentifier", fitsNamespace);
+            for (Element xIDElement : xIDElements) {
+                String type = xIDElement.getAttributeValue("type");
+                String value = xIDElement.getText();
+                ToolInfo toolInfo = new ToolInfo();
+                Attribute toolNameAttr = xIDElement.getAttribute("toolname");
+                Attribute toolVersionAttr = xIDElement.getAttribute("toolversion");
+                if (toolNameAttr != null) {
+                    toolInfo.setName(toolNameAttr.getValue());
+                }
+                if (toolVersionAttr != null) {
+                    toolInfo.setVersion(toolVersionAttr.getValue());
+                }
+                ExternalIdentifier xid = new ExternalIdentifier(type, value, toolInfo);
+                fileIdentSect.addExternalID(xid);
+            }
+            identities.add(fileIdentSect);
+        }
+        return identities;
+    }
 
-	public void createStatistics(ToolBelt toolBelt, long totalExecutionTime) {
-		Element root = fitsXml.getRootElement();
-		Element statistics = new Element("statistics", fitsNamespace);
+    public void createStatistics(ToolBelt toolBelt, long totalExecutionTime) {
+        Element root = fitsXml.getRootElement();
+        Element statistics = new Element("statistics", fitsNamespace);
 
-		for(Tool t: toolBelt.getTools()) {
+        for (Tool t : toolBelt.getTools()) {
 
-			//if the tool should have been used for the file, else ignore it because it did not run
-			ToolInfo info = t.getToolInfo();
-			Element tool = new Element("tool", fitsNamespace);
-			tool.setAttribute("toolname", info.getName());
-			tool.setAttribute("toolversion", info.getVersion());
+            // if the tool should have been used for the file, else ignore it because it did not run
+            ToolInfo info = t.getToolInfo();
+            Element tool = new Element("tool", fitsNamespace);
+            tool.setAttribute("toolname", info.getName());
+            tool.setAttribute("toolversion", info.getVersion());
 
-			//if the tool ran successfully then output the execution time
-			if(t.getRunStatus() == RunStatus.SUCCESSFUL) {
-				tool.setAttribute("executionTime",String.valueOf(t.getDuration()));
-			}
-			//else if the tool should have run but never changed to a successful state
-			else if (t.getRunStatus() == RunStatus.SHOULDRUN){
-				tool.setAttribute("status","failed");
-			}
-			//else if the tool should have run but never changed to a successful state
-			else if (t.getRunStatus() == RunStatus.SHOULDNOTRUN){
-				tool.setAttribute("status","did not run");
-			}
-			else if (t.getRunStatus() == RunStatus.FAILED){
-				tool.setAttribute("status","failed");
-			}
+            // if the tool ran successfully then output the execution time
+            if (t.getRunStatus() == RunStatus.SUCCESSFUL) {
+                tool.setAttribute("executionTime", String.valueOf(t.getDuration()));
+            }
+            // else if the tool should have run but never changed to a successful state
+            else if (t.getRunStatus() == RunStatus.SHOULDRUN) {
+                tool.setAttribute("status", "failed");
+            }
+            // else if the tool should have run but never changed to a successful state
+            else if (t.getRunStatus() == RunStatus.SHOULDNOTRUN) {
+                tool.setAttribute("status", "did not run");
+            } else if (t.getRunStatus() == RunStatus.FAILED) {
+                tool.setAttribute("status", "failed");
+            }
 
-			statistics.addContent(tool);
+            statistics.addContent(tool);
+        }
+        statistics.setAttribute("fitsExecutionTime", String.valueOf(totalExecutionTime));
 
-		}
-		statistics.setAttribute("fitsExecutionTime", String.valueOf(totalExecutionTime));
+        root.addContent(statistics);
+    }
 
-		root.addContent(statistics);
+    /**
+     * This is the version of FITS that created the input file of this instance.
+     * @return The FITS version of the input file.
+     */
+    public String getFitsVersion() {
 
-	}
-	
-	/**
-	 * This is the version of FITS that created the input file of this instance.
-	 * @return The FITS version of the input file.
-	 */
-	public String getFitsVersion() {
-		
-		String fitsVersion = null;
-		Element root = fitsXml.getRootElement();
-		Attribute fitsVersionAttr = root.getAttribute("version");
-		if (fitsVersionAttr != null) {
-			fitsVersion = fitsVersionAttr.getValue();
-		}
-		return fitsVersion;
-	}
+        String fitsVersion = null;
+        Element root = fitsXml.getRootElement();
+        Attribute fitsVersionAttr = root.getAttribute("version");
+        if (fitsVersionAttr != null) {
+            fitsVersion = fitsVersionAttr.getValue();
+        }
+        return fitsVersion;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/FormatElements.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/FormatElements.java
@@ -11,36 +11,35 @@
 package edu.harvard.hul.ois.fits;
 
 public enum FormatElements {
-	size ("fileSize"),
-	filename ("fileName"),
-	mimeType ("mimeType"),
-	location ("location"),
-	bitRate ("bitRate"),
-	dateCreated ("dateCreated"),
-	dateModified ("dateModified"),
-	formatProfile ("formatProfile"),
-	format ("format"),
-	duration ("duration");
+    size("fileSize"),
+    filename("fileName"),
+    mimeType("mimeType"),
+    location("location"),
+    bitRate("bitRate"),
+    dateCreated("dateCreated"),
+    dateModified("dateModified"),
+    formatProfile("formatProfile"),
+    format("format"),
+    duration("duration");
 
-	private String ebucoreName;
+    private String ebucoreName;
 
-	FormatElements(String ebucoreName) {
+    FormatElements(String ebucoreName) {
         this.ebucoreName = ebucoreName;
     }
 
-    public String getEbucoreName () {
+    public String getEbucoreName() {
         return ebucoreName;
     }
 
-    static public FormatElements lookup(String name) {
-    	FormatElements retMethod = null;
-    	for(FormatElements method : FormatElements.values()) {
-    		if (method.name().equals(name)) {
-    			retMethod = method;
-    			break;
-    		}
-    	}
-    	return retMethod;
+    public static FormatElements lookup(String name) {
+        FormatElements retMethod = null;
+        for (FormatElements method : FormatElements.values()) {
+            if (method.name().equals(name)) {
+                retMethod = method;
+                break;
+            }
+        }
+        return retMethod;
     }
-
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/MixModel.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/MixModel.java
@@ -10,8 +10,6 @@
 
 package edu.harvard.hul.ois.fits;
 
-import java.util.StringTokenizer;
-
 import edu.harvard.hul.ois.ots.schemas.MIX.BasicDigitalObjectInformation;
 import edu.harvard.hul.ois.ots.schemas.MIX.BasicImageCharacteristics;
 import edu.harvard.hul.ois.ots.schemas.MIX.BasicImageInformation;
@@ -26,6 +24,7 @@ import edu.harvard.hul.ois.ots.schemas.MIX.EncodingOptions;
 import edu.harvard.hul.ois.ots.schemas.MIX.GPSData;
 import edu.harvard.hul.ois.ots.schemas.MIX.GPSDestLatitude;
 import edu.harvard.hul.ois.ots.schemas.MIX.GPSDestLongitude;
+import edu.harvard.hul.ois.ots.schemas.MIX.GPSItudeElement;
 import edu.harvard.hul.ois.ots.schemas.MIX.GPSLatitude;
 import edu.harvard.hul.ois.ots.schemas.MIX.GPSLongitude;
 import edu.harvard.hul.ois.ots.schemas.MIX.GeneralCaptureInformation;
@@ -50,9 +49,9 @@ import edu.harvard.hul.ois.ots.schemas.MIX.WhitePoint;
 import edu.harvard.hul.ois.ots.schemas.MIX.YCbCr;
 import edu.harvard.hul.ois.ots.schemas.MIX.YCbCrCoefficients;
 import edu.harvard.hul.ois.ots.schemas.MIX.YCbCrSubSampling;
-import edu.harvard.hul.ois.ots.schemas.MIX.GPSItudeElement;
 import edu.harvard.hul.ois.ots.schemas.XmlContent.Rational;
 import edu.harvard.hul.ois.ots.schemas.XmlContent.XmlContentException;
+import java.util.StringTokenizer;
 
 /** This class represents a Mix object, with various convenient functions for use by
  *  XmlContentConverter in building up the structure. It's a captive class with no
@@ -90,74 +89,70 @@ public class MixModel {
     protected GPSData gps;
     protected Colormap cm;
 
-
-
-    protected MixModel () {
-        mix = new Mix ();
+    protected MixModel() {
+        mix = new Mix();
         try {
-             // Add the top-level elements to the mix element, to make life simpler.
+            // Add the top-level elements to the mix element, to make life simpler.
             bdoi = new BasicDigitalObjectInformation();
             mix.setBasicDigitalObjectInformation(bdoi);
-            bii = new BasicImageInformation ();
-            mix.setBasicImageInformation (bii);
-            bic = new BasicImageCharacteristics ();
-            bii.setBasicImageCharacteristics (bic);
-            phi = new PhotometricInterpretation ();
+            bii = new BasicImageInformation();
+            mix.setBasicImageInformation(bii);
+            bic = new BasicImageCharacteristics();
+            bii.setBasicImageCharacteristics(bic);
+            phi = new PhotometricInterpretation();
             bic.setPhotometricInterpetation(phi);
-            icm = new ImageCaptureMetadata ();
+            icm = new ImageCaptureMetadata();
             mix.setImageCaptureMetadata(icm);
             iam = new ImageAssessmentMetadata();
             mix.setImageAssessmentMetadata(iam);
-            sm = new SpatialMetrics ();
+            sm = new SpatialMetrics();
             iam.setSpatialMetrics(sm);
-            ice = new ImageColorEncoding ();
+            ice = new ImageColorEncoding();
             iam.setImageColorEncoding(ice);
-            gci = new GeneralCaptureInformation ();
+            gci = new GeneralCaptureInformation();
             icm.setGeneralCaptureInformation(gci);
 
             // Here are some pieces which are constructed once, but added only if they're needed.
-            cp = new ColorProfile ();           // Add this to phi if needed
-            iccp = new IccProfile();            // Add this to cp if needed
-            ycbcr = new YCbCr ();               // Add this to phi if needed
-            sfc = new SpecialFormatCharacteristics();  // Add this to bii if needed
-            jp2000 = new JPEG2000 ();           // Add this to sfc if needed
-            eo = new EncodingOptions ();
-            tiles = new Tiles ();               // Add this to eo if needed
-            wp = null;                          // We leave this null so we can tell if it's been created
-            pc = null;                          // We leave this null so we can tell if it's been created
-            sc = new ScannerCapture ();         // Add this to icm if needed
-            scanm = new ScannerModel ();        // Add this to sc if needed
-            sss = new ScanningSystemSoftware ();  // add this to sc if needed
-            id = new ImageData ();              // Add this to ccs if needed
-            gps = new GPSData ();               // Add this to ccs if needed
-            sd = new SubjectDistance ();        // Add this to id if needed
+            cp = new ColorProfile(); // Add this to phi if needed
+            iccp = new IccProfile(); // Add this to cp if needed
+            ycbcr = new YCbCr(); // Add this to phi if needed
+            sfc = new SpecialFormatCharacteristics(); // Add this to bii if needed
+            jp2000 = new JPEG2000(); // Add this to sfc if needed
+            eo = new EncodingOptions();
+            tiles = new Tiles(); // Add this to eo if needed
+            wp = null; // We leave this null so we can tell if it's been created
+            pc = null; // We leave this null so we can tell if it's been created
+            sc = new ScannerCapture(); // Add this to icm if needed
+            scanm = new ScannerModel(); // Add this to sc if needed
+            sss = new ScanningSystemSoftware(); // add this to sc if needed
+            id = new ImageData(); // Add this to ccs if needed
+            gps = new GPSData(); // Add this to ccs if needed
+            sd = new SubjectDistance(); // Add this to id if needed
 
             // Build DigitalCameraCapture with subelements, but don't hook it to icm
             // until it's needed.
-            dcc = new DigitalCameraCapture ();
-            dcm = new DigitalCameraModel ();
+            dcc = new DigitalCameraCapture();
+            dcm = new DigitalCameraModel();
             dcc.setDigitalCameraModel(dcm);
-            ccs = new CameraCaptureSettings ();
+            ccs = new CameraCaptureSettings();
             dcc.setCameraCaptureSettings(ccs);
 
             cm = new Colormap();
-        }
-        catch (XmlContentException e) {
+        } catch (XmlContentException e) {
             // Should never happen, unless the code is buggy
         }
     }
 
     /** Fill out a YCbCrSubSampling element, tokenizing the value */
-    protected void populateYCbCrSS (YCbCrSubSampling ycbcrss, String data) {
+    protected void populateYCbCrSS(YCbCrSubSampling ycbcrss, String data) {
         // Separation by spaces is easy material for an ordinary StringTokenizer
-        StringTokenizer tok = new StringTokenizer (data);
+        StringTokenizer tok = new StringTokenizer(data);
         int hor;
         int ver;
         try {
-            hor = Integer.parseInt (tok.nextToken ());
-            ver = Integer.parseInt (tok.nextToken ());
-        }
-        catch (Exception e) {
+            hor = Integer.parseInt(tok.nextToken());
+            ver = Integer.parseInt(tok.nextToken());
+        } catch (Exception e) {
             // Malformed data
             return;
         }
@@ -166,289 +161,266 @@ public class MixModel {
             ycbcrss.setYCbCrSubsampleHoriz(hor);
             ycbcrss.setYCbCrSubsampleVert(ver);
             phi.setYCbCr(ycbcr);
-        }
-        catch (XmlContentException e) {
+        } catch (XmlContentException e) {
         }
     }
 
-    protected void populateYCbCrCoefficients (String data) {
-        StringTokenizer tok = new StringTokenizer (data);
+    protected void populateYCbCrCoefficients(String data) {
+        StringTokenizer tok = new StringTokenizer(data);
         double red;
         double green;
         double blue;
         try {
-            red = Double.parseDouble (tok.nextToken ());
-            green = Double.parseDouble (tok.nextToken ());
-            blue = Double.parseDouble (tok.nextToken ());
-        }
-        catch (Exception e) {
+            red = Double.parseDouble(tok.nextToken());
+            green = Double.parseDouble(tok.nextToken());
+            blue = Double.parseDouble(tok.nextToken());
+        } catch (Exception e) {
             // Malformed data
             return;
         }
-        YCbCrCoefficients ycbcrc = new YCbCrCoefficients ();
+        YCbCrCoefficients ycbcrc = new YCbCrCoefficients();
         try {
             ycbcr.setYCbCrCoefficients(ycbcrc);
-            phi.setYCbCr (ycbcr);
-            ycbcrc.setLumaRed(new Rational ((int) (red * 100), 100));
-            ycbcrc.setLumaGreen(new Rational ((int) (green * 100), 100));
-            ycbcrc.setLumaBlue(new Rational ((int) (blue * 100), 100));
+            phi.setYCbCr(ycbcr);
+            ycbcrc.setLumaRed(new Rational((int) (red * 100), 100));
+            ycbcrc.setLumaGreen(new Rational((int) (green * 100), 100));
+            ycbcrc.setLumaBlue(new Rational((int) (blue * 100), 100));
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
-
-    protected void populateJPEG2000 () {
+    protected void populateJPEG2000() {
         try {
             bii.setSpecialFormatCharacteristics(sfc);
             sfc.setJPEG2000(jp2000);
             jp2000.setEncodingOptions(eo);
             eo.setTiles(tiles);
-        }
-        catch (XmlContentException e) {
+        } catch (XmlContentException e) {
         }
     }
 
-    protected void populateWhitePoint () {
+    protected void populateWhitePoint() {
         try {
             if (wp == null) {
-                wp = new WhitePoint ();
-                ice.addWhitePoint (wp);
+                wp = new WhitePoint();
+                ice.addWhitePoint(wp);
             }
-        }
-        catch (XmlContentException e) {
+        } catch (XmlContentException e) {
         }
     }
 
-    protected void populatePrimaryChromaticities () {
+    protected void populatePrimaryChromaticities() {
         try {
             if (pc == null) {
-                pc = new PrimaryChromaticities ();
+                pc = new PrimaryChromaticities();
                 ice.addPrimaryChromaticities(pc);
             }
-        }
-        catch (XmlContentException e) {
+        } catch (XmlContentException e) {
         }
     }
 
-
-    //bits per sample in FITS should be in the form "8 8 8", with all values
+    // bits per sample in FITS should be in the form "8 8 8", with all values
     //  concatenated together separated by a space.
-    protected void setBitsPerSample (String stringBPS) {
+    protected void setBitsPerSample(String stringBPS) {
         try {
-            BitsPerSample bps = new BitsPerSample ();
-            bps.setBitsPerSampleUnit ("integer");
+            BitsPerSample bps = new BitsPerSample();
+            bps.setBitsPerSampleUnit("integer");
             String[] bpsParts = stringBPS.split(" ");
-            for(int i=0;i<bpsParts.length; i++) {
-            	bps.addBitsPerSampleValue(Integer.parseInt(bpsParts[i]));
+            for (int i = 0; i < bpsParts.length; i++) {
+                bps.addBitsPerSampleValue(Integer.parseInt(bpsParts[i]));
             }
-            ice.setBitsPerSample (bps);
-        }
-        catch (XmlContentException e) {
+            ice.setBitsPerSample(bps);
+        } catch (XmlContentException e) {
         }
     }
-
-
 
     /** Make the ColorProfile and ICCProfile part of the MIX */
-    protected void attachIccp () {
+    protected void attachIccp() {
         try {
             phi.setColorProfile(cp);
             cp.setIccProfile(iccp);
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
     /** Make the ScannerCapture part of the MIX */
-    protected void attachScannerCapture () {
+    protected void attachScannerCapture() {
         try {
-            icm.setScannerCapture (sc);
+            icm.setScannerCapture(sc);
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
-    protected void attachScanningSystemSoftware () {
+    protected void attachScanningSystemSoftware() {
         try {
-            icm.setScannerCapture (sc);
+            icm.setScannerCapture(sc);
             sc.setScanningSystemSoftware(sss);
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
-    protected void attachImageData () {
+    protected void attachImageData() {
         try {
-            ccs.setImageData (id);
+            ccs.setImageData(id);
             sc.setScanningSystemSoftware(sss);
-            icm.setDigitalCameraCapture (dcc);
+            icm.setDigitalCameraCapture(dcc);
             // The links in between are already set up
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
-    protected void attachGPSData () {
+    protected void attachGPSData() {
         try {
-            ccs.setGPSData (gps);
+            ccs.setGPSData(gps);
             sc.setScanningSystemSoftware(sss);
-            icm.setDigitalCameraCapture (dcc);
+            icm.setDigitalCameraCapture(dcc);
             // The links in between are already set up
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
-    protected void populateGPSLongitude (String longitude) {
-        attachGPSData ();
-        GPSLongitude longit = new GPSLongitude ();
-        parseItude (longit, longitude);
+    protected void populateGPSLongitude(String longitude) {
+        attachGPSData();
+        GPSLongitude longit = new GPSLongitude();
+        parseItude(longit, longitude);
         try {
             gps.setGPSLongitude(longit);
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
-    protected void populateGPSLatitude (String latitude) {
-        attachGPSData ();
-        GPSLatitude latit = new GPSLatitude ();
-        parseItude (latit, latitude);
+    protected void populateGPSLatitude(String latitude) {
+        attachGPSData();
+        GPSLatitude latit = new GPSLatitude();
+        parseItude(latit, latitude);
         try {
             gps.setGPSLatitude(latit);
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
-    protected void populateGPSDestLongitude (String longitude) {
-        attachGPSData ();
-        GPSDestLongitude longit = new GPSDestLongitude ();
-        parseItude (longit, longitude);
+    protected void populateGPSDestLongitude(String longitude) {
+        attachGPSData();
+        GPSDestLongitude longit = new GPSDestLongitude();
+        parseItude(longit, longitude);
         try {
             gps.setGPSDestLongitude(longit);
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
-    protected void populateGPSDestLatitude (String latitude)  {
-        attachGPSData ();
-        GPSDestLatitude latit = new GPSDestLatitude ();
-        parseItude (latit, latitude);
+    protected void populateGPSDestLatitude(String latitude) {
+        attachGPSData();
+        GPSDestLatitude latit = new GPSDestLatitude();
+        parseItude(latit, latitude);
         try {
             gps.setGPSDestLatitude(latit);
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
-    protected void populateReferenceBlackWhite (String data, String colorspace) {
+    protected void populateReferenceBlackWhite(String data, String colorspace) {
         /* This consists of a series of six numbers, separated by spaces, each of which
          * is a headroom-footroom pair. The second argument tells us whether
          * the components are yCbCr or RGB. For the current cut, assume YCbCr.
          */
-        StringTokenizer tok = new StringTokenizer (data);
-        boolean rgb = ("RGB".equals (colorspace));
+        StringTokenizer tok = new StringTokenizer(data);
+        boolean rgb = ("RGB".equals(colorspace));
         double rbwVal[] = new double[6];
         try {
             for (int i = 0; i < 6; i++) {
                 rbwVal[i] = Double.parseDouble(tok.nextToken());
             }
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             return;
         }
         try {
-            ReferenceBlackWhite rbw = new ReferenceBlackWhite ();
+            ReferenceBlackWhite rbw = new ReferenceBlackWhite();
             phi.addReferenceBlackWhite(rbw);
             for (int i = 0; i < 6; i += 2) {
-                Component comp = new Component ();
+                Component comp = new Component();
                 rbw.addComponent(comp);
                 String interp;
                 switch (i) {
-                case 0:
-                    if (rgb)
-                        interp = "R";
-                    else
-                        interp = "Y";
-                    break;
-                case 2:
-                    if (rgb)
-                        interp = "G";
-                    else
-                        interp = "Cb";
-                    break;
-                default:
-                    if (rgb)
-                        interp = "B";
-                    else
-                        interp = "Cr";
-                    break;
+                    case 0:
+                        if (rgb) interp = "R";
+                        else interp = "Y";
+                        break;
+                    case 2:
+                        if (rgb) interp = "G";
+                        else interp = "Cb";
+                        break;
+                    default:
+                        if (rgb) interp = "B";
+                        else interp = "Cr";
+                        break;
                 }
                 comp.setComponentPhotometricInterpretation(interp);
-                comp.setHeadroom (new Rational ((int) (rbwVal[i] * 100), 100));
-                comp.setFootroom (new Rational ((int) (rbwVal[i+1] * 100), 100));
+                comp.setHeadroom(new Rational((int) (rbwVal[i] * 100), 100));
+                comp.setFootroom(new Rational((int) (rbwVal[i + 1] * 100), 100));
             }
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
     /** Make the ScannerModel part of the MIX */
-    protected void attachScannerModel () {
+    protected void attachScannerModel() {
         try {
-            icm.setScannerCapture (sc);
-            sc.setScannerModel (scanm);
+            icm.setScannerCapture(sc);
+            sc.setScannerModel(scanm);
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
     /** Make the Colormap part of the MIX */
-    protected void attachColorMap () {
+    protected void attachColorMap() {
         try {
-            ice.setColormap (cm);
+            ice.setColormap(cm);
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
-    protected void attachSubjectDistance () {
+    protected void attachSubjectDistance() {
         try {
-            id.setSubjectDistance (sd);
-            ccs.setImageData (id);
-            icm.setDigitalCameraCapture (dcc);
+            id.setSubjectDistance(sd);
+            ccs.setImageData(id);
+            icm.setDigitalCameraCapture(dcc);
             // The links in between are already set up
+        } catch (XmlContentException e) {
         }
-        catch (XmlContentException e) {}
     }
 
     /** Parse the longitude or latitude string from ExifTool. This is in
      *  a rather ugly format, like this:
      *  33 deg 24' 51.80" N
      */
-    private void parseItude (GPSItudeElement elem, String itude) {
-        StringBuffer itudeBuf = new StringBuffer (itude);
+    private void parseItude(GPSItudeElement elem, String itude) {
+        StringBuffer itudeBuf = new StringBuffer(itude);
         // Get rid of the non-number portions
         try {
-            int pos = itudeBuf.indexOf ("deg ");
-            if (pos > 0)
-                itudeBuf.delete (pos, pos + 4);
-            pos = itudeBuf.indexOf ("\"");
-            if (pos > 0)
-                itudeBuf.deleteCharAt(pos);
-            pos = itudeBuf.indexOf ("'");
-            if (pos > 0)
-                itudeBuf.deleteCharAt(pos);
+            int pos = itudeBuf.indexOf("deg ");
+            if (pos > 0) itudeBuf.delete(pos, pos + 4);
+            pos = itudeBuf.indexOf("\"");
+            if (pos > 0) itudeBuf.deleteCharAt(pos);
+            pos = itudeBuf.indexOf("'");
+            if (pos > 0) itudeBuf.deleteCharAt(pos);
 
             // Now we should just have three numbers separated by spaces.
             // Fractional degrees or minutes don't make much sense given that
             // seconds exist, so treat only seconds as a double.
-            StringTokenizer tok = new StringTokenizer (itudeBuf.toString());
+            StringTokenizer tok = new StringTokenizer(itudeBuf.toString());
             int deg = 0;
             int min = 0;
             double sec = 0;
 
-            deg = Integer.parseInt (tok.nextToken ());
-            if (tok.hasMoreElements())
-                min = Integer.parseInt (tok.nextToken ());
-            if (tok.hasMoreElements())
-                sec = Double.parseDouble (tok.nextToken ());
+            deg = Integer.parseInt(tok.nextToken());
+            if (tok.hasMoreElements()) min = Integer.parseInt(tok.nextToken());
+            if (tok.hasMoreElements()) sec = Double.parseDouble(tok.nextToken());
 
-            elem.setDegrees (new Rational (deg, 1));
-            elem.setMinutes (new Rational (min, 1));
-            elem.setSeconds (new Rational ((int) (sec * 100), 100));
-        }
-        catch (Exception e) {
+            elem.setDegrees(new Rational(deg, 1));
+            elem.setMinutes(new Rational(min, 1));
+            elem.setSeconds(new Rational((int) (sec * 100), 100));
+        } catch (Exception e) {
         }
     }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/TextMDModel.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/TextMDModel.java
@@ -22,28 +22,28 @@ public class TextMDModel {
     protected MarkupBasis mb;
     protected CharacterInfo ci;
 
-    protected TextMDModel () {
-        textMD = new TextMD ();
+    protected TextMDModel() {
+        textMD = new TextMD();
         ml = null;
     }
 
-    protected void attachMarkupLanguage () {
+    protected void attachMarkupLanguage() {
         if (ml == null) {
-            ml = new MarkupLanguage ();
+            ml = new MarkupLanguage();
             textMD.addMarkupLanguage(ml);
         }
     }
 
-    protected void attachMarkupBasis () {
+    protected void attachMarkupBasis() {
         if (mb == null) {
-            mb = new MarkupBasis ();
+            mb = new MarkupBasis();
             textMD.addMarkupBasis(mb);
         }
     }
 
-    protected void attachCharacterInfo () {
+    protected void attachCharacterInfo() {
         if (ci == null) {
-            ci = new CharacterInfo ();
+            ci = new CharacterInfo();
             textMD.addCharacterInfo(ci);
         }
     }

--- a/src/main/java/edu/harvard/hul/ois/fits/VideoFormatElements.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/VideoFormatElements.java
@@ -11,42 +11,42 @@
 package edu.harvard.hul.ois.fits;
 
 public enum VideoFormatElements {
-	width ("width"),
-	height ("height"),
-	frameRate ("frameRate"),
-	bitRate ("bitRate"),
-	bitRateMax ("bitRateMax"),
-	bitRateMode ("bitRateMode"),
-	scanningFormat ("scanningFormat"),
-	videoDataEncoding ("videoDataEncoding"),
-	aspectRatio ("aspectRatio"),
-	chromaSubsampling ("chromaSubsampling"),
-	colorspace ("colorspace"),
-	frameRateMode ("frameRateMode"),
-	byteOrder ("byteOrder"),
-	delay ("delay"),
-	compression ("compression"),
+    width("width"),
+    height("height"),
+    frameRate("frameRate"),
+    bitRate("bitRate"),
+    bitRateMax("bitRateMax"),
+    bitRateMode("bitRateMode"),
+    scanningFormat("scanningFormat"),
+    videoDataEncoding("videoDataEncoding"),
+    aspectRatio("aspectRatio"),
+    chromaSubsampling("chromaSubsampling"),
+    colorspace("colorspace"),
+    frameRateMode("frameRateMode"),
+    byteOrder("byteOrder"),
+    delay("delay"),
+    compression("compression"),
 
-	// NOTE the difference between the name and the ebucoreName so that .name()
-	// and .getEbucoreName() are different
-	trackSize ("streamSize"),
+    // NOTE the difference between the name and the ebucoreName so that .name()
+    // and .getEbucoreName() are different
+    trackSize("streamSize"),
 
-	broadcastStandard ("broadcastStandard"),
-	frameCount ("frameCount"),
-	bitDepth ("bitDepth"),
-	duration ("duration");
+    broadcastStandard("broadcastStandard"),
+    frameCount("frameCount"),
+    bitDepth("bitDepth"),
+    duration("duration");
 
-	private String name;
+    private String name;
 
-	VideoFormatElements(String name) {
+    VideoFormatElements(String name) {
         this.name = name;
     }
 
-    public String getName () {
+    public String getName() {
         return name;
     }
 
-    //static public VideoFormatElements lookup(String name) {
+    // static public VideoFormatElements lookup(String name) {
     //	VideoFormatElements retMethod = null;
     //	for(VideoFormatElements method : VideoFormatElements.values()) {
     //		if (method.Name().equals(name)) {
@@ -55,5 +55,5 @@ public enum VideoFormatElements {
     //		}
     //	}
     //	return retMethod;
-    //}
+    // }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/XmlContentConverter.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/XmlContentConverter.java
@@ -10,21 +10,6 @@
 
 package edu.harvard.hul.ois.fits;
 
-
-import java.io.File;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.commons.lang.StringUtils;
-import org.jdom2.Attribute;
-import org.jdom2.Content;
-import org.jdom2.Element;
-import org.jdom2.Namespace;
-import org.jdom2.Text;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import edu.harvard.hul.ois.fits.identity.FitsIdentity;
 import edu.harvard.hul.ois.ots.schemas.ContainerMD.Container;
 import edu.harvard.hul.ois.ots.schemas.ContainerMD.ContainerMd;
@@ -39,6 +24,17 @@ import edu.harvard.hul.ois.ots.schemas.MIX.YCbCrSubSampling;
 import edu.harvard.hul.ois.ots.schemas.XmlContent.Rational;
 import edu.harvard.hul.ois.ots.schemas.XmlContent.XmlContent;
 import edu.harvard.hul.ois.ots.schemas.XmlContent.XmlContentException;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
+import org.jdom2.Attribute;
+import org.jdom2.Content;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.jdom2.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** This class handles conversion between FITS metadata and XmlContent
  *  implementations of metadata schemas.
@@ -46,30 +42,30 @@ import edu.harvard.hul.ois.ots.schemas.XmlContent.XmlContentException;
  *  for this to compile. */
 public class XmlContentConverter {
 
-	private static List<String> docMdNames;
+    private static List<String> docMdNames;
 
     private static final Logger logger = LoggerFactory.getLogger(XmlContentConverter.class);
 
-	private static final Namespace ns = Namespace.getNamespace(Fits.XML_NAMESPACE);
+    private static final Namespace ns = Namespace.getNamespace(Fits.XML_NAMESPACE);
 
-	static {
-    	// collect names of DocumentMD enums
-		docMdNames = new ArrayList<String>(DocumentMDElement.values().length);
-		for (DocumentMDElement elem : DocumentMDElement.values()) {
-			docMdNames.add(elem.getName());
-		}
-	}
+    static {
+        // collect names of DocumentMD enums
+        docMdNames = new ArrayList<String>(DocumentMDElement.values().length);
+        for (DocumentMDElement elem : DocumentMDElement.values()) {
+            docMdNames.add(elem.getName());
+        }
+    }
 
     /** Converts an image element to a MIX object
      *
      *  @param  fitsImage   an image element in the FITS schema
      */
-    public XmlContent toMix (Element fitsImage, Element fileinfo) {
-        MixModel mm = new MixModel ();
+    public XmlContent toMix(Element fitsImage, Element fileinfo) {
+        MixModel mm = new MixModel();
 
         for (ImageElement fitsElem : ImageElement.values()) {
-            String fitsName = fitsElem.getName ();
-            List<Element> dataElements = fitsImage.getChildren(fitsName,ns);
+            String fitsName = fitsElem.getName();
+            List<Element> dataElements = fitsImage.getChildren(fitsName, ns);
             if (dataElements == null || dataElements.isEmpty()) {
                 continue;
             }
@@ -108,8 +104,7 @@ public class XmlContentConverter {
                             // referenceBlackWhite depends on colorSpace
                             Element cspc = fitsImage.getChild("colorSpace", ns);
                             String cspcStr = "";
-                            if (cspc != null)
-                                cspcStr = cspc.getText().trim();
+                            if (cspc != null) cspcStr = cspc.getText().trim();
                             mm.populateReferenceBlackWhite(dataValue, cspcStr);
                             break;
                         case iccProfileName:
@@ -134,10 +129,8 @@ public class XmlContentConverter {
                             mm.populateJPEG2000();
                             intValue = parseInt(dataValue, fitsElem.toString());
                             if (intValue != null) {
-                                if (fitsElem == ImageElement.tileWidth)
-                                    mm.tiles.setTileWidth(intValue);
-                                else
-                                    mm.tiles.setTileHeight(intValue);
+                                if (fitsElem == ImageElement.tileWidth) mm.tiles.setTileWidth(intValue);
+                                else mm.tiles.setTileHeight(intValue);
                             }
                             break;
                         case qualityLayers:
@@ -145,10 +138,8 @@ public class XmlContentConverter {
                             mm.populateJPEG2000();
                             intValue = parseInt(dataValue, fitsElem.toString());
                             if (intValue != null) {
-                                if (fitsElem == ImageElement.qualityLayers)
-                                    mm.eo.setQualityLayers(intValue);
-                                else
-                                    mm.eo.setResolutionLevels(intValue);
+                                if (fitsElem == ImageElement.qualityLayers) mm.eo.setQualityLayers(intValue);
+                                else mm.eo.setResolutionLevels(intValue);
                             }
                             break;
                         case orientation:
@@ -159,29 +150,25 @@ public class XmlContentConverter {
                             break;
                         case xSamplingFrequency:
                             rationalValue = parseRational(dataValue, fitsElem.toString());
-                            if (rationalValue != null)
-                                mm.sm.setXSamplingFrequency(rationalValue);
+                            if (rationalValue != null) mm.sm.setXSamplingFrequency(rationalValue);
                             break;
                         case ySamplingFrequency:
                             rationalValue = parseRational(dataValue, fitsElem.toString());
-                            if (rationalValue != null)
-                                mm.sm.setYSamplingFrequency(rationalValue);
+                            if (rationalValue != null) mm.sm.setYSamplingFrequency(rationalValue);
                             break;
                         case bitsPerSample:
-                            if (dataValue != null)
-                                mm.setBitsPerSample(dataValue);
+                            if (dataValue != null) mm.setBitsPerSample(dataValue);
                             break;
                         case samplesPerPixel:
                             intValue = parseInt(dataValue, fitsElem.toString());
-                            if (intValue != null)
-                                mm.ice.setSamplesPerPixel(intValue);
+                            if (intValue != null) mm.ice.setSamplesPerPixel(intValue);
                             break;
                         case extraSamples:
-                            //Can there be more than one of these? Assume only one.
+                            // Can there be more than one of these? Assume only one.
                             mm.ice.addExtraSamples(dataValue);
                             break;
                         case colorMap:
-                            //Assume we're getting the colormap reference.
+                            // Assume we're getting the colormap reference.
                             mm.attachColorMap();
                             mm.cm.setColormapReference(dataValue);
                             break;
@@ -194,7 +181,7 @@ public class XmlContentConverter {
                             mm.ice.setGrayResponseUnit(dataValue);
                             break;
                         case whitePointXValue:
-                            //Can there be more than one of these?
+                            // Can there be more than one of these?
                             rationalValue = parseRational(dataValue, fitsElem.toString());
                             if (rationalValue != null) {
                                 mm.populateWhitePoint();
@@ -202,7 +189,7 @@ public class XmlContentConverter {
                             }
                             break;
                         case whitePointYValue:
-                            //Can there be more than one of these?
+                            // Can there be more than one of these?
                             rationalValue = parseRational(dataValue, fitsElem.toString());
                             if (rationalValue != null) {
                                 mm.populateWhitePoint();
@@ -245,8 +232,7 @@ public class XmlContentConverter {
                         case scannerModelName:
                         case scannerModelNumber:
                         case scannerModelSerialNo:
-                            if (fitsElem == ImageElement.scannerModelName)
-                                mm.scanm.setScannerModelName(dataValue);
+                            if (fitsElem == ImageElement.scannerModelName) mm.scanm.setScannerModelName(dataValue);
                             else if (fitsElem == ImageElement.scannerModelNumber)
                                 mm.scanm.setScannerModelNumber(dataValue);
                             else if (fitsElem == ImageElement.scannerModelSerialNo)
@@ -257,11 +243,9 @@ public class XmlContentConverter {
                         case scanningSoftwareVersionNo:
                             if (fitsElem == ImageElement.scanningSoftwareName)
                                 mm.sss.setScanningSoftwareName(dataValue);
-                            else
-                                mm.sss.setScanningSoftwareVersionNo(dataValue);
+                            else mm.sss.setScanningSoftwareVersionNo(dataValue);
                             mm.attachScanningSystemSoftware();
                             break;
-
 
                         case digitalCameraManufacturer:
                             mm.dcc.setDigitalCameraManufacturer(dataValue);
@@ -406,8 +390,8 @@ public class XmlContentConverter {
                             }
                             break;
                         case cfaPattern2:
-                            //This is generated by Exiftool and has no counterpart
-                            //in MIX. No one knows what it means. Ignore it.
+                            // This is generated by Exiftool and has no counterpart
+                            // in MIX. No one knows what it means. Ignore it.
                             break;
                         case gpsVersionID:
                             mm.gps.setGpsVersionID(dataValue);
@@ -550,23 +534,27 @@ public class XmlContentConverter {
                             mm.gps.setGpsDifferential(dataValue);
                             mm.attachGPSData();
                             break;
-
                     }
                     // The first child element that is successfully processed terminates the iteration
                     break;
                 } catch (XmlContentException e) {
-                    logger.warn("Invalid MIX content for element [" + fitsElem + "]: " + e.getMessage ());
+                    logger.warn("Invalid MIX content for element [" + fitsElem + "]: " + e.getMessage());
                 }
             }
-        }//end of for loop
+        } // end of for loop
 
-        if(fileinfo != null) {
-            Element created = fileinfo.getChild (ImageElement.created.toString(),ns);
-            if(created != null) {
+        if (fileinfo != null) {
+            Element created = fileinfo.getChild(ImageElement.created.toString(), ns);
+            if (created != null) {
                 try {
-                    mm.icm.getGeneralCaptureInformation().setDateTimeCreated(created.getText().trim());
+                    mm.icm
+                            .getGeneralCaptureInformation()
+                            .setDateTimeCreated(created.getText().trim());
                 } catch (XmlContentException e) {
-                    logger.warn("Invalid MIX content for data element [{}]", created.getText().trim(), e);
+                    logger.warn(
+                            "Invalid MIX content for data element [{}]",
+                            created.getText().trim(),
+                            e);
                 }
             }
         }
@@ -579,114 +567,116 @@ public class XmlContentConverter {
      * @param  fitsDoc   a document element in the FITS schema
      */
     public XmlContent toDocumentMD(Element fitsDoc) {
-    	
-    	// The following values will only be set with the first value
-    	// in the case where there is more than one. That is,
-    	// the tool earlier in the list takes precedence.
-    	boolean isPageCountSet = false;
-    	boolean isWordCountSet = false;
-    	boolean isCharacterCountSet = false;
-    	boolean isParagraphCountSet = false;
-    	boolean isLineCountSet = false;
-    	boolean isGraphicsCountSet = false;
-    	boolean isTableCountSet = false;
-    	
+
+        // The following values will only be set with the first value
+        // in the case where there is more than one. That is,
+        // the tool earlier in the list takes precedence.
+        boolean isPageCountSet = false;
+        boolean isWordCountSet = false;
+        boolean isCharacterCountSet = false;
+        boolean isParagraphCountSet = false;
+        boolean isLineCountSet = false;
+        boolean isGraphicsCountSet = false;
+        boolean isTableCountSet = false;
+
         DocumentMDModel dm = new DocumentMDModel();
-		List<Element> dataElements = fitsDoc.getChildren();
+        List<Element> dataElements = fitsDoc.getChildren();
         for (Element dataElement : dataElements) {
-        	// If element name is contained in enum then we're interested in it.
-        	DocumentMDElement fitsElem = null;
-        	if (docMdNames.contains(dataElement.getName())) {
-        		// If name of element is contained in list of enum names then we can safely use valueOf()
-        		// rather than having to trap potential exception whenever the dataElement name does not convert to an enum.
-        		fitsElem = DocumentMDElement.valueOf(dataElement.getName());
-        	} else {
-        		continue;
-        	}
+            // If element name is contained in enum then we're interested in it.
+            DocumentMDElement fitsElem = null;
+            if (docMdNames.contains(dataElement.getName())) {
+                // If name of element is contained in list of enum names then we can safely use valueOf()
+                // rather than having to trap potential exception whenever the dataElement name does not convert to an
+                // enum.
+                fitsElem = DocumentMDElement.valueOf(dataElement.getName());
+            } else {
+                continue;
+            }
             String dataValue = dataElement.getText().trim();
-            Integer intValue = null;  // it's sometimes necessary to convert to Integer
+            Integer intValue = null; // it's sometimes necessary to convert to Integer
             switch (fitsElem) {
                 case pageCount:
                     intValue = parseInt(dataValue, fitsElem.toString());
-                    if(intValue != null) {
-                    	if (!isPageCountSet) {
-                    		dm.docMD.setPageCount(intValue);
-                    		isPageCountSet = true;
-                    	}
+                    if (intValue != null) {
+                        if (!isPageCountSet) {
+                            dm.docMD.setPageCount(intValue);
+                            isPageCountSet = true;
+                        }
                     }
                     break;
                 case wordCount:
                     intValue = parseInt(dataValue, fitsElem.toString());
-                    if(intValue != null) {
-                    	if (!isWordCountSet) {
-                    		dm.docMD.setWordCount(intValue);
-                    		isWordCountSet = true;
-                    	}
+                    if (intValue != null) {
+                        if (!isWordCountSet) {
+                            dm.docMD.setWordCount(intValue);
+                            isWordCountSet = true;
+                        }
                     }
                     break;
                 case characterCount:
                     intValue = parseInt(dataValue, fitsElem.toString());
-                    if(intValue != null) {
-                    	if (!isCharacterCountSet) {
-                    		dm.docMD.setCharacterCount(intValue);
-                    		isCharacterCountSet = true;
-                    	}
+                    if (intValue != null) {
+                        if (!isCharacterCountSet) {
+                            dm.docMD.setCharacterCount(intValue);
+                            isCharacterCountSet = true;
+                        }
                     }
                     break;
                 case paragraphCount:
                     intValue = parseInt(dataValue, fitsElem.toString());
-                    if(intValue != null) {
-                    	if (!isParagraphCountSet) {
-                    		dm.docMD.setParagraphCount(intValue);
-                    		isParagraphCountSet = true;
-                    	}
+                    if (intValue != null) {
+                        if (!isParagraphCountSet) {
+                            dm.docMD.setParagraphCount(intValue);
+                            isParagraphCountSet = true;
+                        }
                     }
                     break;
                 case lineCount:
                     intValue = parseInt(dataValue, fitsElem.toString());
-                    if(intValue != null) {
-                    	if (!isLineCountSet) {
-                    		dm.docMD.setLineCount(intValue);
-                    		isLineCountSet = true;
-                    	}
+                    if (intValue != null) {
+                        if (!isLineCountSet) {
+                            dm.docMD.setLineCount(intValue);
+                            isLineCountSet = true;
+                        }
                     }
                     break;
                 case graphicsCount:
                     intValue = parseInt(dataValue, fitsElem.toString());
-                    if(intValue != null) {
-                    	if (!isGraphicsCountSet) {
-                    		dm.docMD.setGraphicsCount(intValue);
-                    		isGraphicsCountSet = true;
-                    	}
+                    if (intValue != null) {
+                        if (!isGraphicsCountSet) {
+                            dm.docMD.setGraphicsCount(intValue);
+                            isGraphicsCountSet = true;
+                        }
                     }
                     break;
                 case tableCount:
                     intValue = parseInt(dataValue, fitsElem.toString());
-                    if(intValue != null) {
-                    	if (!isTableCountSet) {
-                    		dm.docMD.setTableCount(intValue);
-                    		isTableCountSet = true;
-                    	}
+                    if (intValue != null) {
+                        if (!isTableCountSet) {
+                            dm.docMD.setTableCount(intValue);
+                            isTableCountSet = true;
+                        }
                     }
                     break;
                 case language:
-                    if(dataValue != null) {
+                    if (dataValue != null) {
                         dm.docMD.addLanguage(dataValue);
                     }
                     break;
                 case font:
                     // Need to look for sub-elements
-                	Element fontName = dataElement.getChild(DocumentMDElement.fontName.getName(), ns);
-                	Element fontIsEmbedded = dataElement.getChild(DocumentMDElement.fontIsEmbedded.getName(), ns);
-                	if (fontName != null && !fontName.getText().isEmpty()) {
-                		Font font = new Font();
-                		font.setName(fontName.getText());
-                		if (fontIsEmbedded != null) {
-                			boolean isEmbedded = !fontIsEmbedded.getText().isEmpty() && "true".equals(fontIsEmbedded.getText());
-                			font.setEmbedded(isEmbedded);
-                		}
-                		dm.docMD.addFont(font);
-                	}
+                    Element fontName = dataElement.getChild(DocumentMDElement.fontName.getName(), ns);
+                    Element fontIsEmbedded = dataElement.getChild(DocumentMDElement.fontIsEmbedded.getName(), ns);
+                    if (fontName != null && !fontName.getText().isEmpty()) {
+                        Font font = new Font();
+                        font.setName(fontName.getText());
+                        if (fontIsEmbedded != null) {
+                            boolean isEmbedded =
+                                    !fontIsEmbedded.getText().isEmpty() && "true".equals(fontIsEmbedded.getText());
+                            font.setEmbedded(isEmbedded);
+                        }
+                        dm.docMD.addFont(font);
+                    }
                     break;
                 case isTagged:
                 case hasOutline:
@@ -698,12 +688,12 @@ public class XmlContentConverter {
                 case useTransparency:
                 case hasHyperlinks:
                 case hasEmbeddedResources:
-                    if(dataElement != null) {
+                    if (dataElement != null) {
                         dm.addFeature(dataElement);
                     }
                     break;
                 default:
-                	logger.warn("No case entry for : " + fitsElem.getName());
+                    logger.warn("No case entry for : " + fitsElem.getName());
             }
         }
         return dm.docMD;
@@ -712,46 +702,44 @@ public class XmlContentConverter {
     /** Converts a text element to a TextMD object
      *  @param  fitsText   a text element in the FITS schema
      */
-    public XmlContent toTextMD (Element fitsText) {
-        TextMDModel tm = new TextMDModel ();
+    public XmlContent toTextMD(Element fitsText) {
+        TextMDModel tm = new TextMDModel();
         for (TextMDElement fitsElem : TextMDElement.values()) {
             try {
-                String fitsName = fitsElem.getName ();
-                Element dataElement = fitsText.getChild (fitsName,ns);
-                if (dataElement == null)
-                    continue;
+                String fitsName = fitsElem.getName();
+                Element dataElement = fitsText.getChild(fitsName, ns);
+                if (dataElement == null) continue;
                 String dataValue = dataElement.getText().trim();
                 switch (fitsElem) {
-                case linebreak:
-                    tm.attachCharacterInfo();
-                    tm.ci.setLinebreak(dataValue);
-                    break;
-                case charset:
-                    tm.attachCharacterInfo();
-                    tm.ci.setCharset(dataValue.toUpperCase());
-                    break;
-                case markupBasis:
-                    tm.attachMarkupBasis ();
-                    tm.mb.setValue(dataValue);
-                    break;
-                case markupBasisVersion:
-                    tm.attachMarkupBasis ();
-                    tm.mb.setVersion(dataValue);
-                    break;
-                case markupLanguage:
-                    tm.attachMarkupLanguage ();
-                    tm.ml.setValue(dataValue);
-                    break;
-                case markupLanguageVersion:
-                    tm.attachMarkupLanguage ();
-                    tm.ml.setVersion(dataValue);
-                    break;
+                    case linebreak:
+                        tm.attachCharacterInfo();
+                        tm.ci.setLinebreak(dataValue);
+                        break;
+                    case charset:
+                        tm.attachCharacterInfo();
+                        tm.ci.setCharset(dataValue.toUpperCase());
+                        break;
+                    case markupBasis:
+                        tm.attachMarkupBasis();
+                        tm.mb.setValue(dataValue);
+                        break;
+                    case markupBasisVersion:
+                        tm.attachMarkupBasis();
+                        tm.mb.setVersion(dataValue);
+                        break;
+                    case markupLanguage:
+                        tm.attachMarkupLanguage();
+                        tm.ml.setValue(dataValue);
+                        break;
+                    case markupLanguageVersion:
+                        tm.attachMarkupLanguage();
+                        tm.ml.setVersion(dataValue);
+                        break;
                 }
+            } catch (XmlContentException e) {
+                logger.warn("Invalid TextMD content for element [" + fitsElem + "]: " + e.getMessage());
             }
-	        catch (XmlContentException e) {
-            	logger.warn("Invalid TextMD content for element [" + fitsElem + "]: " + e.getMessage ());
-	        }
-        }//end for
+        } // end for
 
         return tm.textMD;
     }
@@ -760,150 +748,146 @@ public class XmlContentConverter {
      * Converts a audio element into a AudioObject AES object
      * @param fitsAudio	an audio element in the FITS schema
      */
-    public XmlContent toAES (FitsOutput fitsOutput,Element fitsAudio) {
+    public XmlContent toAES(FitsOutput fitsOutput, Element fitsAudio) {
         AESModel aesModel = null;
 
-    	try {
-			aesModel = new AESModel ();
-		} catch (XmlContentException e2) {
-			logger.error("Invalid content: " + e2.getMessage ());
-		}
+        try {
+            aesModel = new AESModel();
+        } catch (XmlContentException e2) {
+            logger.error("Invalid content: " + e2.getMessage());
+        }
 
-    	String filename = fitsOutput.getFileInfoElement("filename").getValue();
+        String filename = fitsOutput.getFileInfoElement("filename").getValue();
 
+        FitsIdentity fitsIdent = fitsOutput.getIdentities().get(0);
+        String version = null;
+        if (fitsIdent.getFormatVersions().size() > 0) {
+            version = fitsIdent.getFormatVersions().get(0).getValue();
+        }
 
-    	FitsIdentity fitsIdent = fitsOutput.getIdentities().get(0);
-    	String version = null;
-    	if(fitsIdent.getFormatVersions().size() > 0) {
-    		version = fitsIdent.getFormatVersions().get(0).getValue();
-    	}
+        try {
+            aesModel.setFormat(fitsIdent.getFormat(), version);
+        } catch (XmlContentException e1) {
+            logger.error("Invalid content: " + e1.getMessage());
+        }
 
-    	try {
-			aesModel.setFormat(fitsIdent.getFormat(),version);
-		} catch (XmlContentException e1) {
-			logger.error("Invalid content: " + e1.getMessage ());
-		}
+        aesModel.aes.getPrimaryIdentifier().setText(new File(filename).getName());
 
-    	aesModel.aes.getPrimaryIdentifier().setText(new File(filename).getName());
-
-    	int sampleRate = 0;
-    	int channelCnt = 0;
-    	long numSamples = 0;
-    	String duration = "0";
-    	String timeStampStart = "0";
+        int sampleRate = 0;
+        int channelCnt = 0;
+        long numSamples = 0;
+        String duration = "0";
+        String timeStampStart = "0";
 
         for (AudioElement fitsElem : AudioElement.values()) {
             try {
-                String fitsName = fitsElem.getName ();
-                Element dataElement = fitsAudio.getChild (fitsName,ns);
-                if (dataElement == null)
-                    continue;
+                String fitsName = fitsElem.getName();
+                Element dataElement = fitsAudio.getChild(fitsName, ns);
+                if (dataElement == null) continue;
                 String dataValue = dataElement.getText().trim();
                 Integer intValue = null;
                 switch (fitsElem) {
-                case duration:
-                	duration = dataValue;
-                    break;
-                case bitDepth:
-                	intValue = parseInt(dataValue, fitsElem.toString());
-                	if (intValue != null) {
-                		aesModel.setBitDepth(intValue);
-                	}
-                    break;
-                case sampleRate:
-            		if(dataValue.contains(".")) {
-            			String[] sampleParts = dataValue.split("\\.");
-            			if(sampleParts[sampleParts.length-1].equals("0")) {
-            				sampleRate = Integer.parseInt(sampleParts[0]);
-            			}
-            		}
-            		else {
-            			intValue = parseInt(dataValue, fitsElem.toString());
-                    	if (intValue != null) {
-                    		sampleRate = intValue;
-                    	}
-            		}
-            		Double doubleValue = parseDouble(dataValue, fitsElem.toString());
-            		if (doubleValue != null) {
-            			aesModel.genericFormatRegion.setSampleRate(doubleValue);
-            		}
-                    break;
-                case channels:
-                	intValue = parseInt(dataValue, fitsElem.toString());
-                	if (intValue != null) {
-                		channelCnt = intValue;
-                		//add streams and channel cnt
-                		aesModel.setNumChannels(channelCnt);
-                		for(int i=0;i<channelCnt;i++) {
-                			aesModel.addStream(i,0.0,0.0);
-                		}
-                	}
-                    break;
-                case offset:
-                	intValue = parseInt(dataValue, fitsElem.toString());
-                	if (intValue != null) {
-                		aesModel.aes.setFirstSampleOffset(intValue);
-                	}
-                    break;
-                case timeStampStart:
-                    timeStampStart = dataValue;
-                    break;
-                case byteOrder:
-                    aesModel.aes.setByteOrder(dataValue);
-                    break;
-                case bitRate:
-                    aesModel.setBitRate(dataValue);
-                    break;
-                case numSamples:
-                	Long longValue = parseLong(dataValue, fitsElem.toString());
-                	if (longValue != null) {
-                		numSamples = longValue;
-                	}
-                    break;
-                case wordSize:
-                	intValue = parseInt(dataValue, fitsElem.toString());
-                	if (intValue != null) {
-                		aesModel.setWordSize(intValue);
-                	}
-                	break;
-                case audioDataEncoding:
-                	aesModel.setAudioDataEncoding(dataValue);
-                	break;
-                case blockAlign:
-                	intValue = parseInt(dataValue, fitsElem.toString());
-                	if (intValue != null) {
-                		aesModel.setAudioDataBlockSize(intValue);
-                	}
-                	break;
-                case codecName:
-                	aesModel.setCodec(dataValue);
-                	break;
-                case codecNameVersion:
-                	aesModel.setCodecVersion(dataValue);
-                	break;
-                case codecCreatorApplication:
-                	aesModel.setCodecCreatorApplication(dataValue);
-                	break;
-                case codecCreatorApplicationVersion:
-                	aesModel.setCodecCreatorApplicationVersion(dataValue);
-                	break;
+                    case duration:
+                        duration = dataValue;
+                        break;
+                    case bitDepth:
+                        intValue = parseInt(dataValue, fitsElem.toString());
+                        if (intValue != null) {
+                            aesModel.setBitDepth(intValue);
+                        }
+                        break;
+                    case sampleRate:
+                        if (dataValue.contains(".")) {
+                            String[] sampleParts = dataValue.split("\\.");
+                            if (sampleParts[sampleParts.length - 1].equals("0")) {
+                                sampleRate = Integer.parseInt(sampleParts[0]);
+                            }
+                        } else {
+                            intValue = parseInt(dataValue, fitsElem.toString());
+                            if (intValue != null) {
+                                sampleRate = intValue;
+                            }
+                        }
+                        Double doubleValue = parseDouble(dataValue, fitsElem.toString());
+                        if (doubleValue != null) {
+                            aesModel.genericFormatRegion.setSampleRate(doubleValue);
+                        }
+                        break;
+                    case channels:
+                        intValue = parseInt(dataValue, fitsElem.toString());
+                        if (intValue != null) {
+                            channelCnt = intValue;
+                            // add streams and channel cnt
+                            aesModel.setNumChannels(channelCnt);
+                            for (int i = 0; i < channelCnt; i++) {
+                                aesModel.addStream(i, 0.0, 0.0);
+                            }
+                        }
+                        break;
+                    case offset:
+                        intValue = parseInt(dataValue, fitsElem.toString());
+                        if (intValue != null) {
+                            aesModel.aes.setFirstSampleOffset(intValue);
+                        }
+                        break;
+                    case timeStampStart:
+                        timeStampStart = dataValue;
+                        break;
+                    case byteOrder:
+                        aesModel.aes.setByteOrder(dataValue);
+                        break;
+                    case bitRate:
+                        aesModel.setBitRate(dataValue);
+                        break;
+                    case numSamples:
+                        Long longValue = parseLong(dataValue, fitsElem.toString());
+                        if (longValue != null) {
+                            numSamples = longValue;
+                        }
+                        break;
+                    case wordSize:
+                        intValue = parseInt(dataValue, fitsElem.toString());
+                        if (intValue != null) {
+                            aesModel.setWordSize(intValue);
+                        }
+                        break;
+                    case audioDataEncoding:
+                        aesModel.setAudioDataEncoding(dataValue);
+                        break;
+                    case blockAlign:
+                        intValue = parseInt(dataValue, fitsElem.toString());
+                        if (intValue != null) {
+                            aesModel.setAudioDataBlockSize(intValue);
+                        }
+                        break;
+                    case codecName:
+                        aesModel.setCodec(dataValue);
+                        break;
+                    case codecNameVersion:
+                        aesModel.setCodecVersion(dataValue);
+                        break;
+                    case codecCreatorApplication:
+                        aesModel.setCodecCreatorApplication(dataValue);
+                        break;
+                    case codecCreatorApplicationVersion:
+                        aesModel.setCodecCreatorApplicationVersion(dataValue);
+                        break;
                 }
 
+            } catch (XmlContentException e) {
+                logger.warn("Invalid AES content for element [" + fitsElem + "]: " + e.getMessage());
             }
-            catch (XmlContentException e) {
-            	logger.warn("Invalid AES content for element [" + fitsElem + "]: " + e.getMessage ());
-            }
-        }//end for
+        } // end for
 
-    	//set other requires values
-    	aesModel.aes.setAnalogDigitalFlag("FILE_DIGITAL");
-    	try {
-			aesModel.setDummyUseType();
-        	aesModel.setDuration(duration,sampleRate,numSamples);
-        	aesModel.setStartTime(timeStampStart,sampleRate);
-		} catch (XmlContentException e) {
-			logger.error("Invalid content: " + e.getMessage ());
-		}
+        // set other requires values
+        aesModel.aes.setAnalogDigitalFlag("FILE_DIGITAL");
+        try {
+            aesModel.setDummyUseType();
+            aesModel.setDuration(duration, sampleRate, numSamples);
+            aesModel.setStartTime(timeStampStart, sampleRate);
+        } catch (XmlContentException e) {
+            logger.error("Invalid content: " + e.getMessage());
+        }
 
         return aesModel.aes;
     }
@@ -913,61 +897,65 @@ public class XmlContentConverter {
      * @param  fitsElement an element in the FITS schema
      */
     public XmlContent toContainerMD(Element fitsElement) {
-    	
-    	ContainerMd containerMd = new ContainerMd ();
 
-    	try {
-    		Container container = new Container();
-    		containerMd.setContainer(container);
-    		
-    		Encoding encoding = new Encoding();
-    		List<Encoding> encodings = new ArrayList<>();
-    		encodings.add(encoding);
-    		container.setEncodings(encodings);
-    		
-    		// TODO: get encryption element to pull value for either 'encryption' or 'compression'
-    		
-    		encoding.setAttribute("type", "compression");
-    		Element compressionMethod = fitsElement.getChild(ContainerMDElement.compressionMethod.getName(), ns);
-    		if (compressionMethod != null && !compressionMethod.getText().isEmpty()) {
-    			encoding.setAttribute("method", compressionMethod.getText());
-    		}
-    		Element originalSize = fitsElement.getChild(ContainerMDElement.originalSize.getName(), ns);
-    		if (originalSize != null && !originalSize.getText().isEmpty()) {
-    			encoding.setAttribute("originalSize", originalSize.getText());
-    		}
-    		
-    		Entries entries = new Entries();
-    		containerMd.setEntries(entries);
-    		
-    		EntriesInformation entriesInformation = new EntriesInformation();
-    		entries.setEntriesInformation(entriesInformation);
-    		
-    		
-    		Element entriesElement = fitsElement.getChild(ContainerMDElement.entries.getName(), ns);
-    		if (entriesElement != null) {
-    			String totalEntries = entriesElement.getAttributeValue(ContainerMDElement.totalEntries.getName());
-    			entriesInformation.setNumber( parseLong(totalEntries,
-    					ContainerMDElement.entries.getName() + " -- attr.: " + ContainerMDElement.totalEntries.getName()) );
-    			
-    			Formats formats = new Formats();
-    			entriesInformation.setFormats(formats);
-    			
-    			List<Element> formatElements = entriesElement.getChildren(ContainerMDElement.format.getName(), ns);
-    			if (formatElements != null & formatElements.size() > 0) {
-    				for (Element formatElement : formatElements) {
-    					Format format = new Format();
-    					formats.addFormat(format);
-    					String formatName = formatElement.getAttributeValue(ContainerMDElement.formatName.getName());
-    					format.setNameAttribute(formatName);
-    					String number = formatElement.getAttributeValue(ContainerMDElement.number.getName());
-    					format.setNumber( parseLong(number, ContainerMDElement.formatName.getName() + " -- attr.: " + ContainerMDElement.number.getName()) );
-    				}
-    			}
-    		}
-		} catch (XmlContentException e1) {
-			logger.error("Invalid content: " + e1.getMessage ());
-		}
+        ContainerMd containerMd = new ContainerMd();
+
+        try {
+            Container container = new Container();
+            containerMd.setContainer(container);
+
+            Encoding encoding = new Encoding();
+            List<Encoding> encodings = new ArrayList<>();
+            encodings.add(encoding);
+            container.setEncodings(encodings);
+
+            // TODO: get encryption element to pull value for either 'encryption' or 'compression'
+
+            encoding.setAttribute("type", "compression");
+            Element compressionMethod = fitsElement.getChild(ContainerMDElement.compressionMethod.getName(), ns);
+            if (compressionMethod != null && !compressionMethod.getText().isEmpty()) {
+                encoding.setAttribute("method", compressionMethod.getText());
+            }
+            Element originalSize = fitsElement.getChild(ContainerMDElement.originalSize.getName(), ns);
+            if (originalSize != null && !originalSize.getText().isEmpty()) {
+                encoding.setAttribute("originalSize", originalSize.getText());
+            }
+
+            Entries entries = new Entries();
+            containerMd.setEntries(entries);
+
+            EntriesInformation entriesInformation = new EntriesInformation();
+            entries.setEntriesInformation(entriesInformation);
+
+            Element entriesElement = fitsElement.getChild(ContainerMDElement.entries.getName(), ns);
+            if (entriesElement != null) {
+                String totalEntries = entriesElement.getAttributeValue(ContainerMDElement.totalEntries.getName());
+                entriesInformation.setNumber(parseLong(
+                        totalEntries,
+                        ContainerMDElement.entries.getName() + " -- attr.: "
+                                + ContainerMDElement.totalEntries.getName()));
+
+                Formats formats = new Formats();
+                entriesInformation.setFormats(formats);
+
+                List<Element> formatElements = entriesElement.getChildren(ContainerMDElement.format.getName(), ns);
+                if (formatElements != null & formatElements.size() > 0) {
+                    for (Element formatElement : formatElements) {
+                        Format format = new Format();
+                        formats.addFormat(format);
+                        String formatName = formatElement.getAttributeValue(ContainerMDElement.formatName.getName());
+                        format.setNameAttribute(formatName);
+                        String number = formatElement.getAttributeValue(ContainerMDElement.number.getName());
+                        format.setNumber(parseLong(
+                                number,
+                                ContainerMDElement.formatName.getName() + " -- attr.: "
+                                        + ContainerMDElement.number.getName()));
+                    }
+                }
+            }
+        } catch (XmlContentException e1) {
+            logger.error("Invalid content: " + e1.getMessage());
+        }
 
         return containerMd;
     }
@@ -976,172 +964,170 @@ public class XmlContentConverter {
      * Converts a video element into a VideoObject ??? object
      * @param fitsVideo		a video element in the FITS schema
      */
-    public XmlContent toEbuCoreVideo (FitsOutput fitsOutput,Element fitsVideo) {
-    	
-    	//
-    	// NOTE:
-    	// The FitsOutput INPUT can be one of 3 types:
-    	// 1) "FITS"
-    	// 2) "Combined" (both FITS and Standard)
-    	// 3) "Standard" (Ebucore)
-    	// ... and either contain spaces in the XML, or not
-    	//
-    	// The XmlContent object returned output will be as follows for each
-    	// input type:
-    	// 1) FITS or Combined = Standard Ebucore
-    	// 2) Standard (Ebucore) = null XmlContent Object, as the fitsOutput
-    	// does not contain elements or data which can be parsed into Ebucore.
-    	// In other words, there is no data present which can be used to 
-    	// transform the data to Ebucore because it is ALREADY Ebucore.
-    	//
-    	// TODO: - Maybe return an Ebucore-based FitsOutput based upon the
-    	// Ebucore data contained in the Standard Element for FitsOutput input
-    	// objects of type "Standard".
+    public XmlContent toEbuCoreVideo(FitsOutput fitsOutput, Element fitsVideo) {
 
-    	EbuCoreModel ebucoreModel = null;
-    	String fitsName = null;
+        //
+        // NOTE:
+        // The FitsOutput INPUT can be one of 3 types:
+        // 1) "FITS"
+        // 2) "Combined" (both FITS and Standard)
+        // 3) "Standard" (Ebucore)
+        // ... and either contain spaces in the XML, or not
+        //
+        // The XmlContent object returned output will be as follows for each
+        // input type:
+        // 1) FITS or Combined = Standard Ebucore
+        // 2) Standard (Ebucore) = null XmlContent Object, as the fitsOutput
+        // does not contain elements or data which can be parsed into Ebucore.
+        // In other words, there is no data present which can be used to
+        // transform the data to Ebucore because it is ALREADY Ebucore.
+        //
+        // TODO: - Maybe return an Ebucore-based FitsOutput based upon the
+        // Ebucore data contained in the Standard Element for FitsOutput input
+        // objects of type "Standard".
 
-    	String framerate = "NOT_SET";
-    	String timecode = "NOT_SET";
+        EbuCoreModel ebucoreModel = null;
+        String fitsName = null;
 
-    	try {
-    		ebucoreModel = new EbuCoreModel();
-    		List<Content> videoElemList = fitsVideo.getContent();
+        String framerate = "NOT_SET";
+        String timecode = "NOT_SET";
 
-    		String mimeType = null;
+        try {
+            ebucoreModel = new EbuCoreModel();
+            List<Content> videoElemList = fitsVideo.getContent();
 
-    		// Walk through all of the elements and process them
-    		// skipping any Text Objects
-    		for(Object obj : videoElemList) {
-    			try {
-	    			// Skip the text object.
-	    			// This is most likely due to spaces preceding the real element
-	    			if(obj instanceof Text) {
-	    				continue;
-	    			}
-	    			
-	    			Element elem = (Element)obj;
-	    			fitsName = elem.getName ();
-	    			
-	    			// If we have a standard element, then we are done.
-	    			// We only wish to process the basic FITS output
-	    			if(fitsName.equals ("standard")) {
-	    				break;
-	    			}
-	    			
-	    	    	// Ebucore can only be generated from MediaInfo output
-	    	    	if(!isMediaInfoTool(fitsName, elem)) {
-	    	    		continue;
-	    	    	}
-	
-	    	    	// Set mime type - MXF codec generation needs it
-	    	    	if(fitsName.equals("mimeType")) {
-	    	    		mimeType = elem.getValue();
-	    	    	}
-	
-	    			// Process the tracks
-	    			if (fitsName.equals("track")) {
-	    				Attribute typeAttr = elem.getAttribute("type");
-	    				if(typeAttr != null) {
-	    					String type = typeAttr.getValue();
-	
-	    					if(type.toLowerCase().equals("video")) {
-	
-	    						// Set the framerate
-	    				   		Element dataElement = elem.getChild ("frameRate",ns);
-	    			    		if (dataElement != null) {
-	    			    			String dataValue = dataElement.getText().trim();
-	    		   					if (!StringUtils.isEmpty(dataValue)) {
-	            			    		framerate = dataValue;
-	    		   					}
-	
-	    			    		}
-	
-	    						ebucoreModel.createVideoFormatElement(elem, ns, mimeType);
-	
-	    					} // video format
-	
-	    					// Audio Format
-	    					else if (type.toLowerCase().equals("audio")) {
-	    						ebucoreModel.createAudioFormatElement(elem, ns);
-	    					}  // audio format
-	    				}
-	    			}  // track
-	    			else {
-	
-	    				// Set the timecode
-	    				if(fitsName.equals("timecodeStart")) {
-	    					String dataValue = elem.getText().trim();
-	    					if (!StringUtils.isEmpty(dataValue)) {
-	    						timecode = dataValue;
-	    					}
-	    				}
-	
-	    				// Process Elements directly off the root of the Format Element
-	    				ebucoreModel.createFormatElement(fitsName, elem);
-	    			}
+            String mimeType = null;
 
-    			} catch (XmlContentException e) {
-    				logger.warn("Invalid EbuCore content for element [" + fitsName + "]: " + e.getMessage ());
-    			}
-    		}  // for(Element elem : trackList)
+            // Walk through all of the elements and process them
+            // skipping any Text Objects
+            for (Object obj : videoElemList) {
+                try {
+                    // Skip the text object.
+                    // This is most likely due to spaces preceding the real element
+                    if (obj instanceof Text) {
+                        continue;
+                    }
 
-			// Process Elements directly off the root of the Format Element
-			ebucoreModel.createStart(timecode, framerate);
+                    Element elem = (Element) obj;
+                    fitsName = elem.getName();
 
-    	} catch (XmlContentException e) {
-    		// If we get here then construction of EbuCoreModel failed so
-    		// return null here to avoid NPE when dereferencing ebucoreMain below.
-    		logger.error("Could not create EbuCoreModel: " + e.getMessage(), e);
-    		return null;
-    	}
+                    // If we have a standard element, then we are done.
+                    // We only wish to process the basic FITS output
+                    if (fitsName.equals("standard")) {
+                        break;
+                    }
 
-    	return ebucoreModel.ebucoreMain;
+                    // Ebucore can only be generated from MediaInfo output
+                    if (!isMediaInfoTool(fitsName, elem)) {
+                        continue;
+                    }
+
+                    // Set mime type - MXF codec generation needs it
+                    if (fitsName.equals("mimeType")) {
+                        mimeType = elem.getValue();
+                    }
+
+                    // Process the tracks
+                    if (fitsName.equals("track")) {
+                        Attribute typeAttr = elem.getAttribute("type");
+                        if (typeAttr != null) {
+                            String type = typeAttr.getValue();
+
+                            if (type.toLowerCase().equals("video")) {
+
+                                // Set the framerate
+                                Element dataElement = elem.getChild("frameRate", ns);
+                                if (dataElement != null) {
+                                    String dataValue = dataElement.getText().trim();
+                                    if (!StringUtils.isEmpty(dataValue)) {
+                                        framerate = dataValue;
+                                    }
+                                }
+
+                                ebucoreModel.createVideoFormatElement(elem, ns, mimeType);
+
+                            } // video format
+
+                            // Audio Format
+                            else if (type.toLowerCase().equals("audio")) {
+                                ebucoreModel.createAudioFormatElement(elem, ns);
+                            } // audio format
+                        }
+                    } // track
+                    else {
+
+                        // Set the timecode
+                        if (fitsName.equals("timecodeStart")) {
+                            String dataValue = elem.getText().trim();
+                            if (!StringUtils.isEmpty(dataValue)) {
+                                timecode = dataValue;
+                            }
+                        }
+
+                        // Process Elements directly off the root of the Format Element
+                        ebucoreModel.createFormatElement(fitsName, elem);
+                    }
+
+                } catch (XmlContentException e) {
+                    logger.warn("Invalid EbuCore content for element [" + fitsName + "]: " + e.getMessage());
+                }
+            } // for(Element elem : trackList)
+
+            // Process Elements directly off the root of the Format Element
+            ebucoreModel.createStart(timecode, framerate);
+
+        } catch (XmlContentException e) {
+            // If we get here then construction of EbuCoreModel failed so
+            // return null here to avoid NPE when dereferencing ebucoreMain below.
+            logger.error("Could not create EbuCoreModel: " + e.getMessage(), e);
+            return null;
+        }
+
+        return ebucoreModel.ebucoreMain;
     } // toEbuCoreVideo
 
     private boolean isMediaInfoTool(String fitsName, Element elem) {
 
-    	// Ebucore can only be generated from MediaInfo output
-		Attribute toolNameAttr = elem.getAttribute("toolname");
-    	String toolName = toolNameAttr.getValue();
-    	if(toolName == null)  // just in case
-    		return false;
-    	if(!toolName.equalsIgnoreCase("mediainfo"))
-    		return false;
+        // Ebucore can only be generated from MediaInfo output
+        Attribute toolNameAttr = elem.getAttribute("toolname");
+        String toolName = toolNameAttr.getValue();
+        if (toolName == null) // just in case
+        return false;
+        if (!toolName.equalsIgnoreCase("mediainfo")) return false;
 
-    	return true;
+        return true;
     }
 
     /* an enumeration for mapping symbols to FITS audio element names */
     public enum AudioElement {
-       	//samplingRate ("samplingRate"),
-       	//sampleSize ("sampleSize"),
-    	//bitRate ("bitRate"),
-    	//bitRateMode ("bitRateMode"),
-    	//channels ("channels");
+        // samplingRate ("samplingRate"),
+        // sampleSize ("sampleSize"),
+        // bitRate ("bitRate"),
+        // bitRateMode ("bitRateMode"),
+        // channels ("channels");
 
-    	bitsPerSample ("bitsPerSample"),
-    	duration ("duration"),
-    	bitDepth ("bitDepth"),
-    	sampleRate ("sampleRate"),
-    	channels ("channels"),
-    	dataFormatType ("dataFormatType"),
-    	offset ("offset"),
-    	timeStampStart ("timeStampStart"),
-    	byteOrder ("byteOrder"),
-    	bitRate ("bitRate"),
-    	numSamples ("numSamples"),
-    	wordSize ("wordSize"),
-    	audioDataEncoding ("audioDataEncoding"),
-    	blockAlign ("blockAlign"),
-    	codecName ("codecName"),
-        codecNameVersion ("codecNameVersion"),
-        codecCreatorApplication ("codecCreatorApplication"),
-        codecCreatorApplicationVersion ("codecCreatorApplicationVersion");
+        bitsPerSample("bitsPerSample"),
+        duration("duration"),
+        bitDepth("bitDepth"),
+        sampleRate("sampleRate"),
+        channels("channels"),
+        dataFormatType("dataFormatType"),
+        offset("offset"),
+        timeStampStart("timeStampStart"),
+        byteOrder("byteOrder"),
+        bitRate("bitRate"),
+        numSamples("numSamples"),
+        wordSize("wordSize"),
+        audioDataEncoding("audioDataEncoding"),
+        blockAlign("blockAlign"),
+        codecName("codecName"),
+        codecNameVersion("codecNameVersion"),
+        codecCreatorApplication("codecCreatorApplication"),
+        codecCreatorApplicationVersion("codecCreatorApplicationVersion");
 
-    	private String name;
+        private String name;
 
-    	private AudioElement(String name) {
+        private AudioElement(String name) {
             this.name = name;
         }
 
@@ -1152,99 +1138,99 @@ public class XmlContentConverter {
 
     /* An enumeration for mapping symbols to FITS image element names. */
     public enum ImageElement {
-        byteOrder ("byteOrder"),
-        compressionScheme ("compressionScheme"),
-        imageWidth ("imageWidth"),
-        imageHeight ("imageHeight"),
-        colorSpace ("colorSpace"),
-        referenceBlackWhite ("referenceBlackWhite"),
-        iccProfileName ("iccProfileName"),
-        iccProfileVersion ("iccProfileVersion"),
-        YCbCrSubSampling ("YCbCrSubSampling"),
-        YCbCrCoefficients ("YCbCrCoefficients"),
-        tileWidth ("tileWidth"),
-        tileHeight ("tileHeight"),
-        qualityLayers ("qualityLayers"),
-        resolutionLevels ("resolutionLevels"),
-        orientation ("orientation"),
-        samplingFrequencyUnit ("samplingFrequencyUnit"),
-        xSamplingFrequency ("xSamplingFrequency"),
-        ySamplingFrequency ("ySamplingFrequency"),
-        bitsPerSample ("bitsPerSample"),
-        samplesPerPixel ("samplesPerPixel"),
-        extraSamples ("extraSamples"),
-        colorMap ("colorMap"),
-        grayResponseCurve ("grayResponseCurve"),
-        grayResponseUnit ("grayResponseUnit"),
-        whitePointXValue ("whitePointXValue"),
-        whitePointYValue ("whitePointYValue"),
-        primaryChromaticitiesRedX ("primaryChromaticitiesRedX"),
-        primaryChromaticitiesRedY ("primaryChromaticitiesRedY"),
-        primaryChromaticitiesGreenX ("primaryChromaticitiesGreenX"),
-        primaryChromaticitiesGreenY ("primaryChromaticitiesGreenY"),
-        primaryChromaticitiesBlueX ("primaryChromaticitiesBlueX"),
-        primaryChromaticitiesBlueY ("primaryChromaticitiesBlueY"),
-        imageProducer ("imageProducer"),
-        captureDevice ("captureDevice"),
+        byteOrder("byteOrder"),
+        compressionScheme("compressionScheme"),
+        imageWidth("imageWidth"),
+        imageHeight("imageHeight"),
+        colorSpace("colorSpace"),
+        referenceBlackWhite("referenceBlackWhite"),
+        iccProfileName("iccProfileName"),
+        iccProfileVersion("iccProfileVersion"),
+        YCbCrSubSampling("YCbCrSubSampling"),
+        YCbCrCoefficients("YCbCrCoefficients"),
+        tileWidth("tileWidth"),
+        tileHeight("tileHeight"),
+        qualityLayers("qualityLayers"),
+        resolutionLevels("resolutionLevels"),
+        orientation("orientation"),
+        samplingFrequencyUnit("samplingFrequencyUnit"),
+        xSamplingFrequency("xSamplingFrequency"),
+        ySamplingFrequency("ySamplingFrequency"),
+        bitsPerSample("bitsPerSample"),
+        samplesPerPixel("samplesPerPixel"),
+        extraSamples("extraSamples"),
+        colorMap("colorMap"),
+        grayResponseCurve("grayResponseCurve"),
+        grayResponseUnit("grayResponseUnit"),
+        whitePointXValue("whitePointXValue"),
+        whitePointYValue("whitePointYValue"),
+        primaryChromaticitiesRedX("primaryChromaticitiesRedX"),
+        primaryChromaticitiesRedY("primaryChromaticitiesRedY"),
+        primaryChromaticitiesGreenX("primaryChromaticitiesGreenX"),
+        primaryChromaticitiesGreenY("primaryChromaticitiesGreenY"),
+        primaryChromaticitiesBlueX("primaryChromaticitiesBlueX"),
+        primaryChromaticitiesBlueY("primaryChromaticitiesBlueY"),
+        imageProducer("imageProducer"),
+        captureDevice("captureDevice"),
         scannerManufacturer("scannerManufacturer"),
-        scannerModelName ("scannerModelName"),
-        scannerModelNumber ("scannerModelNumber"),
-        scannerModelSerialNo ("scannerModelSerialNo"),
-        scanningSoftwareName ("scanningSoftwareName"),
-        scanningSoftwareVersionNo ("scanningSoftwareVersionNo"),
-        fNumber ("fNumber"),
-        exposureTime ("exposureTime"),
-        exposureProgram ("exposureProgram"),
-        spectralSensitivity ("spectralSensitivity"),
-        isoSpeedRating ("isoSpeedRating"),
-        oECF ("oECF"),
-        exifVersion ("exifVersion"),
-        shutterSpeedValue ("shutterSpeedValue"),
-        apertureValue ("apertureValue"),
-        brightnessValue ("brightnessValue"),
-        exposureBiasValue ("exposureBiasValue"),
-        maxApertureValue ("maxApertureValue"),
-        subjectDistance ("subjectDistance"),
-        meteringMode ("meteringMode"),
-        lightSource ("lightSource"),
-        flash ("flash"),
-        focalLength ("focalLength"),
-        flashEnergy ("flashEnergy"),
-        exposureIndex ("exposureIndex"),
-        sensingMethod ("sensingMethod"),
-        cfaPattern ("cfaPattern"),
-        cfaPattern2 ("cfaPattern2"),
-        gpsVersionID ("gpsVersionID"),
-        gpsLatitudeRef ("gpsLatitudeRef"),
-        gpsLatitude ("gpsLatitude"),
-        gpsLongitudeRef ("gpsLongitudeRef"),
-        gpsLongitude ("gpsLongitude"),
-        gpsAltitudeRef ("gpsAltitudeRef"),
-        gpsAltitude ("gpsAltitude"),
-        gpsTimeStamp ("gpsTimeStamp"),
-        gpsSatellites ("gpsSatellites"),
-        gpsStatus ("gpsStatus"),
-        gpsMeasureMode ("gpsMeasureMode"),
-        gpsDOP ("gpsDOP"),
-        gpsSpeedRef ("gpsSpeedRef"),
-        gpsSpeed ("gpsSpeed"),
-        gpsTrackRef ("gpsTrackRef"),
-        gpsTrack ("gpsTrack"),
-        gpsImgDirectionRef ("gpsImgDirectionRef"),
-        gpsImgDirection ("gpsImgDirection"),
-        gpsMapDatum ("gpsMapDatum"),
-        gpsDestLatitudeRef ("gpsDestLatitudeRef"),
-        gpsDestLatitude ("gpsDestLatitude"),
-        gpsDestLongitudeRef ("gpsDestLongitudeRef"),
-        gpsDestLongitude ("gpsDestLongitude"),
-        gpsDestBearingRef ("gpsDestBearingRef"),
-        gpsDestBearing ("gpsDestBearing"),
-        gpsDestDistanceRef ("gpsDestDistanceRef"),
-        gpsDestDistance ("gpsDestDistance"),
-        gpsProcessingMethod ("gpsProcessingMethod"),
-        gpsAreaInformation ("gpsAreaInformation"),
-        gpsDateStamp ("gpsDateStamp"),
-        gpsDifferential ("gpsDifferential"),
+        scannerModelName("scannerModelName"),
+        scannerModelNumber("scannerModelNumber"),
+        scannerModelSerialNo("scannerModelSerialNo"),
+        scanningSoftwareName("scanningSoftwareName"),
+        scanningSoftwareVersionNo("scanningSoftwareVersionNo"),
+        fNumber("fNumber"),
+        exposureTime("exposureTime"),
+        exposureProgram("exposureProgram"),
+        spectralSensitivity("spectralSensitivity"),
+        isoSpeedRating("isoSpeedRating"),
+        oECF("oECF"),
+        exifVersion("exifVersion"),
+        shutterSpeedValue("shutterSpeedValue"),
+        apertureValue("apertureValue"),
+        brightnessValue("brightnessValue"),
+        exposureBiasValue("exposureBiasValue"),
+        maxApertureValue("maxApertureValue"),
+        subjectDistance("subjectDistance"),
+        meteringMode("meteringMode"),
+        lightSource("lightSource"),
+        flash("flash"),
+        focalLength("focalLength"),
+        flashEnergy("flashEnergy"),
+        exposureIndex("exposureIndex"),
+        sensingMethod("sensingMethod"),
+        cfaPattern("cfaPattern"),
+        cfaPattern2("cfaPattern2"),
+        gpsVersionID("gpsVersionID"),
+        gpsLatitudeRef("gpsLatitudeRef"),
+        gpsLatitude("gpsLatitude"),
+        gpsLongitudeRef("gpsLongitudeRef"),
+        gpsLongitude("gpsLongitude"),
+        gpsAltitudeRef("gpsAltitudeRef"),
+        gpsAltitude("gpsAltitude"),
+        gpsTimeStamp("gpsTimeStamp"),
+        gpsSatellites("gpsSatellites"),
+        gpsStatus("gpsStatus"),
+        gpsMeasureMode("gpsMeasureMode"),
+        gpsDOP("gpsDOP"),
+        gpsSpeedRef("gpsSpeedRef"),
+        gpsSpeed("gpsSpeed"),
+        gpsTrackRef("gpsTrackRef"),
+        gpsTrack("gpsTrack"),
+        gpsImgDirectionRef("gpsImgDirectionRef"),
+        gpsImgDirection("gpsImgDirection"),
+        gpsMapDatum("gpsMapDatum"),
+        gpsDestLatitudeRef("gpsDestLatitudeRef"),
+        gpsDestLatitude("gpsDestLatitude"),
+        gpsDestLongitudeRef("gpsDestLongitudeRef"),
+        gpsDestLongitude("gpsDestLongitude"),
+        gpsDestBearingRef("gpsDestBearingRef"),
+        gpsDestBearing("gpsDestBearing"),
+        gpsDestDistanceRef("gpsDestDistanceRef"),
+        gpsDestDistance("gpsDestDistance"),
+        gpsProcessingMethod("gpsProcessingMethod"),
+        gpsAreaInformation("gpsAreaInformation"),
+        gpsDateStamp("gpsDateStamp"),
+        gpsDifferential("gpsDifferential"),
         digitalCameraModelName("digitalCameraModelName"),
         digitalCameraModelNumber("digitalCameraModelNumber"),
         digitalCameraModelSerialNo("digitalCameraModelSerialNo"),
@@ -1262,15 +1248,14 @@ public class XmlContentConverter {
         }
     }
 
-
     /* An enumeration for mapping symbols to FITS text metadata element names. */
     public enum TextMDElement {
-        linebreak ("linebreak"),
-        charset ("charset"),
-        markupBasis ("markupBasis"),
-        markupBasisVersion ("markupBasisVersion"),
-        markupLanguage ("markupLanguage"),
-        markupLanguageVersion ("markupLanguageVersion");
+        linebreak("linebreak"),
+        charset("charset"),
+        markupBasis("markupBasis"),
+        markupBasisVersion("markupBasisVersion"),
+        markupLanguage("markupLanguage"),
+        markupLanguageVersion("markupLanguageVersion");
 
         private String name;
 
@@ -1283,22 +1268,21 @@ public class XmlContentConverter {
         }
     }
 
-
     /* An enumeration for mapping symbols to FITS Document metadata element names. */
     public enum DocumentMDElement {
-        pageCount ("pageCount"),
-        wordCount ("wordCount"),
-        characterCount ("characterCount"),
-        paragraphCount ("paragraphCount"),
-        lineCount ("lineCount"),
-        graphicsCount ("graphicsCount"),
-        tableCount ("tableCount"),
+        pageCount("pageCount"),
+        wordCount("wordCount"),
+        characterCount("characterCount"),
+        paragraphCount("paragraphCount"),
+        lineCount("lineCount"),
+        graphicsCount("graphicsCount"),
+        tableCount("tableCount"),
         language("language"),
         font("font"),
         fontName("fontName"), // should only be sub-element of 'font'
         fontIsEmbedded("fontIsEmbedded"), // should only be sub-element of 'font'
         isTagged("isTagged"),
-        hasLayers ("hasLayers"),
+        hasLayers("hasLayers"),
         useTransparency("useTransparency"),
         hasOutline("hasOutline"),
         hasThumbnails("hasThumbnails"),
@@ -1321,15 +1305,15 @@ public class XmlContentConverter {
 
     /* an enumeration for mapping symbols to FITS audio element names */
     public enum AudioFormatElement {
-       	samplingRate ("samplingRate"),
-       	sampleSize ("sampleSize"),
-    	bitRate ("bitRate"),
-    	bitRateMode ("bitRateMode"),
-    	channels ("channels");
+        samplingRate("samplingRate"),
+        sampleSize("sampleSize"),
+        bitRate("bitRate"),
+        bitRateMode("bitRateMode"),
+        channels("channels");
 
-    	private String name;
+        private String name;
 
-    	private AudioFormatElement(String name) {
+        private AudioFormatElement(String name) {
             this.name = name;
         }
 
@@ -1337,21 +1321,21 @@ public class XmlContentConverter {
             return name;
         }
     }
-    
+
     /* An enumeration for mapping symbols to FITS container element names. */
     public enum ContainerMDElement {
-       	entries("entries"),
-       	totalEntries("totalEntries"),
-       	entry("entry"),
-       	format("format"),
-       	formatName("name"),
-       	number("number"),
-       	originalSize ("originalSize"),
-       	compressionMethod ("compressionMethod");
+        entries("entries"),
+        totalEntries("totalEntries"),
+        entry("entry"),
+        format("format"),
+        formatName("name"),
+        number("number"),
+        originalSize("originalSize"),
+        compressionMethod("compressionMethod");
 
-    	private String name;
+        private String name;
 
-    	private ContainerMDElement(String name) {
+        private ContainerMDElement(String name) {
             this.name = name;
         }
 
@@ -1364,83 +1348,82 @@ public class XmlContentConverter {
      * Parse a String value to Integer
      */
     private Integer parseInt(String valueToParse, String fitsElem) {
-    	Integer intValue = null;
-    	try {
-    		intValue = Integer.parseInt(valueToParse);
-    	}
-    	catch (NumberFormatException | NullPointerException e) {
-        	logger.info("Could not parse element [" + fitsElem + "] to Integer: " + valueToParse + " -- ignoring value. Exception message: " + e.getMessage());
-    	}
-    	return intValue;
+        Integer intValue = null;
+        try {
+            intValue = Integer.parseInt(valueToParse);
+        } catch (NumberFormatException | NullPointerException e) {
+            logger.info("Could not parse element [" + fitsElem + "] to Integer: " + valueToParse
+                    + " -- ignoring value. Exception message: " + e.getMessage());
+        }
+        return intValue;
     }
 
     /*
      * Parse a String value to Double
      */
     private Double parseDouble(String valueToParse, String fitsElem) {
-    	Double doubleValue = null;
-    	try {
-    		doubleValue = Double.parseDouble(valueToParse);
-    	}
-    	catch (NumberFormatException | NullPointerException e) {
-        	logger.info("Could not parse element [" + fitsElem + "] Double: " + valueToParse + " -- ignoring value.. Exception message: " + e.getMessage());
-    	}
-    	return doubleValue;
+        Double doubleValue = null;
+        try {
+            doubleValue = Double.parseDouble(valueToParse);
+        } catch (NumberFormatException | NullPointerException e) {
+            logger.info("Could not parse element [" + fitsElem + "] Double: " + valueToParse
+                    + " -- ignoring value.. Exception message: " + e.getMessage());
+        }
+        return doubleValue;
     }
 
     /*
      * Parse a String value to Long
      */
     private Long parseLong(String valueToParse, String fitsElem) {
-    	Long longValue = null;
-    	try {
-    		longValue = Long.parseLong(valueToParse);
-    	}
-    	catch (NumberFormatException | NullPointerException e) {
-        	logger.info("Could not parse element [" + fitsElem + "] to Long: " + valueToParse + " -- ignoring value.. Exception message: " + e.getMessage());
-    	}
-    	return longValue;
+        Long longValue = null;
+        try {
+            longValue = Long.parseLong(valueToParse);
+        } catch (NumberFormatException | NullPointerException e) {
+            logger.info("Could not parse element [" + fitsElem + "] to Long: " + valueToParse
+                    + " -- ignoring value.. Exception message: " + e.getMessage());
+        }
+        return longValue;
     }
-    
+
     /*
      * First convert String input to either Integer or Double then, subsequently, to an OTS Rational value.
      * The input could be fractional, separated by a '/' character which would then get converted to a Rational.
      */
     private Rational parseRational(String valueToParse, String fitsElem) {
-    	Rational rationalValue = null;
-    	Integer intValue = null;
-    	Double dblValue = null;
-    	
-    	try {
-    		intValue = Integer.parseInt(valueToParse);
-    	}
-    	catch(NumberFormatException | NullPointerException e) {} 
-    	
+        Rational rationalValue = null;
+        Integer intValue = null;
+        Double dblValue = null;
+
+        try {
+            intValue = Integer.parseInt(valueToParse);
+        } catch (NumberFormatException | NullPointerException e) {
+        }
+
         if (intValue != null) {
-            rationalValue = new Rational (intValue, 1);
+            rationalValue = new Rational(intValue, 1);
+        } else {
+            try {
+                dblValue = Double.parseDouble(valueToParse);
+            } catch (NumberFormatException | NullPointerException e) {
+            }
+
+            if (dblValue != null) {
+                rationalValue = new Rational((int) (dblValue * 100 + 0.5), 100);
+            } else if (valueToParse.contains("/")) {
+                try {
+                    int num = Integer.parseInt(valueToParse.substring(0, valueToParse.indexOf("/")));
+                    int den = Integer.parseInt(valueToParse.substring(valueToParse.indexOf("/") + 1));
+                    rationalValue = new Rational(num, den);
+                } catch (NumberFormatException | NullPointerException e) {
+                }
+            }
         }
-        else {
-        	try {
-        		dblValue = Double.parseDouble(valueToParse);
-        	}
-        	catch(NumberFormatException | NullPointerException e) {}
-        	
-        	if (dblValue != null) {
-        		rationalValue = new Rational ((int) (dblValue * 100 + 0.5), 100);
-        	}
-        	else if(valueToParse.contains("/")) {
-        		try {
-        			int num = Integer.parseInt(valueToParse.substring(0,valueToParse.indexOf("/")));
-        			int den = Integer.parseInt(valueToParse.substring(valueToParse.indexOf("/")+1));
-        			rationalValue = new Rational(num,den);
-        		}
-        		catch (NumberFormatException | NullPointerException e) {}
-        	}
-        }
-    	
+
         if (rationalValue == null) {
-        	logger.info("Could not parse element [" + fitsElem + "] to Rational -- ignoring valueToParse: [" + valueToParse + "]");
+            logger.info("Could not parse element [" + fitsElem + "] to Rational -- ignoring valueToParse: ["
+                    + valueToParse + "]");
         }
-    	return rationalValue;
+        return rationalValue;
     }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/consolidation/OISConsolidator.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/consolidation/OISConsolidator.java
@@ -10,25 +10,6 @@
 
 package edu.harvard.hul.ois.fits.consolidation;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.ListIterator;
-
-import org.jdom2.Attribute;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.Namespace;
-import org.jdom2.filter.Filters;
-import org.jdom2.input.SAXBuilder;
-import org.jdom2.xpath.XPathExpression;
-import org.jdom2.xpath.XPathFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.FitsOutput;
 import edu.harvard.hul.ois.fits.exceptions.FitsConfigurationException;
@@ -40,754 +21,750 @@ import edu.harvard.hul.ois.fits.tools.Tool;
 import edu.harvard.hul.ois.fits.tools.ToolInfo;
 import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import edu.harvard.hul.ois.fits.tools.utils.XmlUtils;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.ListIterator;
+import org.jdom2.Attribute;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.jdom2.filter.Filters;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OISConsolidator implements ToolOutputConsolidator {
 
-    private static Namespace xsiNS = Namespace.getNamespace("xsi","http://www.w3.org/2001/XMLSchema-instance");
+    private static Namespace xsiNS = Namespace.getNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
     private static Namespace fitsNamespace = Namespace.getNamespace("fits", Fits.XML_NAMESPACE);
 
-	private static final Logger logger = LoggerFactory.getLogger(OISConsolidator.class);
+    private static final Logger logger = LoggerFactory.getLogger(OISConsolidator.class);
 
-	private boolean reportConflicts;
-	private boolean displayToolOutput;
-	private Document formatTree;
-	private Fits fits;
-	private XPathFactory xFactory = XPathFactory.instance();
+    private boolean reportConflicts;
+    private boolean displayToolOutput;
+    private Document formatTree;
+    private Fits fits;
+    private XPathFactory xFactory = XPathFactory.instance();
 
-	private final static int CONFLICT = 0;
-	private final static int SINGLE_RESULT = 1;
-	private final static int ALL_AGREE = 2;
+    private static final int CONFLICT = 0;
+    private static final int SINGLE_RESULT = 1;
+    private static final int ALL_AGREE = 2;
 
-	private final static String TRACK_ELEM_NM = "track";
+    private static final String TRACK_ELEM_NM = "track";
 
-	static private final String REAL_NUMBER = "^[-+]?\\d+(\\.\\d+)?$";
+    private static final String REAL_NUMBER = "^[-+]?\\d+(\\.\\d+)?$";
 
-	static private final List<String> repeatableElements =  new ArrayList<String>(Arrays.asList("linebreak"));  ;
+    private static final List<String> repeatableElements = new ArrayList<String>(Arrays.asList("linebreak"));
+    ;
 
-	private final static Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
+    private static final Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
 
-	private enum STATUS_VALUE {
-		SINGLE_RESULT,
-		PARTIAL,
-		CONFLICT,
-		UNKNOWN;
-	}
+    private enum STATUS_VALUE {
+        SINGLE_RESULT,
+        PARTIAL,
+        CONFLICT,
+        UNKNOWN;
+    }
 
-// This class is instantiated by Reflection in the Fits class using a 1-arg constructor
-//	public OISConsolidator() throws FitsConfigurationException {
-//
-//		reportConflicts = Fits.config.getBoolean("output.report-conflicts",true);
-//		displayToolOutput = Fits.config.getBoolean("output.display-tool-output",false);
-//		SAXBuilder saxBuilder = new SAXBuilder();
-//		try {
-//			formatTree = saxBuilder.build(Fits.FITS_XML_DIR+"fits_format_tree.xml");
-//		} catch (Exception e) {
-//			throw new FitsConfigurationException("",e);
-//		}
-//		//fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
-//	}
+    // This class is instantiated by Reflection in the Fits class using a 1-arg constructor
+    //	public OISConsolidator() throws FitsConfigurationException {
+    //
+    //		reportConflicts = Fits.config.getBoolean("output.report-conflicts",true);
+    //		displayToolOutput = Fits.config.getBoolean("output.display-tool-output",false);
+    //		SAXBuilder saxBuilder = new SAXBuilder();
+    //		try {
+    //			formatTree = saxBuilder.build(Fits.FITS_XML_DIR+"fits_format_tree.xml");
+    //		} catch (Exception e) {
+    //			throw new FitsConfigurationException("",e);
+    //		}
+    //		//fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
+    //	}
 
-	public OISConsolidator(Fits fits) throws FitsConfigurationException {
-		if (fits == null || fits.getConfig() == null) {
-			throw new FitsConfigurationException("Fits parameter to constructor or fits.getConfig() cannot be null.");
-		}
-		this.fits = fits;
-		reportConflicts = fits.getConfig().getBoolean("output.report-conflicts",true);
-		displayToolOutput = fits.getConfig().getBoolean("output.display-tool-output",false);
-		// tool output can be turned on from command line overriding configured value
-		if (fits.isRawToolOutput()) {
-		    displayToolOutput = true;
-		}
-		SAXBuilder saxBuilder = new SAXBuilder();
-		try {
-			formatTree = saxBuilder.build(Fits.FITS_XML_DIR+"fits_format_tree.xml");
-		} catch (Exception e) {
-			throw new FitsConfigurationException("",e);
-		}
-	}
-	
-	private Element findAnElement(List<ToolOutput> results, String xpath_query, boolean useChildren) {
-		for(ToolOutput result : results) {
-			Document dom = result.getFitsXml();
-			//only look at non null dom structures
-			if(dom != null) {
-				
-	            XPathExpression<Element> expr = xFactory.compile(xpath_query, Filters.element(), null, fitsNamespace);
-	            Element e = expr.evaluateFirst(dom);
+    public OISConsolidator(Fits fits) throws FitsConfigurationException {
+        if (fits == null || fits.getConfig() == null) {
+            throw new FitsConfigurationException("Fits parameter to constructor or fits.getConfig() cannot be null.");
+        }
+        this.fits = fits;
+        reportConflicts = fits.getConfig().getBoolean("output.report-conflicts", true);
+        displayToolOutput = fits.getConfig().getBoolean("output.display-tool-output", false);
+        // tool output can be turned on from command line overriding configured value
+        if (fits.isRawToolOutput()) {
+            displayToolOutput = true;
+        }
+        SAXBuilder saxBuilder = new SAXBuilder();
+        try {
+            formatTree = saxBuilder.build(Fits.FITS_XML_DIR + "fits_format_tree.xml");
+        } catch (Exception e) {
+            throw new FitsConfigurationException("", e);
+        }
+    }
 
-	            if(e != null && e.getChildren().size() > 0) {
-					if(useChildren) {
-						e = (Element)e.getChildren().get(0);
-					}
-					List children = e.getChildren();
-					if(children.size()>0) {
-						Element child = (Element)children.get(0);
-						return child;
-					}
-				}
-			}
-		}
-		return null;
-	}
+    private Element findAnElement(List<ToolOutput> results, String xpath_query, boolean useChildren) {
+        for (ToolOutput result : results) {
+            Document dom = result.getFitsXml();
+            // only look at non null dom structures
+            if (dom != null) {
 
-	/**
-	 * Removes null and unknown output from ToolOutput results
-	 * @param results
-	 * @return
-	 */
-	private List<ToolOutput> cullResults(List<ToolOutput> results) {
-		List<ToolOutput> newResults = new ArrayList<ToolOutput>();
-		for(ToolOutput result : results) {
-			if(result != null) {
-				Tool t = result.getTool();
-				//if the tool can't identify files, or if it can and all identities are good
-				if(!t.canIdentify() || (t.canIdentify() && allIdentitiesAreGood(result))) {
-					newResults.add(result);
-				}
-				else {
-					logger.debug("tossing " + t.getName() + " identification because of invalid identification");
-				}
-			}
-		}
-		return newResults;
-	}
+                XPathExpression<Element> expr = xFactory.compile(xpath_query, Filters.element(), null, fitsNamespace);
+                Element e = expr.evaluateFirst(dom);
 
-	/**
-	 * Skips null identities and returns the first tools unknown Identities that are found
-	 * @param results
-	 * @return
-	 */
-	private List<FitsIdentity> getFirstUnknownIdentity(List<ToolOutput> results) {
-		List<FitsIdentity> identities = new ArrayList<FitsIdentity>();
-		for(ToolOutput result : results) {
-			//if result is null skip it
-			if(result == null) {
-				continue;
-			}
-			List<ToolIdentity> toolIdentities = result.getFileIdentity();
-			if(result.getTool().canIdentify() && toolIdentities != null && toolIdentities.size() > 0) {
-				for(ToolIdentity fileIdent : toolIdentities) {
-					identities.add(new FitsIdentity(fileIdent));
-				}
-				break;
-			}
-		}
-		return identities;
-	}
+                if (e != null && e.getChildren().size() > 0) {
+                    if (useChildren) {
+                        e = (Element) e.getChildren().get(0);
+                    }
+                    List children = e.getChildren();
+                    if (children.size() > 0) {
+                        Element child = (Element) children.get(0);
+                        return child;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 
-	/**
-	 * Skips null identities and returns the first tools unknown Identities that are found
-	 * @param results
-	 * @return
-	 */
-	private List<FitsIdentity> getFirstPartialIdentity(List<ToolOutput> results) {
-		List<FitsIdentity> identities = new ArrayList<FitsIdentity>();
-		for(ToolOutput result : results) {
-			//if result is null skip it
-			if(result == null) {
-				continue;
-			}
-			List<ToolIdentity> toolIdentities = result.getFileIdentity();
-			if(result.getTool().canIdentify() && toolIdentities != null && toolIdentities.size() > 0) {
-				if(isPartialIdentity(toolIdentities)) {
-					for(ToolIdentity fileIdent : toolIdentities) {
-						identities.add(new FitsIdentity(fileIdent));
-					}
-					break;
-				}
+    /**
+     * Removes null and unknown output from ToolOutput results
+     * @param results
+     * @return
+     */
+    private List<ToolOutput> cullResults(List<ToolOutput> results) {
+        List<ToolOutput> newResults = new ArrayList<ToolOutput>();
+        for (ToolOutput result : results) {
+            if (result != null) {
+                Tool t = result.getTool();
+                // if the tool can't identify files, or if it can and all identities are good
+                if (!t.canIdentify() || (t.canIdentify() && allIdentitiesAreGood(result))) {
+                    newResults.add(result);
+                } else {
+                    logger.debug("tossing " + t.getName() + " identification because of invalid identification");
+                }
+            }
+        }
+        return newResults;
+    }
 
-			}
-		}
-		return identities;
-	}
+    /**
+     * Skips null identities and returns the first tools unknown Identities that are found
+     * @param results
+     * @return
+     */
+    private List<FitsIdentity> getFirstUnknownIdentity(List<ToolOutput> results) {
+        List<FitsIdentity> identities = new ArrayList<FitsIdentity>();
+        for (ToolOutput result : results) {
+            // if result is null skip it
+            if (result == null) {
+                continue;
+            }
+            List<ToolIdentity> toolIdentities = result.getFileIdentity();
+            if (result.getTool().canIdentify() && toolIdentities != null && toolIdentities.size() > 0) {
+                for (ToolIdentity fileIdent : toolIdentities) {
+                    identities.add(new FitsIdentity(fileIdent));
+                }
+                break;
+            }
+        }
+        return identities;
+    }
 
-	private boolean allIdentitiesAreGood(ToolOutput result) {
-		List<ToolIdentity> identities = result.getFileIdentity();
-		if(identities.size() == 0) {
-			return false;
-		}
-		Tool t = result.getTool();
-		for(ToolIdentity ident : identities) {
-			if(t.isIdentityKnown(ident)) {
-				continue;
-			}
-			else {
-				return false;
-			}
-		}
-		return true;
-	}
+    /**
+     * Skips null identities and returns the first tools unknown Identities that are found
+     * @param results
+     * @return
+     */
+    private List<FitsIdentity> getFirstPartialIdentity(List<ToolOutput> results) {
+        List<FitsIdentity> identities = new ArrayList<FitsIdentity>();
+        for (ToolOutput result : results) {
+            // if result is null skip it
+            if (result == null) {
+                continue;
+            }
+            List<ToolIdentity> toolIdentities = result.getFileIdentity();
+            if (result.getTool().canIdentify() && toolIdentities != null && toolIdentities.size() > 0) {
+                if (isPartialIdentity(toolIdentities)) {
+                    for (ToolIdentity fileIdent : toolIdentities) {
+                        identities.add(new FitsIdentity(fileIdent));
+                    }
+                    break;
+                }
+            }
+        }
+        return identities;
+    }
 
-	private List<Element> mergeXmlResults(List<ToolOutput> results, Element element) {
-		//holder for consolidated elements
-		List<Element> consolidatedElements = new ArrayList<Element>();
-		//Get the element from each ToolOutput result
-		List<Element> fitsElements = new ArrayList<Element>();
-		for(ToolOutput result : results) {
-			Document dom = result.getFitsXml();
-			//if dom is null there is nothing to merge
-			if(dom == null) {
-				continue;
-			}
-			ToolInfo toolInfo = result.getTool().getToolInfo();
-            XPathExpression<Element> expr = xFactory.compile("//fits:"+element.getName(), Filters.element(), null, fitsNamespace);
+    private boolean allIdentitiesAreGood(ToolOutput result) {
+        List<ToolIdentity> identities = result.getFileIdentity();
+        if (identities.size() == 0) {
+            return false;
+        }
+        Tool t = result.getTool();
+        for (ToolIdentity ident : identities) {
+            if (t.isIdentityKnown(ident)) {
+                continue;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private List<Element> mergeXmlResults(List<ToolOutput> results, Element element) {
+        // holder for consolidated elements
+        List<Element> consolidatedElements = new ArrayList<Element>();
+        // Get the element from each ToolOutput result
+        List<Element> fitsElements = new ArrayList<Element>();
+        for (ToolOutput result : results) {
+            Document dom = result.getFitsXml();
+            // if dom is null there is nothing to merge
+            if (dom == null) {
+                continue;
+            }
+            ToolInfo toolInfo = result.getTool().getToolInfo();
+            XPathExpression<Element> expr =
+                    xFactory.compile("//fits:" + element.getName(), Filters.element(), null, fitsNamespace);
             Element e = expr.evaluateFirst(dom);
-			if(e != null) {
-				e.setAttribute("toolname",toolInfo.getName());
-				e.setAttribute("toolversion",toolInfo.getVersion());
-				fitsElements.add(e);
-				e.getParent().removeContent(e);
-			}
-		}
+            if (e != null) {
+                e.setAttribute("toolname", toolInfo.getName());
+                e.setAttribute("toolversion", toolInfo.getVersion());
+                fitsElements.add(e);
+                e.getParent().removeContent(e);
+            }
+        }
 
-		// To make FITS track-aware, we simply allow elements with the name of
-		// "track" to pass through and not be removed by the call to
-		// removeUnknowns
-		//
-		// TODO: Possibly externalize this in a property file, or revise
-		// removeUnknowns() to be track-aware
-		if(!element.getName().equals(TRACK_ELEM_NM)) {
-			//remove any unknown values
-			fitsElements = removeUnknowns(fitsElements);
-		}
+        // To make FITS track-aware, we simply allow elements with the name of
+        // "track" to pass through and not be removed by the call to
+        // removeUnknowns
+        //
+        // TODO: Possibly externalize this in a property file, or revise
+        // removeUnknowns() to be track-aware
+        if (!element.getName().equals(TRACK_ELEM_NM)) {
+            // remove any unknown values
+            fitsElements = removeUnknowns(fitsElements);
+        }
 
-		//if there are no elements after removing unknowns just return null
-		if(fitsElements.size() == 0) {
-			return fitsElements;
-		}
-		int equalityResult = testEquality(fitsElements);
-		if(equalityResult == ALL_AGREE) {
-			//since all tools agreed, or all conflicts could be resolved
-			//return the element without the identifying tool name and version
-			Element e = fitsElements.get(0);
-			//Commented out so tool name and version are always displayed
-			//e.removeAttribute("toolname");
-			//e.removeAttribute("toolversion");
-			consolidatedElements.add(e);
-		}
-		else if(equalityResult == SINGLE_RESULT) {
-			Element e = fitsElements.get(0);
-			e.setAttribute("status", STATUS_VALUE.SINGLE_RESULT.name());
-			consolidatedElements.add(e);
-		}
-		//if configured to report conflicts return all values in fitsElements
-		else if(equalityResult == CONFLICT && reportConflicts && !isRepeatableElement(fitsElements)) {
-			for(Element e : fitsElements) {
-				e.setAttribute("status", STATUS_VALUE.CONFLICT.name());
-			}
-			//to flatten any matches into single results
-			consolidatedElements = consolidateFitsElements(fitsElements);
-		}
-		else {
-			//pick first value using preferred tool list
-			Element e = fitsElements.get(0);
-			consolidatedElements.add(e);
-		}
-		return consolidatedElements;
-	}
+        // if there are no elements after removing unknowns just return null
+        if (fitsElements.size() == 0) {
+            return fitsElements;
+        }
+        int equalityResult = testEquality(fitsElements);
+        if (equalityResult == ALL_AGREE) {
+            // since all tools agreed, or all conflicts could be resolved
+            // return the element without the identifying tool name and version
+            Element e = fitsElements.get(0);
+            // Commented out so tool name and version are always displayed
+            // e.removeAttribute("toolname");
+            // e.removeAttribute("toolversion");
+            consolidatedElements.add(e);
+        } else if (equalityResult == SINGLE_RESULT) {
+            Element e = fitsElements.get(0);
+            e.setAttribute("status", STATUS_VALUE.SINGLE_RESULT.name());
+            consolidatedElements.add(e);
+        }
+        // if configured to report conflicts return all values in fitsElements
+        else if (equalityResult == CONFLICT && reportConflicts && !isRepeatableElement(fitsElements)) {
+            for (Element e : fitsElements) {
+                e.setAttribute("status", STATUS_VALUE.CONFLICT.name());
+            }
+            // to flatten any matches into single results
+            consolidatedElements = consolidateFitsElements(fitsElements);
+        } else {
+            // pick first value using preferred tool list
+            Element e = fitsElements.get(0);
+            consolidatedElements.add(e);
+        }
+        return consolidatedElements;
+    }
 
-	private boolean isRepeatableElement(List<Element> fitsElements) {
-		String name = fitsElements.get(0).getName();
-		if(repeatableElements.contains(name)) {
-			return true;
-		}
-		else {
-			return false;
-		}
-	}
+    private boolean isRepeatableElement(List<Element> fitsElements) {
+        String name = fitsElements.get(0).getName();
+        if (repeatableElements.contains(name)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 
-	private List<Element> consolidateFitsElements(List<Element> fitsElements) {
-		List<Element> conElements = new ArrayList<Element>();
-		for(Element e : fitsElements) {
-			ListIterator<Element> iter = conElements.listIterator();
-			boolean anyMatches = false;
-			while ( iter.hasNext() ) {
-				//compare e with conElement
-				Element conElement = iter.next();
-				if(conElement.getText().equalsIgnoreCase(e.getText())) {
-					//elements match so don't add it
-					anyMatches = true;
-					break;
-				}
-			}
-			if(!anyMatches) {
-				iter.add(e);
-			}
-		}
-		return conElements;
-	}
+    private List<Element> consolidateFitsElements(List<Element> fitsElements) {
+        List<Element> conElements = new ArrayList<Element>();
+        for (Element e : fitsElements) {
+            ListIterator<Element> iter = conElements.listIterator();
+            boolean anyMatches = false;
+            while (iter.hasNext()) {
+                // compare e with conElement
+                Element conElement = iter.next();
+                if (conElement.getText().equalsIgnoreCase(e.getText())) {
+                    // elements match so don't add it
+                    anyMatches = true;
+                    break;
+                }
+            }
+            if (!anyMatches) {
+                iter.add(e);
+            }
+        }
+        return conElements;
+    }
 
-	private synchronized List<Element> removeUnknowns(List<Element> fitsElements) {
-		ListIterator<Element> iter = fitsElements.listIterator();
-		while ( iter.hasNext() ) {
-			Element e = iter.next();
-			if(e.getChildren().isEmpty() && (e == null || e.getValue() == null || e.getText().length() == 0)) {
-				//remove the element from the list
-				iter.remove();
-			}
-		}
-		return fitsElements;
-	}
+    private synchronized List<Element> removeUnknowns(List<Element> fitsElements) {
+        ListIterator<Element> iter = fitsElements.listIterator();
+        while (iter.hasNext()) {
+            Element e = iter.next();
+            if (e.getChildren().isEmpty()
+                    && (e == null || e.getValue() == null || e.getText().length() == 0)) {
+                // remove the element from the list
+                iter.remove();
+            }
+        }
+        return fitsElements;
+    }
 
-	private int testEquality(List<Element> fitsElements) {
-		if(fitsElements.size() == 1) {
-			return SINGLE_RESULT;
-		}
-		Element e = fitsElements.get(0);
-		String eText = e.getText();
-		for(int i=1;i<fitsElements.size();i++) {
-			Element ee = fitsElements.get(i);
-			//if both match as strings
-			if(eText.equalsIgnoreCase(ee.getText())) {
-				continue;
-			}
-			//else check as digits
-			else if(eText.matches(REAL_NUMBER) && ee.getText().matches(REAL_NUMBER)) {
-				Double e_d = Double.parseDouble(eText);
-				Double ee_d =  Double.parseDouble(ee.getText());
-				if(e_d.compareTo(ee_d) == 0) {
-					continue;
-				}
-				else {
-					return CONFLICT;
-				}
-			}
-			else {
-				return CONFLICT;
-			}
-		}
-		return ALL_AGREE;
-	}
+    private int testEquality(List<Element> fitsElements) {
+        if (fitsElements.size() == 1) {
+            return SINGLE_RESULT;
+        }
+        Element e = fitsElements.get(0);
+        String eText = e.getText();
+        for (int i = 1; i < fitsElements.size(); i++) {
+            Element ee = fitsElements.get(i);
+            // if both match as strings
+            if (eText.equalsIgnoreCase(ee.getText())) {
+                continue;
+            }
+            // else check as digits
+            else if (eText.matches(REAL_NUMBER) && ee.getText().matches(REAL_NUMBER)) {
+                Double e_d = Double.parseDouble(eText);
+                Double ee_d = Double.parseDouble(ee.getText());
+                if (e_d.compareTo(ee_d) == 0) {
+                    continue;
+                } else {
+                    return CONFLICT;
+                }
+            } else {
+                return CONFLICT;
+            }
+        }
+        return ALL_AGREE;
+    }
 
-	private boolean parentContainsChild(Element parent, String childName) {
-		List<Element> children = parent.getChildren();
-		for(Element e : children) {
-			if(e.getName().equalsIgnoreCase(childName)) {
-				return true;
-			}
-		}
-		return false;
-	}
+    private boolean parentContainsChild(Element parent, String childName) {
+        List<Element> children = parent.getChildren();
+        for (Element e : children) {
+            if (e.getName().equalsIgnoreCase(childName)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	private List<ToolIdentity> getAllIdentities(List<ToolOutput> results) {
-		List<ToolIdentity> identities = new ArrayList<ToolIdentity>();
-		for(ToolOutput result : results) {
-			if(result.getTool().canIdentify()) {
-				List<ToolIdentity> identList = result.getFileIdentity();
-				for(ToolIdentity ident : identList) {
-					identities.add(ident);
-				}
-			}
-		}
-		return identities;
-	}
+    private List<ToolIdentity> getAllIdentities(List<ToolOutput> results) {
+        List<ToolIdentity> identities = new ArrayList<ToolIdentity>();
+        for (ToolOutput result : results) {
+            if (result.getTool().canIdentify()) {
+                List<ToolIdentity> identList = result.getFileIdentity();
+                for (ToolIdentity ident : identList) {
+                    identities.add(ident);
+                }
+            }
+        }
+        return identities;
+    }
 
-	private boolean identitiesMatch(ToolIdentity a, FitsIdentity b) {
-		//if format and mimetype match
-		if(a.getFormat().equalsIgnoreCase(b.getFormat())
-				&& a.getMime().equalsIgnoreCase(b.getMimetype())) {
-			return true;
-		}
-		else {
-			return false;
-		}
-	}
+    private boolean identitiesMatch(ToolIdentity a, FitsIdentity b) {
+        // if format and mimetype match
+        if (a.getFormat().equalsIgnoreCase(b.getFormat()) && a.getMime().equalsIgnoreCase(b.getMimetype())) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 
-	/**
-	 * merge from a to b
-	 * @return
-	 */
-	private void mergeExternalIdentifiers(ToolIdentity a, FitsIdentity b) {
-		//add external identifiers to consolidated element from the new item, checking for duplicates
-		for(ExternalIdentifier xIdent : a.getExternalIds()) {
-			if(!b.hasExternalIdentifier(xIdent)) {
-				b.addExternalID(xIdent);
-			}
-		}
-	}
+    /**
+     * merge from a to b
+     * @return
+     */
+    private void mergeExternalIdentifiers(ToolIdentity a, FitsIdentity b) {
+        // add external identifiers to consolidated element from the new item, checking for duplicates
+        for (ExternalIdentifier xIdent : a.getExternalIds()) {
+            if (!b.hasExternalIdentifier(xIdent)) {
+                b.addExternalID(xIdent);
+            }
+        }
+    }
 
-	private void mergeFormatVersions(ToolIdentity a, FitsIdentity b) {
-		FormatVersion v = a.getFormatVersion();
-		if(v != null && v.getValue() != null && !b.hasFormatVersion(v)) {
-			b.addFormatVersion(v);
-		}
-	}
+    private void mergeFormatVersions(ToolIdentity a, FitsIdentity b) {
+        FormatVersion v = a.getFormatVersion();
+        if (v != null && v.getValue() != null && !b.hasFormatVersion(v)) {
+            b.addFormatVersion(v);
+        }
+    }
 
-	private List<FitsIdentity> consolidateIdentities(List<ToolIdentity> identities) {
-		List<FitsIdentity> consolidatedIdentities = new ArrayList<FitsIdentity>();
-		for(ToolIdentity ident : identities) {
-			ListIterator<FitsIdentity> iter = consolidatedIdentities.listIterator();
-			boolean anyMatches = false;
-			boolean formatTreeMatch = false;
-			while ( iter.hasNext() ) {
-				//compare ident with conIdent
-				FitsIdentity identitySection = (FitsIdentity)iter.next();
-				if(identitiesMatch(ident,identitySection)) {
-					//Add external identifiers from ident to the existing item
-					mergeExternalIdentifiers(ident,identitySection);
-					//add format versions from ident to the existing item
-					mergeFormatVersions(ident,identitySection);
-					//add reporting tools from ident to the existing item
-					identitySection.addReportingTool(ident.getToolInfo());
-					//we found a match
-					anyMatches = true;
-					break;
-				}
-				//if identities don't match check format tree for specific/generic formats
-				else {
-					int matchCondition = checkFormatTree(ident,identitySection);
-					if(matchCondition == -1) {
-						logger.debug(ident.getFormat() + " is more specific than " + identitySection.getFormat() + " tossing out " + identitySection.getToolName());
-						// remove current identity; add incoming
-						iter.remove();
-						iter.add(new FitsIdentity(ident));
-						anyMatches = true;
-						break;
-					}
-					// existing format is more specific
-					else if(matchCondition == 1) {
-						logger.debug(identitySection.getFormat() + " is more specific than " + ident.getFormat() + " tossing out " + ident.getToolInfo().getName());
-						formatTreeMatch = true;
-						//do nothing, keep going and add to consolidated identities if no other matches
-					}
-					//formats are not specific or generic version of one another
-					else {
-						//leave anyMatches as false so ident is added to consolidated identities
-					}
-				}
-			}
-			//if there were no matches to existing consolidated identities add it
-			if(!anyMatches && !formatTreeMatch) {
-				iter.add(new FitsIdentity(ident));
-			}
-		}
-		return consolidatedIdentities;
-	}
+    private List<FitsIdentity> consolidateIdentities(List<ToolIdentity> identities) {
+        List<FitsIdentity> consolidatedIdentities = new ArrayList<FitsIdentity>();
+        for (ToolIdentity ident : identities) {
+            ListIterator<FitsIdentity> iter = consolidatedIdentities.listIterator();
+            boolean anyMatches = false;
+            boolean formatTreeMatch = false;
+            while (iter.hasNext()) {
+                // compare ident with conIdent
+                FitsIdentity identitySection = (FitsIdentity) iter.next();
+                if (identitiesMatch(ident, identitySection)) {
+                    // Add external identifiers from ident to the existing item
+                    mergeExternalIdentifiers(ident, identitySection);
+                    // add format versions from ident to the existing item
+                    mergeFormatVersions(ident, identitySection);
+                    // add reporting tools from ident to the existing item
+                    identitySection.addReportingTool(ident.getToolInfo());
+                    // we found a match
+                    anyMatches = true;
+                    break;
+                }
+                // if identities don't match check format tree for specific/generic formats
+                else {
+                    int matchCondition = checkFormatTree(ident, identitySection);
+                    if (matchCondition == -1) {
+                        logger.debug(ident.getFormat() + " is more specific than " + identitySection.getFormat()
+                                + " tossing out " + identitySection.getToolName());
+                        // remove current identity; add incoming
+                        iter.remove();
+                        iter.add(new FitsIdentity(ident));
+                        anyMatches = true;
+                        break;
+                    }
+                    // existing format is more specific
+                    else if (matchCondition == 1) {
+                        logger.debug(identitySection.getFormat() + " is more specific than " + ident.getFormat()
+                                + " tossing out " + ident.getToolInfo().getName());
+                        formatTreeMatch = true;
+                        // do nothing, keep going and add to consolidated identities if no other matches
+                    }
+                    // formats are not specific or generic version of one another
+                    else {
+                        // leave anyMatches as false so ident is added to consolidated identities
+                    }
+                }
+            }
+            // if there were no matches to existing consolidated identities add it
+            if (!anyMatches && !formatTreeMatch) {
+                iter.add(new FitsIdentity(ident));
+            }
+        }
+        return consolidatedIdentities;
+    }
 
-	/**
-	 * Returns 1 if a  is more specific than b.  Returns -1 if b is more specific than a.
-	 * If neither is more specific then 0 is returned.
-	 * @param a
-	 * @param b
-	 * @return
-	 */
-	private int checkFormatTree(ToolIdentity a, FitsIdentity b) {
+    /**
+     * Returns 1 if a  is more specific than b.  Returns -1 if b is more specific than a.
+     * If neither is more specific then 0 is returned.
+     * @param a
+     * @param b
+     * @return
+     */
+    private int checkFormatTree(ToolIdentity a, FitsIdentity b) {
 
-		//if formats are equal then just return
-		if(a.getFormat().equals(b.getFormat())) {
-			return 0;
-		}
+        // if formats are equal then just return
+        if (a.getFormat().equals(b.getFormat())) {
+            return 0;
+        }
 
-		//check if a is more specific than b
-		Attribute a_attr = new Attribute("format",a.getFormat());
-		Attribute b_attr = new Attribute("format",b.getFormat());
+        // check if a is more specific than b
+        Attribute a_attr = new Attribute("format", a.getFormat());
+        Attribute b_attr = new Attribute("format", b.getFormat());
 
-		Element root = formatTree.getRootElement();
-		Element a_element = XmlUtils.getChildWithAttribute(root,a_attr);
-		Element b_element = XmlUtils.getChildWithAttribute(root,b_attr);
+        Element root = formatTree.getRootElement();
+        Element a_element = XmlUtils.getChildWithAttribute(root, a_attr);
+        Element b_element = XmlUtils.getChildWithAttribute(root, b_attr);
 
-		if(a_element != null && b_element != null) {
-			//if a contains b's attribute, so b is more specific
-			if(XmlUtils.getChildWithAttribute(a_element,b_attr) != null) {
-				return 1;
-			}
-			//if b contains a's attribute, so a is more specific
-			else if(XmlUtils.getChildWithAttribute(b_element,a_attr) != null) {
-				return -1;
-			}
-			else {
-				return 0;
-			}
-		}
-		return 0;
-	}
+        if (a_element != null && b_element != null) {
+            // if a contains b's attribute, so b is more specific
+            if (XmlUtils.getChildWithAttribute(a_element, b_attr) != null) {
+                return 1;
+            }
+            // if b contains a's attribute, so a is more specific
+            else if (XmlUtils.getChildWithAttribute(b_element, a_attr) != null) {
+                return -1;
+            } else {
+                return 0;
+            }
+        }
+        return 0;
+    }
 
-	private void filterToolOutput(FitsIdentity section, List<ToolOutput> results) {
-		ListIterator<ToolOutput> iter = results.listIterator();
-		while ( iter.hasNext() ) {
-			ToolOutput result = iter.next();
-			//if the identity section doesn't contain the results from the tool remove it
-			if(!section.hasOutputFromTool(result.getTool().getToolInfo())) {
-				iter.remove();
-			}
-		}
-	}
+    private void filterToolOutput(FitsIdentity section, List<ToolOutput> results) {
+        ListIterator<ToolOutput> iter = results.listIterator();
+        while (iter.hasNext()) {
+            ToolOutput result = iter.next();
+            // if the identity section doesn't contain the results from the tool remove it
+            if (!section.hasOutputFromTool(result.getTool().getToolInfo())) {
+                iter.remove();
+            }
+        }
+    }
 
+    /* (non-Javadoc)
+     * @see edu.harvard.hul.ois.fits.DataConsolidator#processResults(java.util.List)
+     */
+    public FitsOutput processResults(List<ToolOutput> results) {
+        // Remove any null results, or results from tools that have the capability to identify files,
+        // but couldn't identify the file.
+        List<ToolOutput> culledResults = cullResults(results);
 
-	/* (non-Javadoc)
-	 * @see edu.harvard.hul.ois.fits.DataConsolidator#processResults(java.util.List)
-	 */
-	public FitsOutput processResults(List<ToolOutput> results) {
-		//Remove any null results, or results from tools that have the capability to identify files,
-		// but couldn't identify the file.
-		List<ToolOutput> culledResults = cullResults(results);
+        // start building the FITS xml document
+        Document mergedDoc = new Document();
+        Element elem = new Element("fits", fitsNS);
 
-		//start building the FITS xml document
-		Document mergedDoc = new Document();
-		Element elem = new Element("fits",fitsNS);
+        elem.addNamespaceDeclaration(xsiNS);
+        elem.setAttribute(
+                new Attribute("schemaLocation", Fits.XML_NAMESPACE + " " + fits.getExternalOutputSchema(), xsiNS));
 
-		elem.addNamespaceDeclaration(xsiNS);
-		elem.setAttribute(new Attribute("schemaLocation",
-										Fits.XML_NAMESPACE + " " + fits.getExternalOutputSchema(),
-										xsiNS));
+        elem.setAttribute("version", Fits.VERSION);
+        DateFormat dateFormat = new SimpleDateFormat();
+        Date date = new Date();
+        elem.setAttribute("timestamp", dateFormat.format(date));
 
-		elem.setAttribute("version", Fits.VERSION);
-		DateFormat dateFormat = new SimpleDateFormat();
-		Date date = new Date();
-		elem.setAttribute("timestamp",dateFormat.format(date));
+        Element identificationsection = new Element("identification", fitsNS);
+        elem.addContent(identificationsection);
+        mergedDoc.addContent(elem);
 
-		Element identificationsection = new Element("identification",fitsNS);
-		elem.addContent(identificationsection);
-		mergedDoc.addContent(elem);
+        String curSec;
+        String curSecName;
 
-		String curSec;
-		String curSecName;
+        // check identities
+        // one "identity" per unique combination of format and mimetype
+        List<ToolIdentity> identities = getAllIdentities(culledResults);
+        List<FitsIdentity> identitySections = new ArrayList<FitsIdentity>();
+        boolean unknownStatus = false;
+        boolean partialStatus = false;
+        // If there are no known identities in the culled results
+        if (identities.size() == 0) {
+            // try to find a partial identity match in the original results
+            identitySections = getFirstPartialIdentity(results);
+            if (identitySections.size() == 0) {
+                // get the first default unknown identity from original results
+                unknownStatus = true;
+                identitySections = getFirstUnknownIdentity(results);
+            } else {
+                partialStatus = true;
+            }
 
-		//check identities
-			//one "identity" per unique combination of format and mimetype
-		List<ToolIdentity> identities = getAllIdentities(culledResults);
-		List<FitsIdentity> identitySections = new ArrayList<FitsIdentity>();
-		boolean unknownStatus = false;
-		boolean partialStatus = false;
-		//If there are no known identities in the culled results
-		if(identities.size() == 0) {
-			//try to find a partial identity match in the original results
-			identitySections = getFirstPartialIdentity(results);
-			if(identitySections.size() == 0)  {
-				//get the first default unknown identity from original results
-				unknownStatus = true;
-				identitySections = getFirstUnknownIdentity(results);
-			}
-			else {
-				partialStatus = true;
-			}
+        } else {
+            // else merge the known identities
+            identitySections = consolidateIdentities(identities);
+        }
 
-		}
-		else {
-			//else merge the known identities
-			identitySections = consolidateIdentities(identities);
-		}
+        for (FitsIdentity identSection : identitySections) {
+            Element identElement = new Element("identity", fitsNS);
+            Attribute identFormatAttr = new Attribute("format", identSection.getFormat());
+            Attribute identMimeAttr = new Attribute("mimetype", identSection.getMimetype());
+            Attribute fitsToolName = new Attribute("toolname", identSection.getToolName());
+            Attribute fitsToolVersion = new Attribute("toolversion", identSection.getToolVersion());
 
-		for(FitsIdentity identSection : identitySections) {
-			Element identElement = new Element("identity",fitsNS);
-			Attribute identFormatAttr = new Attribute("format",identSection.getFormat());
-			Attribute identMimeAttr = new Attribute("mimetype",identSection.getMimetype());
-			Attribute fitsToolName = new Attribute("toolname",identSection.getToolName());
-			Attribute fitsToolVersion = new Attribute("toolversion",identSection.getToolVersion());
+            // set format and mimetype attributes
+            identElement.setAttribute(identFormatAttr);
+            identElement.setAttribute(identMimeAttr);
+            identElement.setAttribute(fitsToolName);
+            identElement.setAttribute(fitsToolVersion);
 
-			//set format and mimetype attributes
-			identElement.setAttribute(identFormatAttr);
-			identElement.setAttribute(identMimeAttr);
-			identElement.setAttribute(fitsToolName);
-			identElement.setAttribute(fitsToolVersion);
+            // add reporting tools
+            for (ToolInfo info : identSection.getReportingTools()) {
+                Element tool = new Element("tool", fitsNS);
+                tool.setAttribute("toolname", info.getName());
+                tool.setAttribute("toolversion", info.getVersion());
+                identElement.addContent(tool);
+            }
+            // tools agree
+            boolean toolsAgree = (identitySections.size() == 1
+                    && identSection.getReportingTools().size() > 1);
 
-			//add reporting tools
-			for(ToolInfo info : identSection.getReportingTools()) {
-				Element tool = new Element("tool",fitsNS);
-				tool.setAttribute("toolname", info.getName());
-				tool.setAttribute("toolversion", info.getVersion());
-				identElement.addContent(tool);
-			}
-			 // tools agree
-			 boolean toolsAgree = (identitySections.size() == 1 && identSection.getReportingTools().size() > 1);
+            // add format version
 
-			//add format version
+            List<FormatVersion> formatVersions = identSection.getFormatVersions();
+            String formatStatus = null;
+            if (formatVersions.size() > 1) {
+                formatStatus = STATUS_VALUE.CONFLICT.name();
+            }
 
-			List<FormatVersion> formatVersions = identSection.getFormatVersions();
-			String formatStatus = null;
-			if(formatVersions.size() > 1) {
-				formatStatus = STATUS_VALUE.CONFLICT.name();
-			}
+            // only add if there is a version number to report
+            if (formatVersions.size() > 0) {
+                for (FormatVersion version : formatVersions) {
+                    Element identVersion = new Element("version", fitsNS);
+                    identVersion.setAttribute("toolname", version.getToolInfo().getName());
+                    identVersion.setAttribute(
+                            "toolversion", version.getToolInfo().getVersion());
+                    if (formatStatus != null) {
+                        identVersion.setAttribute("status", formatStatus);
+                    }
+                    identVersion.setText(version.getValue());
+                    identElement.addContent(identVersion);
+                }
+            }
 
-			//only add if there is a version number to report
-			if(formatVersions.size() > 0) {
-				for(FormatVersion version : formatVersions) {
-					Element identVersion = new Element("version",fitsNS);
-					identVersion.setAttribute("toolname",version.getToolInfo().getName());
-					identVersion.setAttribute("toolversion",version.getToolInfo().getVersion());
-					if(formatStatus != null) {
-						identVersion.setAttribute("status",formatStatus);
-					}
-					identVersion.setText(version.getValue());
-					identElement.addContent(identVersion);
-				}
-			}
+            for (ExternalIdentifier xId : identSection.getExternalIdentifiers()) {
+                Element externalID = new Element("externalIdentifier", fitsNS);
+                ToolInfo xIdInfo = xId.getToolInfo();
+                externalID.setAttribute("toolname", xIdInfo.getName());
+                externalID.setAttribute("toolversion", xIdInfo.getVersion());
+                externalID.setAttribute("type", xId.getName());
+                externalID.setText(xId.getValue());
+                identElement.addContent(externalID);
+            }
+            // set the status of the section
+            String status = "";
+            if (identitySections.size() > 1 && reportConflicts) {
+                status = STATUS_VALUE.CONFLICT.name();
+            } else if ((identitySections.size() == 1 && (!unknownStatus && !partialStatus && !toolsAgree))
+                    || !reportConflicts) {
+                status = STATUS_VALUE.SINGLE_RESULT.name();
+            } else if (identitySections.size() == 1 && partialStatus) {
+                status = STATUS_VALUE.PARTIAL.name();
+            } else if (!toolsAgree) {
+                status = STATUS_VALUE.UNKNOWN.name();
+            }
 
-			for(ExternalIdentifier xId : identSection.getExternalIdentifiers()) {
-				Element externalID = new Element("externalIdentifier",fitsNS);
-				ToolInfo xIdInfo = xId.getToolInfo();
-				externalID.setAttribute("toolname",xIdInfo.getName());
-				externalID.setAttribute("toolversion",xIdInfo.getVersion());
-				externalID.setAttribute("type",xId.getName());
-				externalID.setText(xId.getValue());
-				identElement.addContent(externalID);
-			}
-			//set the status of the section
-			String status = "";
-			if(identitySections.size() > 1 && reportConflicts) {
-				status = STATUS_VALUE.CONFLICT.name();
-			}
-			else if((identitySections.size() == 1 && (!unknownStatus && !partialStatus && !toolsAgree)) || !reportConflicts) {
-				status = STATUS_VALUE.SINGLE_RESULT.name();
-			}
-			else if(identitySections.size() == 1 && partialStatus) {
-				status = STATUS_VALUE.PARTIAL.name();
-			}
-			else if (!toolsAgree) {
-				status = STATUS_VALUE.UNKNOWN.name();
-			}
+            if (status != "") {
+                identificationsection.setAttribute("status", status);
+            }
 
-			 if (status != "")
-				 {
-						identificationsection.setAttribute("status",status);
-				 }
+            identificationsection.addContent(identElement);
 
-			identificationsection.addContent(identElement);
+            // if conflicts are being reported continue, else break after 1 iteration
+            if (reportConflicts) {
+                continue;
+            } else {
+                break;
+            }
+        }
 
-			//if conflicts are being reported continue, else break after 1 iteration
-			if(reportConflicts) {
-				continue;
-			}
-			else {
-				break;
-			}
-		}
+        // check fileinfo, do normal xml comparison.  Use all non-culled tool output
+        curSec = "/fits:fits/fits:fileinfo";
+        // curSec = "/fits/fileinfo";
+        curSecName = "fileinfo";
+        Element s = new Element(curSecName, fitsNS);
+        elem.addContent(s);
+        Element e = null;
+        while ((e = findAnElement(culledResults, curSec, false)) != null) {
+            List<Element> fitsElements = mergeXmlResults(culledResults, e);
+            for (Element fitsElement : fitsElements) {
+                s.addContent(fitsElement);
+            }
+        }
 
-		//check fileinfo, do normal xml comparison.  Use all non-culled tool output
-		curSec = "/fits:fits/fits:fileinfo";
-		//curSec = "/fits/fileinfo";
-		curSecName = "fileinfo";
-		Element s = new Element(curSecName,fitsNS);
-		elem.addContent(s);
-		Element e = null;
-		while((e = findAnElement(culledResults,curSec,false)) != null) {
-			List<Element> fitsElements = mergeXmlResults(culledResults, e);
-			for(Element fitsElement : fitsElements) {
-				s.addContent(fitsElement);
-			}
-		}
+        if (fits.isConsolidateFirstIdentity()) {
+            // Only use the output from tools that we're able to identify
+            // the file and are in the first identity section
+            if (identitySections.size() > 0) {
+                filterToolOutput(identitySections.get(0), culledResults);
+            }
+        }
 
-		if (fits.isConsolidateFirstIdentity()) {
-			// Only use the output from tools that we're able to identify
-			// the file and are in the first identity section
-			if(identitySections.size() > 0) {
-				filterToolOutput(identitySections.get(0),culledResults);
-			}
-		}
+        // check filestatus, do normal xml comparison
+        curSec = "/fits:fits/fits:filestatus";
+        // curSec = "/fits/filestatus";
+        curSecName = "filestatus";
+        s = new Element(curSecName, fitsNS);
+        elem.addContent(s);
+        e = null;
+        while ((e = findAnElement(culledResults, curSec, false)) != null) {
+            List<Element> fitsElements = mergeXmlResults(culledResults, e);
+            for (Element fitsElement : fitsElements) {
+                s.addContent(fitsElement);
+            }
+        }
 
-		//check filestatus, do normal xml comparison
-		curSec = "/fits:fits/fits:filestatus";
-		//curSec = "/fits/filestatus";
-		curSecName = "filestatus";
-		s = new Element(curSecName,fitsNS);
-		elem.addContent(s);
-		e = null;
-		while((e = findAnElement(culledResults,curSec,false)) != null) {
-			List<Element> fitsElements = mergeXmlResults(culledResults, e);
-			for(Element fitsElement : fitsElements) {
-				s.addContent(fitsElement);
-			}
-		}
+        // check metadata/child
+        // if child.getParent() !exist in mergedDoc, then create and add these elements to it.
+        //  else, add to existing section in mergedDoc
+        // then do normal xml comparison
+        curSec = "/fits:fits/fits:metadata";
+        // curSec = "/fits/metadata";
+        curSecName = "metadata";
+        s = new Element(curSecName, fitsNS);
+        elem.addContent(s);
+        e = null;
+        while ((e = findAnElement(culledResults, curSec, true)) != null) {
+            Element eParent = e.getParentElement();
+            Element metadataType = null;
+            if (!parentContainsChild(s, eParent.getName())) {
+                metadataType = new Element(eParent.getName(), fitsNS);
+                s.addContent(metadataType);
+            } else {
+                metadataType = s.getChild(eParent.getName(), fitsNS);
+            }
+            List<Element> fitsElements = mergeXmlResults(culledResults, e);
+            for (Element fitsElement : fitsElements) {
+                metadataType.addContent(fitsElement);
+            }
+        }
 
-		//check metadata/child
-			//if child.getParent() !exist in mergedDoc, then create and add these elements to it.
-			//  else, add to existing section in mergedDoc
-			//then do normal xml comparison
-		curSec = "/fits:fits/fits:metadata";
-		//curSec = "/fits/metadata";
-		curSecName = "metadata";
-		s = new Element(curSecName,fitsNS);
-		elem.addContent(s);
-		e = null;
-		while((e = findAnElement(culledResults,curSec,true)) != null) {
-			Element eParent = e.getParentElement();
-			Element metadataType = null;
-			if(!parentContainsChild(s,eParent.getName())) {
-				metadataType = new Element(eParent.getName(),fitsNS);
-				s.addContent(metadataType);
-			}
-			else {
-				metadataType = s.getChild(eParent.getName(),fitsNS);
-			}
-			List<Element> fitsElements = mergeXmlResults(culledResults, e);
-			for(Element fitsElement : fitsElements) {
-				metadataType.addContent(fitsElement);
-			}
-		}
+        // Consolidate results from each tool
+        // Check for identical and unknown values for each field
+        // Check format tree for specific/generic formats
+        // if conflicts exist && configured to report multiple values in conflict
+        // report both values
+        // else
+        // pick value using preferred tool list ordering
 
+        // while non empty results exist - check for elements in //identity, //info and //metadata (method for this)
+        // Start with first result that is not empty (method for this to grab any element from these sections)
+        // pull out an element
+        //  /fits/summary/identity
+        //  /fits/summary/info
+        //  /fits/summary/metadata
+        // look up and pull that element out of other results
+        // do comparison
+        // Identical?
+        // unknown values?
+        // consult tree?
+        // configured to report multiple conflicting values?
+        // use preferred ordering of tools
+        // add result or results if configured to report multiples when conflict exists
+        // to mergedDoc
 
-		//Consolidate results from each tool
-		// Check for identical and unknown values for each field
-		// Check format tree for specific/generic formats
-		// if conflicts exist && configured to report multiple values in conflict
-			//report both values
-		// else
-			// pick value using preferred tool list ordering
+        // continue with next element until result is empty
+        // continue with all results until all are empty.
 
+        if (displayToolOutput) {
+            Element toolOutput = new Element("toolOutput", fitsNS);
+            for (ToolOutput output : results) {
+                if (output != null) {
+                    Element tool = new Element("tool", fitsNS);
+                    tool.setAttribute("name", output.getTool().getToolInfo().getName());
+                    tool.setAttribute("version", output.getTool().getToolInfo().getVersion());
+                    Document doc = output.getToolOutput();
+                    if (doc != null) {
+                        Element root = (Element) doc.getRootElement().detach();
+                        tool.addContent(root);
+                        toolOutput.addContent(tool);
+                    }
+                }
+            }
+            elem.addContent(toolOutput);
+        }
 
-		//while non empty results exist - check for elements in //identity, //info and //metadata (method for this)
-		//Start with first result that is not empty (method for this to grab any element from these sections)
-			//pull out an element
-				//  /fits/summary/identity
-				//  /fits/summary/info
-				//  /fits/summary/metadata
-			//look up and pull that element out of other results
-			//do comparison
-				//Identical?
-				//unknown values?
-				//consult tree?
-				//configured to report multiple conflicting values?
-					//use preferred ordering of tools
-			//add result or results if configured to report multiples when conflict exists
-			//to mergedDoc
+        FitsOutput result = new FitsOutput(mergedDoc);
+        return result;
+    }
 
-			//continue with next element until result is empty
-			//continue with all results until all are empty.
+    private boolean isPartialIdentity(List<ToolIdentity> identities) {
+        ToolIdentity identity = identities.get(0);
+        if (identity != null) {
+            String mime = identity.getMime();
+            String format = identity.getFormat();
 
-		if(displayToolOutput) {
-			Element toolOutput = new Element("toolOutput",fitsNS);
-			for(ToolOutput output : results) {
-				if(output != null) {
-					Element tool = new Element("tool",fitsNS);
-					tool.setAttribute("name",output.getTool().getToolInfo().getName());
-					tool.setAttribute("version",output.getTool().getToolInfo().getVersion());
-					Document doc = output.getToolOutput();
-					if(doc != null) {
-						Element root = (Element)doc.getRootElement().detach();
-						tool.addContent(root);
-						toolOutput.addContent(tool);
-						}
-				}
-			}
-			elem.addContent(toolOutput);
-		}
+            boolean validMime = (mime != null && mime.length() > 0);
+            boolean validFormat = (format != null && format.length() > 0);
 
-		FitsOutput result = new FitsOutput(mergedDoc);
-		return result;
-	}
-
-	private boolean isPartialIdentity(List<ToolIdentity> identities) {
-		ToolIdentity identity = identities.get(0);
-		if(identity != null) {
-			String mime = identity.getMime();
-			String format = identity.getFormat();
-
-			boolean validMime = (mime != null && mime.length()>0);
-			boolean validFormat = (format != null && format.length()>0);
-
-			if((validMime && validFormat) ||
-					(validMime && !validFormat) ||
-					(validFormat && !validMime)) {
-				if((mime.equals("application/octet-stream")
-						&& !format.equals("Unknown Binary"))
-						||
-						(format.equals("Unknown Binary")
-						&& !mime.equals("application/octet-stream"))) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
+            if ((validMime && validFormat) || (validMime && !validFormat) || (validFormat && !validMime)) {
+                if ((mime.equals("application/octet-stream") && !format.equals("Unknown Binary"))
+                        || (format.equals("Unknown Binary") && !mime.equals("application/octet-stream"))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/consolidation/ToolOutputConsolidator.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/consolidation/ToolOutputConsolidator.java
@@ -8,16 +8,13 @@
 // See the License for the specific language governing permission and limitations under the License.
 //
 
-
 package edu.harvard.hul.ois.fits.consolidation;
-
-import java.util.List;
 
 import edu.harvard.hul.ois.fits.FitsOutput;
 import edu.harvard.hul.ois.fits.tools.ToolOutput;
+import java.util.List;
 
 public interface ToolOutputConsolidator {
 
-	public FitsOutput processResults(List<ToolOutput> results);
-
+    public FitsOutput processResults(List<ToolOutput> results);
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/consolidation/VersionComparer.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/consolidation/VersionComparer.java
@@ -8,7 +8,6 @@
 // See the License for the specific language governing permission and limitations under the License.
 //
 
-
 package edu.harvard.hul.ois.fits.consolidation;
 
 import java.io.IOException;
@@ -58,8 +57,8 @@ public final class VersionComparer implements Serializable, Comparable<VersionCo
         major = 0;
         minor = 0;
         build = 0;
-        name = ""; //$NON-NLS-1$
-        StringTokenizer st = new StringTokenizer(str, "" + SEPARATOR, false); //$NON-NLS-1$
+        name = ""; // $NON-NLS-1$
+        StringTokenizer st = new StringTokenizer(str, "" + SEPARATOR, false); // $NON-NLS-1$
         // major segment
         if (!st.hasMoreTokens()) {
             return;
@@ -120,12 +119,11 @@ public final class VersionComparer implements Serializable, Comparable<VersionCo
      * @param aBuild build number
      * @param aName build name, <code>null</code> value becomes empty string
      */
-    public VersionComparer(final int aMajor, final int aMinor, final int aBuild,
-            final String aName) {
+    public VersionComparer(final int aMajor, final int aMinor, final int aBuild, final String aName) {
         major = aMajor;
         minor = aMinor;
         build = aBuild;
-        name = (aName == null) ? "" : aName; //$NON-NLS-1$
+        name = (aName == null) ? "" : aName; // $NON-NLS-1$
     }
 
     /**
@@ -183,11 +181,11 @@ public final class VersionComparer implements Serializable, Comparable<VersionCo
         if ((major == other.major) && (minor > other.minor)) {
             return true;
         }
-        if ((major == other.major) && (minor == other.minor)
-                && (build > other.build)) {
+        if ((major == other.major) && (minor == other.minor) && (build > other.build)) {
             return true;
         }
-        if ((major == other.major) && (minor == other.minor)
+        if ((major == other.major)
+                && (minor == other.minor)
                 && (build == other.build)
                 && name.equalsIgnoreCase(other.name)) {
             return true;
@@ -288,7 +286,6 @@ public final class VersionComparer implements Serializable, Comparable<VersionCo
             return true;
         }
         return false;
-
     }
 
     /**
@@ -311,7 +308,8 @@ public final class VersionComparer implements Serializable, Comparable<VersionCo
             return false;
         }
         VersionComparer other = (VersionComparer) obj;
-        if ((major != other.major) || (minor != other.minor)
+        if ((major != other.major)
+                || (minor != other.minor)
                 || (build != other.build)
                 || !name.equalsIgnoreCase(other.name)) {
             return false;
@@ -329,7 +327,7 @@ public final class VersionComparer implements Serializable, Comparable<VersionCo
     public String toString() {
         if (asString == null) {
             asString = "" + major + SEPARATOR + minor + SEPARATOR + build //$NON-NLS-1$
-                + (name.length() == 0 ? "" : SEPARATOR + name); //$NON-NLS-1$
+                    + (name.length() == 0 ? "" : SEPARATOR + name); // $NON-NLS-1$
         }
         return asString;
     }
@@ -352,8 +350,7 @@ public final class VersionComparer implements Serializable, Comparable<VersionCo
         if (build != obj.build) {
             return build - obj.build;
         }
-        return name.toLowerCase(Locale.ENGLISH).compareTo(
-                obj.name.toLowerCase(Locale.ENGLISH));
+        return name.toLowerCase(Locale.ENGLISH).compareTo(obj.name.toLowerCase(Locale.ENGLISH));
     }
 
     // Serialization related stuff.

--- a/src/main/java/edu/harvard/hul/ois/fits/exceptions/FitsConfigurationException.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/exceptions/FitsConfigurationException.java
@@ -8,24 +8,24 @@
 // See the License for the specific language governing permission and limitations under the License.
 //
 
-
 package edu.harvard.hul.ois.fits.exceptions;
 
 public class FitsConfigurationException extends FitsException {
 
-	/**
-	 * generated serial id
-	 */
-	private static final long serialVersionUID = -513805006091059617L;
+    /**
+     * generated serial id
+     */
+    private static final long serialVersionUID = -513805006091059617L;
 
-	public FitsConfigurationException() {
-		super();
-	}
+    public FitsConfigurationException() {
+        super();
+    }
+
     public FitsConfigurationException(String message) {
         super(message);
     }
-    public FitsConfigurationException(String message, Exception e) {
-    	super(message,e);
-    }
 
+    public FitsConfigurationException(String message, Exception e) {
+        super(message, e);
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/exceptions/FitsException.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/exceptions/FitsException.java
@@ -12,34 +12,37 @@ package edu.harvard.hul.ois.fits.exceptions;
 
 public class FitsException extends Exception {
 
-	/**
-	 * generated serial id
-	 */
-	private static final long serialVersionUID = 1266363844796336485L;
-	private Throwable embeddedException = null;
-	private String message;
+    /**
+     * generated serial id
+     */
+    private static final long serialVersionUID = 1266363844796336485L;
 
-	public FitsException() {
-		super();
-	}
+    private Throwable embeddedException = null;
+    private String message;
+
+    public FitsException() {
+        super();
+    }
+
     public FitsException(String message) {
         this();
         this.message = message;
     }
+
     public FitsException(String message, Throwable e) {
         this();
         this.embeddedException = e;
         this.message = message;
-        if (e.getMessage() != null){
+        if (e.getMessage() != null) {
             this.message = this.message + " (" + e.getMessage() + ")";
         }
     }
 
     public String getMessage() {
-    	return message;
+        return message;
     }
 
     public Throwable getEmbeddedException() {
-    	return embeddedException;
+        return embeddedException;
     }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/exceptions/FitsToolCLIException.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/exceptions/FitsToolCLIException.java
@@ -12,19 +12,20 @@ package edu.harvard.hul.ois.fits.exceptions;
 
 public class FitsToolCLIException extends FitsToolException {
 
-	/**
-	 * generated serial id
-	 */
-	private static final long serialVersionUID = 7600086963317407645L;
+    /**
+     * generated serial id
+     */
+    private static final long serialVersionUID = 7600086963317407645L;
 
-	public FitsToolCLIException() {
-		super();
-	}
+    public FitsToolCLIException() {
+        super();
+    }
+
     public FitsToolCLIException(String message) {
         super(message);
     }
-    public FitsToolCLIException(String message, Exception e) {
-    	super(message,e);
-    }
 
+    public FitsToolCLIException(String message, Exception e) {
+        super(message, e);
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/exceptions/FitsToolException.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/exceptions/FitsToolException.java
@@ -12,18 +12,20 @@ package edu.harvard.hul.ois.fits.exceptions;
 
 public class FitsToolException extends FitsException {
 
-	/**
-	 * generated serial id
-	 */
-	private static final long serialVersionUID = -1253164097737356624L;
-	public FitsToolException() {
-		super();
-	}
+    /**
+     * generated serial id
+     */
+    private static final long serialVersionUID = -1253164097737356624L;
+
+    public FitsToolException() {
+        super();
+    }
+
     public FitsToolException(String message) {
         super(message);
     }
-    public FitsToolException(String message, Throwable e) {
-    	super(message,e);
-    }
 
+    public FitsToolException(String message, Throwable e) {
+        super(message, e);
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/identity/ExternalIdentifier.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/identity/ExternalIdentifier.java
@@ -14,52 +14,52 @@ import edu.harvard.hul.ois.fits.tools.ToolInfo;
 
 public class ExternalIdentifier {
 
-	private String name;
-	private String value;
-	private ToolInfo toolInfo;
+    private String name;
+    private String value;
+    private ToolInfo toolInfo;
 
-	public ExternalIdentifier() {
+    public ExternalIdentifier() {}
 
-	}
+    public ExternalIdentifier(String name, String value, ToolInfo toolInfo) {
+        this.name = name;
+        this.value = value;
+        this.toolInfo = toolInfo;
+    }
 
-	public ExternalIdentifier(String name, String value, ToolInfo toolInfo) {
-		this.name = name;
-		this.value = value;
-		this.toolInfo = toolInfo;
-	}
+    public ToolInfo getToolInfo() {
+        return toolInfo;
+    }
 
-	public ToolInfo getToolInfo() {
-		return toolInfo;
-	}
+    public void setToolInfo(ToolInfo toolInfo) {
+        this.toolInfo = toolInfo;
+    }
 
-	public void setToolInfo(ToolInfo toolInfo) {
-		this.toolInfo = toolInfo;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public String getName() {
-		return name;
-	}
-	public void setName(String name) {
-		this.name = name;
-	}
-	public String getValue() {
-		return value;
-	}
-	public void setValue(String value) {
-		this.value = value;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	@Override
-	public String toString() {
-		StringBuilder builder = new StringBuilder();
-		builder.append("ExternalIdentifier [name=");
-		builder.append(name);
-		builder.append(", value=");
-		builder.append(value);
-		builder.append(", toolInfo=");
-		builder.append(toolInfo);
-		builder.append("]");
-		return builder.toString();
-	}
+    public String getValue() {
+        return value;
+    }
 
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("ExternalIdentifier [name=");
+        builder.append(name);
+        builder.append(", value=");
+        builder.append(value);
+        builder.append(", toolInfo=");
+        builder.append(toolInfo);
+        builder.append("]");
+        return builder.toString();
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/identity/FitsIdentity.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/identity/FitsIdentity.java
@@ -6,16 +6,16 @@
 // Unless required by applicable law or agreed to in writing, software distributed under the License is
 // distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permission and limitations under the License.
-// 
+//
 
 package edu.harvard.hul.ois.fits.identity;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.consolidation.VersionComparer;
 import edu.harvard.hul.ois.fits.tools.ToolInfo;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A non-tool-specific container for identification information about a file.
  * Like ToolIdentity, it holds the format name,
@@ -29,159 +29,157 @@ import edu.harvard.hul.ois.fits.tools.ToolInfo;
  *
  */
 public class FitsIdentity {
-	private String format;
-	private String mimetype;
-	private String toolName;
-	private String toolVersion;
-	private List<FormatVersion> formatVersions = new ArrayList<FormatVersion>();
-	private List<ToolInfo> reportingTools = new ArrayList<ToolInfo>();
-	private List<ExternalIdentifier> externalIDs = new ArrayList<ExternalIdentifier>();
+    private String format;
+    private String mimetype;
+    private String toolName;
+    private String toolVersion;
+    private List<FormatVersion> formatVersions = new ArrayList<FormatVersion>();
+    private List<ToolInfo> reportingTools = new ArrayList<ToolInfo>();
+    private List<ExternalIdentifier> externalIDs = new ArrayList<ExternalIdentifier>();
 
-	public FitsIdentity() {
-		toolName= "FITS";
-		toolVersion = Fits.VERSION;
-	}
+    public FitsIdentity() {
+        toolName = "FITS";
+        toolVersion = Fits.VERSION;
+    }
 
-	public FitsIdentity(ToolIdentity identity) {
-		this.format = identity.getFormat();
-		this.mimetype = identity.getMime();
-		toolName= "FITS";
-		toolVersion = Fits.VERSION;
-		if(identity.getFormatVersionValue() != null) {
-			formatVersions.add(identity.getFormatVersion());
-		}
-		externalIDs.addAll(identity.getExternalIds());
-		reportingTools.add(identity.getToolInfo());
-	}
+    public FitsIdentity(ToolIdentity identity) {
+        this.format = identity.getFormat();
+        this.mimetype = identity.getMime();
+        toolName = "FITS";
+        toolVersion = Fits.VERSION;
+        if (identity.getFormatVersionValue() != null) {
+            formatVersions.add(identity.getFormatVersion());
+        }
+        externalIDs.addAll(identity.getExternalIds());
+        reportingTools.add(identity.getToolInfo());
+    }
 
-	public String getFormat() {
-		return format;
-	}
+    public String getFormat() {
+        return format;
+    }
 
-	public String getMimetype() {
-		return mimetype;
-	}
+    public String getMimetype() {
+        return mimetype;
+    }
 
-	/** Sets the format name */
-	public void setFormat(String format) {
-		this.format = format;
-	}
+    /** Sets the format name */
+    public void setFormat(String format) {
+        this.format = format;
+    }
 
-	/** Sets the MIME type */
-	public void setMimetype(String mimetype) {
-		this.mimetype = mimetype;
-	}
+    /** Sets the MIME type */
+    public void setMimetype(String mimetype) {
+        this.mimetype = mimetype;
+    }
 
-	public FitsIdentity(String format, String mimetype) {
-		this.format = format;
-		this.mimetype = mimetype;
-	}
+    public FitsIdentity(String format, String mimetype) {
+        this.format = format;
+        this.mimetype = mimetype;
+    }
 
-	/** Adds a format version vote to the list */
-	public void addFormatVersion(FormatVersion version) {
-		formatVersions.add(version);
-	}
+    /** Adds a format version vote to the list */
+    public void addFormatVersion(FormatVersion version) {
+        formatVersions.add(version);
+    }
 
-	/** Returns a list of tool votes on what version of the
-	 *  format is being used, with identification of the tool */
-	public List<FormatVersion> getFormatVersions() {
-		return formatVersions;
-	}
+    /** Returns a list of tool votes on what version of the
+     *  format is being used, with identification of the tool */
+    public List<FormatVersion> getFormatVersions() {
+        return formatVersions;
+    }
 
-	/** Sets the entire format version vote list */
-	public void setFormatVersions(List<FormatVersion> versions) {
-		formatVersions = versions;
-	}
+    /** Sets the entire format version vote list */
+    public void setFormatVersions(List<FormatVersion> versions) {
+        formatVersions = versions;
+    }
 
-	public void addExternalID(ExternalIdentifier identifier) {
-		externalIDs.add(identifier);
-	}
+    public void addExternalID(ExternalIdentifier identifier) {
+        externalIDs.add(identifier);
+    }
 
-	public List<ExternalIdentifier> getExternalIdentifiers() {
-		return externalIDs;
-	}
+    public List<ExternalIdentifier> getExternalIdentifiers() {
+        return externalIDs;
+    }
 
-	/**
-	 * Adds a ToolInfo object to the reported tools list only if one with the same
-	 * name and version has not already been added.
-	 * @param info
-	 */
-	public void addReportingTool(ToolInfo info) {
-		for(ToolInfo reportedInfo : reportingTools) {
-			String Name = reportedInfo.getName();
-			String version = reportedInfo.getVersion();
-			if(Name.equalsIgnoreCase(info.getName()) && version.equalsIgnoreCase(info.getVersion())) {
-				return;
-			}
-		}
-		reportingTools.add(info);
-	}
+    /**
+     * Adds a ToolInfo object to the reported tools list only if one with the same
+     * name and version has not already been added.
+     * @param info
+     */
+    public void addReportingTool(ToolInfo info) {
+        for (ToolInfo reportedInfo : reportingTools) {
+            String Name = reportedInfo.getName();
+            String version = reportedInfo.getVersion();
+            if (Name.equalsIgnoreCase(info.getName()) && version.equalsIgnoreCase(info.getVersion())) {
+                return;
+            }
+        }
+        reportingTools.add(info);
+    }
 
-	/** Returns the list of all tools that contributed to this identity. */
-	public List<ToolInfo> getReportingTools() {
-		return reportingTools;
-	}
+    /** Returns the list of all tools that contributed to this identity. */
+    public List<ToolInfo> getReportingTools() {
+        return reportingTools;
+    }
 
-	public boolean hasExternalIdentifier(ExternalIdentifier xid) {
-		for(ExternalIdentifier externalID : externalIDs) {
-			if(externalID.getName().equalsIgnoreCase(xid.getName())
-					&& externalID.getValue().equalsIgnoreCase(xid.getValue())) {
-				return true;
-			}
-		}
-		return false;
-	}
+    public boolean hasExternalIdentifier(ExternalIdentifier xid) {
+        for (ExternalIdentifier externalID : externalIDs) {
+            if (externalID.getName().equalsIgnoreCase(xid.getName())
+                    && externalID.getValue().equalsIgnoreCase(xid.getValue())) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	public boolean hasFormatVersion(FormatVersion version) {
-		for(FormatVersion v : formatVersions) {
-			String vValue = v.getValue();
-			if(vValue != null) {
-				//check as strings first
-				if(vValue.equalsIgnoreCase(version.getValue())) {
-					return true;
-				}
-				//try as Version objects
-				else {
-					VersionComparer v1 = VersionComparer.parse(vValue);
-					VersionComparer v2 = VersionComparer.parse(version.getValue());
-					if(v1.isEquivalentTo(v2)) {
-						return true;
-					}
-				}
-			}
-		}
-		return false;
-	}
+    public boolean hasFormatVersion(FormatVersion version) {
+        for (FormatVersion v : formatVersions) {
+            String vValue = v.getValue();
+            if (vValue != null) {
+                // check as strings first
+                if (vValue.equalsIgnoreCase(version.getValue())) {
+                    return true;
+                }
+                // try as Version objects
+                else {
+                    VersionComparer v1 = VersionComparer.parse(vValue);
+                    VersionComparer v2 = VersionComparer.parse(version.getValue());
+                    if (v1.isEquivalentTo(v2)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
 
-	public boolean hasOutputFromTool(ToolInfo info) {
-		if(reportingTools.contains(info)) {
-			return true;
-		}
-		else {
-			return false;
-		}
-	}
+    public boolean hasOutputFromTool(ToolInfo info) {
+        if (reportingTools.contains(info)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 
-	/** This will always return "FITS" */
-	public String getToolName() {
-		return toolName;
-	}
+    /** This will always return "FITS" */
+    public String getToolName() {
+        return toolName;
+    }
 
-	public String getToolVersion() {
-		return toolVersion;
-	}
+    public String getToolVersion() {
+        return toolVersion;
+    }
 
-	@Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder("FitsIdentity: [");
-		sb.append("mime: ");
-		sb.append(getMimetype());
-		sb.append(", format: ");
-		sb.append(getFormat());
-		sb.append(", reporting tools: ");
-		sb.append(getReportingTools());
-		sb.append("]");
-		return sb.toString();
-	}
-
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("FitsIdentity: [");
+        sb.append("mime: ");
+        sb.append(getMimetype());
+        sb.append(", format: ");
+        sb.append(getFormat());
+        sb.append(", reporting tools: ");
+        sb.append(getReportingTools());
+        sb.append("]");
+        return sb.toString();
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/identity/FormatVersion.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/identity/FormatVersion.java
@@ -18,26 +18,27 @@ import edu.harvard.hul.ois.fits.tools.ToolInfo;
  */
 public class FormatVersion {
 
-	private ToolInfo toolInfo;
-	private String value;
+    private ToolInfo toolInfo;
+    private String value;
 
-	public FormatVersion(String value, ToolInfo toolInfo) {
-		this.value = value;
-		this.toolInfo = toolInfo;
-	}
+    public FormatVersion(String value, ToolInfo toolInfo) {
+        this.value = value;
+        this.toolInfo = toolInfo;
+    }
 
-	public ToolInfo getToolInfo() {
-		return toolInfo;
-	}
-	public void setInfo(ToolInfo info) {
-		this.toolInfo = info;
-	}
-	public String getValue() {
-		return value;
-	}
-	public void setValue(String version) {
-		this.value = version;
-	}
+    public ToolInfo getToolInfo() {
+        return toolInfo;
+    }
 
+    public void setInfo(ToolInfo info) {
+        this.toolInfo = info;
+    }
 
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String version) {
+        this.value = version;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/identity/ToolIdentity.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/identity/ToolIdentity.java
@@ -10,91 +10,91 @@
 
 package edu.harvard.hul.ois.fits.identity;
 
+import edu.harvard.hul.ois.fits.tools.ToolInfo;
 import java.util.ArrayList;
 import java.util.List;
-
-import edu.harvard.hul.ois.fits.tools.ToolInfo;
 
 /** Information about a file's format, MIME type, and identifiers,
  *  as provided by a single tool.
  */
 public class ToolIdentity {
 
-	//Some tools may report multiple mimetypes, formats or format versions
-	private String mime = new String();
-	private String format = new String();
-	private FormatVersion formatVersion;
-	private List<ExternalIdentifier> externalIds = new ArrayList<ExternalIdentifier>();
-	private ToolInfo toolInfo;
+    // Some tools may report multiple mimetypes, formats or format versions
+    private String mime = new String();
+    private String format = new String();
+    private FormatVersion formatVersion;
+    private List<ExternalIdentifier> externalIds = new ArrayList<ExternalIdentifier>();
+    private ToolInfo toolInfo;
 
-	public ToolIdentity(String mime, String format, ToolInfo toolInfo) {
-		this.mime = mime;
-		this.format = format;
-		formatVersion = null;
-		this.toolInfo = toolInfo;
-	}
+    public ToolIdentity(String mime, String format, ToolInfo toolInfo) {
+        this.mime = mime;
+        this.format = format;
+        formatVersion = null;
+        this.toolInfo = toolInfo;
+    }
 
-	public ToolIdentity(String mime, String format, String formatVersion, ToolInfo toolInfo) {
-		this.mime = mime;
-		this.format = format;
-		this.formatVersion = new FormatVersion(formatVersion,toolInfo);
-		this.toolInfo = toolInfo;
-	}
+    public ToolIdentity(String mime, String format, String formatVersion, ToolInfo toolInfo) {
+        this.mime = mime;
+        this.format = format;
+        this.formatVersion = new FormatVersion(formatVersion, toolInfo);
+        this.toolInfo = toolInfo;
+    }
 
-	public ToolInfo getToolInfo() {
-		return toolInfo;
-	}
+    public ToolInfo getToolInfo() {
+        return toolInfo;
+    }
 
-	public String getMime() {
-		return mime;
-	}
+    public String getMime() {
+        return mime;
+    }
 
-	public String getFormat() {
-		return format;
-	}
+    public String getFormat() {
+        return format;
+    }
 
-	public void setFormatVersion(String formatVersion) {
-		this.formatVersion = new FormatVersion(formatVersion,toolInfo);
-	}
+    public void setFormatVersion(String formatVersion) {
+        this.formatVersion = new FormatVersion(formatVersion, toolInfo);
+    }
 
-	public FormatVersion getFormatVersion() {
-		return formatVersion;
-	}
+    public FormatVersion getFormatVersion() {
+        return formatVersion;
+    }
 
-	public String getFormatVersionValue() {
-		return formatVersion.getValue();
-	}
+    public String getFormatVersionValue() {
+        return formatVersion.getValue();
+    }
 
-	public List<ExternalIdentifier> getExternalIds() {
-		return externalIds;
-	}
+    public List<ExternalIdentifier> getExternalIds() {
+        return externalIds;
+    }
 
-	public void addExternalIdentifier(ExternalIdentifier id) {
-		externalIds.add(id);
-	}
-	public void addExternalIdentifier(String name, String id) {
-		externalIds.add(new ExternalIdentifier(name,id,toolInfo));
-	}
+    public void addExternalIdentifier(ExternalIdentifier id) {
+        externalIds.add(id);
+    }
 
-	public boolean hasExternalIdentifier(ExternalIdentifier id) {
-		for(ExternalIdentifier xident : externalIds) {
-			if(xident.getName().equalsIgnoreCase(id.getName())
-					&& xident.getValue().equalsIgnoreCase(id.getValue())) {
-				return true;
-			}
-		}
-		return false;
-	}
+    public void addExternalIdentifier(String name, String id) {
+        externalIds.add(new ExternalIdentifier(name, id, toolInfo));
+    }
 
-	@Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder("ToolIdentity: [");
-		sb.append(getToolInfo());
-		sb.append(", mime: ");
-		sb.append(getMime());
-		sb.append(", format: ");
-		sb.append(getFormat());
-		sb.append("]");
-		return sb.toString();
-	}
+    public boolean hasExternalIdentifier(ExternalIdentifier id) {
+        for (ExternalIdentifier xident : externalIds) {
+            if (xident.getName().equalsIgnoreCase(id.getName())
+                    && xident.getValue().equalsIgnoreCase(id.getValue())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("ToolIdentity: [");
+        sb.append(getToolInfo());
+        sb.append(", mime: ");
+        sb.append(getMime());
+        sb.append(", format: ");
+        sb.append(getFormat());
+        sb.append("]");
+        return sb.toString();
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/mapping/AttributeMap.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/mapping/AttributeMap.java
@@ -12,40 +12,41 @@ package edu.harvard.hul.ois.fits.mapping;
 
 import java.util.Hashtable;
 import java.util.List;
-
 import org.jdom2.Element;
 
 public class AttributeMap {
 
-	private String name;
-	private Hashtable<String,String> maps = new Hashtable<String,String>();
+    private String name;
+    private Hashtable<String, String> maps = new Hashtable<String, String>();
 
-	public AttributeMap(Element element) {
-		name = element.getAttributeValue("name");
-		//Get element mappings
-		List<Element> childMaps = element.getChildren("map");
-		for(Element map : childMaps) {
-			String from = map.getAttributeValue("from");
-			String to   = map.getAttributeValue("to");
-			maps.put(from,to);
-		}
-	}
+    public AttributeMap(Element element) {
+        name = element.getAttributeValue("name");
+        // Get element mappings
+        List<Element> childMaps = element.getChildren("map");
+        for (Element map : childMaps) {
+            String from = map.getAttributeValue("from");
+            String to = map.getAttributeValue("to");
+            maps.put(from, to);
+        }
+    }
 
-	public String getName() {
-		return name;
-	}
-	public void setName(String name) {
-		this.name = name;
-	}
-	public Hashtable<String, String> getMaps() {
-		return maps;
-	}
-	public void setMaps(Hashtable<String, String> maps) {
-		this.maps = maps;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public void addMap(String from, String to) {
-		maps.put(from,to);
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
+    public Hashtable<String, String> getMaps() {
+        return maps;
+    }
+
+    public void setMaps(Hashtable<String, String> maps) {
+        this.maps = maps;
+    }
+
+    public void addMap(String from, String to) {
+        maps.put(from, to);
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/mapping/ElementMap.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/mapping/ElementMap.java
@@ -13,81 +13,79 @@ package edu.harvard.hul.ois.fits.mapping;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
-
 import org.jdom2.Element;
 
 public class ElementMap {
 
-	private String name;
-	private List<String> mimetypes = new ArrayList<String>();
-	private Hashtable<String,String> maps = new Hashtable<String,String>();
-	private List<AttributeMap> attributes = new ArrayList<AttributeMap>();
+    private String name;
+    private List<String> mimetypes = new ArrayList<String>();
+    private Hashtable<String, String> maps = new Hashtable<String, String>();
+    private List<AttributeMap> attributes = new ArrayList<AttributeMap>();
 
-	public ElementMap(Element element, List<String> mimetypes) {
-		name = element.getAttributeValue("name");
-		this.mimetypes = mimetypes;
+    public ElementMap(Element element, List<String> mimetypes) {
+        name = element.getAttributeValue("name");
+        this.mimetypes = mimetypes;
 
-		//Get element mappings
-		List<Element> childMaps = element.getChildren("map");
-		for(Element map : childMaps) {
-			String from = map.getAttributeValue("from");
-			String to   = map.getAttributeValue("to");
-			maps.put(from,to);
-		}
-		// get any attribute mappings for the map
-		List<Element> child_attributes = element.getChildren("attribute");
-		for(Element attr : child_attributes) {
-			attributes.add(new AttributeMap(attr));
-		}
-	}
+        // Get element mappings
+        List<Element> childMaps = element.getChildren("map");
+        for (Element map : childMaps) {
+            String from = map.getAttributeValue("from");
+            String to = map.getAttributeValue("to");
+            maps.put(from, to);
+        }
+        // get any attribute mappings for the map
+        List<Element> child_attributes = element.getChildren("attribute");
+        for (Element attr : child_attributes) {
+            attributes.add(new AttributeMap(attr));
+        }
+    }
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public Hashtable<String, String> getMaps() {
-		return maps;
-	}
+    public Hashtable<String, String> getMaps() {
+        return maps;
+    }
 
-	public void setMaps(Hashtable<String, String> maps) {
-		this.maps = maps;
-	}
+    public void setMaps(Hashtable<String, String> maps) {
+        this.maps = maps;
+    }
 
-	public List<AttributeMap> getAttributes() {
-		return attributes;
-	}
+    public List<AttributeMap> getAttributes() {
+        return attributes;
+    }
 
-	public void setAttributes(List<AttributeMap> attributes) {
-		this.attributes = attributes;
-	}
+    public void setAttributes(List<AttributeMap> attributes) {
+        this.attributes = attributes;
+    }
 
-	public void addAttributeMap(AttributeMap attribute) {
-		attributes.add(attribute);
-	}
+    public void addAttributeMap(AttributeMap attribute) {
+        attributes.add(attribute);
+    }
 
-	public void addMap(String from, String to) {
-		maps.put(from,to);
-	}
+    public void addMap(String from, String to) {
+        maps.put(from, to);
+    }
 
-	public AttributeMap getAttribute(String name) {
-		for(AttributeMap attr : attributes) {
-			if(attr.getName().equalsIgnoreCase(name)) {
-				return attr;
-			}
-		}
-		return null;
-	}
+    public AttributeMap getAttribute(String name) {
+        for (AttributeMap attr : attributes) {
+            if (attr.getName().equalsIgnoreCase(name)) {
+                return attr;
+            }
+        }
+        return null;
+    }
 
-	public boolean isForType(String mime) {
-		if(mime != null && (mimetypes.contains(mime.toLowerCase()) || mimetypes.contains("all"))) {
-			return true;
-		}
-		else {
-			return false;
-		}
-	}
+    public boolean isForType(String mime) {
+        if (mime != null && (mimetypes.contains(mime.toLowerCase()) || mimetypes.contains("all"))) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/mapping/ToolMap.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/mapping/ToolMap.java
@@ -13,56 +13,54 @@ package edu.harvard.hul.ois.fits.mapping;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.jdom2.Element;
 
 public class ToolMap {
 
-	private String toolName;
-	private List<ElementMap> elements = new ArrayList<ElementMap>();
+    private String toolName;
+    private List<ElementMap> elements = new ArrayList<ElementMap>();
 
-	public ToolMap(Element element) {
-		 toolName = element.getAttribute("name").getValue();
+    public ToolMap(Element element) {
+        toolName = element.getAttribute("name").getValue();
 
-		 List<Element> tool_children = element.getChildren("mime");
-		 for(Element mime : tool_children) {
-			 String types = mime.getAttributeValue("type");
-			 String[] alltypes = types.split(",");
-			 List<Element> mime_children = mime.getChildren("element");
-			 for(Element e : mime_children) {
-				 ElementMap xmlMapElement = new ElementMap(e, Arrays.asList(alltypes));
-				 elements.add(xmlMapElement);
-			 }
-		 }
-	}
+        List<Element> tool_children = element.getChildren("mime");
+        for (Element mime : tool_children) {
+            String types = mime.getAttributeValue("type");
+            String[] alltypes = types.split(",");
+            List<Element> mime_children = mime.getChildren("element");
+            for (Element e : mime_children) {
+                ElementMap xmlMapElement = new ElementMap(e, Arrays.asList(alltypes));
+                elements.add(xmlMapElement);
+            }
+        }
+    }
 
-	public String getToolName() {
-		return toolName;
-	}
+    public String getToolName() {
+        return toolName;
+    }
 
-	public void setToolName(String toolName) {
-		this.toolName = toolName;
-	}
+    public void setToolName(String toolName) {
+        this.toolName = toolName;
+    }
 
-	public List<ElementMap> getElements() {
-		return elements;
-	}
+    public List<ElementMap> getElements() {
+        return elements;
+    }
 
-	public void setElements(List<ElementMap> elements) {
-		this.elements = elements;
-	}
+    public void setElements(List<ElementMap> elements) {
+        this.elements = elements;
+    }
 
-	public void addElement(ElementMap element) {
-		elements.add(element);
-	}
+    public void addElement(ElementMap element) {
+        elements.add(element);
+    }
 
-	public ElementMap getXmlMapElement(String name, String mime) {
-		for(ElementMap xmlMapElement : elements) {
-			if(xmlMapElement.getName().equalsIgnoreCase(name)
-					&& xmlMapElement.isForType(mime)) {
-				return xmlMapElement;
-			}
-		}
-		return null;
-	}
+    public ElementMap getXmlMapElement(String name, String mime) {
+        for (ElementMap xmlMapElement : elements) {
+            if (xmlMapElement.getName().equalsIgnoreCase(name) && xmlMapElement.isForType(mime)) {
+                return xmlMapElement;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/Tool.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/Tool.java
@@ -10,111 +10,115 @@
 
 package edu.harvard.hul.ois.fits.tools;
 
-import java.io.File;
-import java.util.List;
-
 import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
 import edu.harvard.hul.ois.fits.identity.ToolIdentity;
+import java.io.File;
+import java.util.List;
 
 /** All FITS tools implement this interface. */
 public interface Tool extends Runnable {
 
-	public enum RunStatus {SHOULDNOTRUN,SHOULDRUN,FAILED,SUCCESSFUL};
+    public enum RunStatus {
+        SHOULDNOTRUN,
+        SHOULDRUN,
+        FAILED,
+        SUCCESSFUL
+    };
 
-	/**
-	 * Extracts the identification and metadata from the provided file
-	 * @param file the file to have its metadata extracted
-	 * @return tooloutput object containing the xml wrapping the tool raw output, fits compatible xml output
-	 * and the fits FileIdentity
-	 * @throws FitsToolException
-	 */
-	public ToolOutput extractInfo(File file) throws FitsToolException;
+    /**
+     * Extracts the identification and metadata from the provided file
+     * @param file the file to have its metadata extracted
+     * @return tooloutput object containing the xml wrapping the tool raw output, fits compatible xml output
+     * and the fits FileIdentity
+     * @throws FitsToolException
+     */
+    public ToolOutput extractInfo(File file) throws FitsToolException;
 
-	/**
-	 * Checks if the value for the given field name is the
-	 * default value that the tool would report if it doesn't
-	 * understand the file that was processed
-	 * @param identity the identity to test
-	 * @return boolean indicating the file is a known or unknown type for the tool
-	 */
-	public boolean isIdentityKnown(ToolIdentity identity);
+    /**
+     * Checks if the value for the given field name is the
+     * default value that the tool would report if it doesn't
+     * understand the file that was processed
+     * @param identity the identity to test
+     * @return boolean indicating the file is a known or unknown type for the tool
+     */
+    public boolean isIdentityKnown(ToolIdentity identity);
 
-	/**
-	 * Returns the information about the tool
-	 * @return ToolInfo
-	 */
-	public ToolInfo getToolInfo();
+    /**
+     * Returns the information about the tool
+     * @return ToolInfo
+     */
+    public ToolInfo getToolInfo();
 
-	/**
-	 * If the tool can identify mimetype and format of files.
-	 * @return Boolean
-	 */
-	public Boolean canIdentify();
+    /**
+     * If the tool can identify mimetype and format of files.
+     * @return Boolean
+     */
+    public Boolean canIdentify();
 
-	/**
-	 *  Returns the name of the tool object (not the name of the software).
-	 */
-	public String getName();
+    /**
+     *  Returns the name of the tool object (not the name of the software).
+     */
+    public String getName();
 
-	/**
-	 *  Sets the name of the tool object (not the name of the software).
-	 */
-	public void setName(String name);
+    /**
+     *  Sets the name of the tool object (not the name of the software).
+     */
+    public void setName(String name);
 
-	/**
-	 * Add a file extension that the tool should not process
-	 * @param ext
-	 */
-	public void addExcludedExtension(String ext);
+    /**
+     * Add a file extension that the tool should not process
+     * @param ext
+     */
+    public void addExcludedExtension(String ext);
 
-	/**
-	 * Add a file extension that the tool should not process
-	 * @param ext
-	 */
-	public void addIncludedExtension(String ext);
+    /**
+     * Add a file extension that the tool should not process
+     * @param ext
+     */
+    public void addIncludedExtension(String ext);
 
-	/**
-	 * Checks if the tool excluded extensions list contains the provided extension
-	 * @param ext
-	 * @return boolean
-	 */
-	public boolean hasExcludedExtension(String ext);
+    /**
+     * Checks if the tool excluded extensions list contains the provided extension
+     * @param ext
+     * @return boolean
+     */
+    public boolean hasExcludedExtension(String ext);
 
-	/**
-	 * Checks if the tool included extensions list contains the provided extension
-	 * @param ext
-	 * @return boolean
-	 */
-	public boolean hasIncludedExtension(String ext);
+    /**
+     * Checks if the tool included extensions list contains the provided extension
+     * @param ext
+     * @return boolean
+     */
+    public boolean hasIncludedExtension(String ext);
 
-	/**
-	 * Checks if the tool uses an 'include-ext' list
-	 * @return boolean
-	 */
-	public boolean hasIncludedExtensions();
+    /**
+     * Checks if the tool uses an 'include-ext' list
+     * @return boolean
+     */
+    public boolean hasIncludedExtensions();
 
-	public boolean hasExcludedExtensions();
+    public boolean hasExcludedExtensions();
 
-	/**
-	 *  Applies the restrictions in a tools-used item to the tool
-	 */
-	public void applyToolsUsed (List<ToolBelt.ToolsUsedItem> toolsUsedItems);
+    /**
+     *  Applies the restrictions in a tools-used item to the tool
+     */
+    public void applyToolsUsed(List<ToolBelt.ToolsUsedItem> toolsUsedItems);
 
-	public void resetOutput();
+    public void resetOutput();
 
-	public boolean isEnabled();
+    public boolean isEnabled();
 
-	public void setEnabled(boolean value);
+    public void setEnabled(boolean value);
 
-	public void setInputFile(File file);
+    public void setInputFile(File file);
 
-	public ToolOutput getOutput();
+    public ToolOutput getOutput();
 
-	public long getDuration();
+    public long getDuration();
 
-	public RunStatus getRunStatus();
+    public RunStatus getRunStatus();
 
-	public void setRunStatus(RunStatus runStatus);
+    public void setRunStatus(RunStatus runStatus);
 
-	public Throwable getCaughtThrowable();
+    public Throwable getCaughtThrowable();
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/ToolBase.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/ToolBase.java
@@ -10,43 +10,38 @@
 
 package edu.harvard.hul.ois.fits.tools;
 
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import edu.harvard.hul.ois.fits.identity.ToolIdentity;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
-
 import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamSource;
-
-//import org.apache.xalan.processor.TransformerFactoryImpl;
 import org.jdom2.Document;
 import org.jdom2.input.SAXBuilder;
 import org.jdom2.transform.JDOMResult;
 import org.jdom2.transform.JDOMSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-//import org.w3c.dom.Node;
-
-import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
-import edu.harvard.hul.ois.fits.identity.ToolIdentity;
 
 /** An abstract class implementing the Tool interface, the base
  *  for all FITS tools.
  */
 public abstract class ToolBase implements Tool {
 
-	private static final Logger logger = LoggerFactory.getLogger( ToolBase.class );
+    private static final Logger logger = LoggerFactory.getLogger(ToolBase.class);
 
-	protected ToolInfo info = null;
-	protected ToolOutput output = null;
-	protected SAXBuilder saxBuilder;
-	protected long duration;
-	protected RunStatus runStatus;
-	protected Hashtable<String,String> transformMap;
-	private TransformerFactory tFactory;
+    protected ToolInfo info = null;
+    protected ToolOutput output = null;
+    protected SAXBuilder saxBuilder;
+    protected long duration;
+    protected RunStatus runStatus;
+    protected Hashtable<String, String> transformMap;
+    private TransformerFactory tFactory;
     private File inputFile;
     private String name;
 
@@ -55,233 +50,231 @@ public abstract class ToolBase implements Tool {
 
     private Throwable caughtThrowable;
 
-	public ToolBase() throws FitsToolException {
-		info = new ToolInfo();
-		tFactory = TransformerFactory.newInstance();
-		String factoryImpl = "net.sf.saxon.TransformerFactoryImpl";
-		try {
-			Class<?> clazz = Class.forName(factoryImpl, true, ToolBase.class.getClassLoader());
-			tFactory = (TransformerFactory)clazz.getDeclaredConstructor().newInstance();
-		} catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-			throw new FitsToolException("Could not access or instantiate class: " + factoryImpl, e);
-		}
-		
-		saxBuilder = new SAXBuilder();
-		excludedExtensions = new ArrayList<String>();
-		includedExtensions = new ArrayList<String>();
-	}
+    public ToolBase() throws FitsToolException {
+        info = new ToolInfo();
+        tFactory = TransformerFactory.newInstance();
+        String factoryImpl = "net.sf.saxon.TransformerFactoryImpl";
+        try {
+            Class<?> clazz = Class.forName(factoryImpl, true, ToolBase.class.getClassLoader());
+            tFactory = (TransformerFactory) clazz.getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException
+                | InstantiationException
+                | IllegalAccessException
+                | NoSuchMethodException
+                | InvocationTargetException e) {
+            throw new FitsToolException("Could not access or instantiate class: " + factoryImpl, e);
+        }
 
-	/** Returns the name. This should be the name of the tool class,
-	 *  without the package prefix.
-	 */
-	public String getName () {
-	    return name;
-	}
-
-	/** Sets the name. This should be the name of the tool class, without
-	 *  the package prefix (e.g., "Droid" or "Jhove").
-	 */
-	public void setName (String n) {
-	    name = n;
-	}
-
-	/** Returns identifying information about the tool. */
-	public ToolInfo getToolInfo() {
-		return info;
-	}
-
-	/** Returns true if the tool provides identification information.
-	 *  Override if a value other than true should ever be returned. */
-	public Boolean canIdentify() {
-		return true;
-	}
-
-	/** Specifies the file to be processed. */
-	public void setInputFile(File file) {
-		inputFile = file;
-	}
-
-	public boolean isIdentityKnown(ToolIdentity identity) {
-		if(!canIdentify()) {
-			return false;
-		}
-		//identity and mimetype must not be null or empty strings for an identity to be "known"
-		if(identity == null
-				|| identity.getMime() == null
-				|| identity.getMime().length() == 0
-				|| identity.getFormat() == null
-				|| identity.getFormat().length() == 0) {
-			return false;
-		}
-		String format = identity.getFormat();
-		String mime = identity.getMime();
-		if(format.equals("Unknown Binary") || mime.equals("application/octet-stream")) {
-			return false;
-		}
-		else {
-			return true;
-		}
-	}
-
-	public Boolean validate(File files_or_dir, ToolIdentity identity) {
-		return null;
-	}
-
-	public Document transform(String xslt, Document input) throws FitsToolException {
-		Document doc = null;
-		try {
-			Templates templates = tFactory.newTemplates(new StreamSource(xslt));
-			Transformer transformer = templates.newTransformer();
-	        JDOMSource in = new JDOMSource(input);
-	        JDOMResult out = new JDOMResult();
-	        transformer.transform(in, out);
-	        doc = out.getDocument();
-		}
-		catch(Exception e) {
-			throw new FitsToolException(info.getName()+": Error converting output using "+xslt,e);
-		}
-		return doc;
-	}
-
-	public void addExcludedExtension(String ext) {
-		excludedExtensions.add(ext);
-	}
-
-	public boolean hasExcludedExtension(String ext) {
-		for(String extension : excludedExtensions) {
-			if(extension.equalsIgnoreCase(ext)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	public void addIncludedExtension(String ext) {
-		includedExtensions.add(ext);
-	}
-
-	public boolean hasIncludedExtensions() {
-		if(includedExtensions.size() > 0) {
-			return true;
-		}
-		else {
-			return false;
-		}
-	}
-
-	public boolean hasExcludedExtensions() {
-		if(excludedExtensions.size() > 0) {
-			return true;
-		}
-		else {
-			return false;
-		}
-	}
-
-	public boolean hasIncludedExtension(String ext) {
-		for(String extension : includedExtensions) {
-			if(extension.equalsIgnoreCase(ext)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/** Take the list of tools-used items and modify the included and
-	 *  excluded extensions if applicable. included-exts and
-	 *  excluded-exts attributes take priority.
-	 */
-	public void applyToolsUsed (List<ToolBelt.ToolsUsedItem> toolsUsedItems) {
-	    for (ToolBelt.ToolsUsedItem tui : toolsUsedItems) {
- 	        if (tui.toolNames.contains (name)) {
-	            // If a tool is
-	            // listed by tui, we add its extensions to
-	            // included-extensions unless it's in excluded-extensions.
-	            // If a tool is not listed by tui, we add its extensions
-	            // to excluded-extensions unless it's in included-extensions.
- 	            // If there are no included extensions, that means all extensions
- 	            // are allowed unless excluded, so we don't add anything.
-	            for (String ext : tui.extensions) {
-	                if (hasIncludedExtensions()) {
-    	                if (!containsIgnoreCase(includedExtensions,ext) &&
-    	                        !containsIgnoreCase(excludedExtensions,ext)) {
-    	                    includedExtensions.add (ext);
-    	                }
-	                }
-	            }
-	        }
-	        else {
-	            for (String ext : tui.extensions) {
-	                if (!containsIgnoreCase(excludedExtensions,ext) &&
-	                        !containsIgnoreCase(includedExtensions,ext)) {
-	                    excludedExtensions.add(ext);
-	                }
-	            }
-	        }
-	    }
-	}
-
-	/* A case-independent surrogate for List.contains */
-	private boolean containsIgnoreCase (List<String> lst, String s) {
-	    for (String s1 : lst) {
-	        if (s1.equalsIgnoreCase (s)) {
-	            return true;
-	        }
-	    }
-	    return false;
-	}
-	public ToolOutput getOutput() {
-		return output;
-	}
-
-	public void resetOutput() {
-		output = null;
-		caughtThrowable = null;
-	}
-
-	public long getDuration() {
-		return duration;
-	}
-
-	public void setDuration(long duration) {
-		this.duration = duration;
-	}
-
-	public RunStatus getRunStatus() {
-		return runStatus;
-	}
-
-	public void setRunStatus(RunStatus runStatus) {
-		this.runStatus = runStatus;
-	}
-
-	/*
-	 * Save an exception for reporting.
-	 */
-	private void setCaughtThrowable (Throwable e) {
-	    caughtThrowable = e;
-	}
-	
-	public Throwable getCaughtThrowable() {
-		return caughtThrowable;
-	}
-
-	/**
-	 * Called to extract metadata when this tool's thread is kicked off.
-	 * We capture any error (Throwable) so that it can be reported later.
-	 * 
-	 * @see java.lang.Runnable#run()
-	 */
-	public void run() {
-		try {
-			output = extractInfo(inputFile);
-		} catch (Throwable e) {
-			setCaughtThrowable(e);
-		}
-	}
-
-	public SAXBuilder getSaxBuilder () {
-        return saxBuilder;
+        saxBuilder = new SAXBuilder();
+        excludedExtensions = new ArrayList<String>();
+        includedExtensions = new ArrayList<String>();
     }
 
+    /** Returns the name. This should be the name of the tool class,
+     *  without the package prefix.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /** Sets the name. This should be the name of the tool class, without
+     *  the package prefix (e.g., "Droid" or "Jhove").
+     */
+    public void setName(String n) {
+        name = n;
+    }
+
+    /** Returns identifying information about the tool. */
+    public ToolInfo getToolInfo() {
+        return info;
+    }
+
+    /** Returns true if the tool provides identification information.
+     *  Override if a value other than true should ever be returned. */
+    public Boolean canIdentify() {
+        return true;
+    }
+
+    /** Specifies the file to be processed. */
+    public void setInputFile(File file) {
+        inputFile = file;
+    }
+
+    public boolean isIdentityKnown(ToolIdentity identity) {
+        if (!canIdentify()) {
+            return false;
+        }
+        // identity and mimetype must not be null or empty strings for an identity to be "known"
+        if (identity == null
+                || identity.getMime() == null
+                || identity.getMime().length() == 0
+                || identity.getFormat() == null
+                || identity.getFormat().length() == 0) {
+            return false;
+        }
+        String format = identity.getFormat();
+        String mime = identity.getMime();
+        if (format.equals("Unknown Binary") || mime.equals("application/octet-stream")) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public Boolean validate(File files_or_dir, ToolIdentity identity) {
+        return null;
+    }
+
+    public Document transform(String xslt, Document input) throws FitsToolException {
+        Document doc = null;
+        try {
+            Templates templates = tFactory.newTemplates(new StreamSource(xslt));
+            Transformer transformer = templates.newTransformer();
+            JDOMSource in = new JDOMSource(input);
+            JDOMResult out = new JDOMResult();
+            transformer.transform(in, out);
+            doc = out.getDocument();
+        } catch (Exception e) {
+            throw new FitsToolException(info.getName() + ": Error converting output using " + xslt, e);
+        }
+        return doc;
+    }
+
+    public void addExcludedExtension(String ext) {
+        excludedExtensions.add(ext);
+    }
+
+    public boolean hasExcludedExtension(String ext) {
+        for (String extension : excludedExtensions) {
+            if (extension.equalsIgnoreCase(ext)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void addIncludedExtension(String ext) {
+        includedExtensions.add(ext);
+    }
+
+    public boolean hasIncludedExtensions() {
+        if (includedExtensions.size() > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public boolean hasExcludedExtensions() {
+        if (excludedExtensions.size() > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public boolean hasIncludedExtension(String ext) {
+        for (String extension : includedExtensions) {
+            if (extension.equalsIgnoreCase(ext)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Take the list of tools-used items and modify the included and
+     *  excluded extensions if applicable. included-exts and
+     *  excluded-exts attributes take priority.
+     */
+    public void applyToolsUsed(List<ToolBelt.ToolsUsedItem> toolsUsedItems) {
+        for (ToolBelt.ToolsUsedItem tui : toolsUsedItems) {
+            if (tui.toolNames.contains(name)) {
+                // If a tool is
+                // listed by tui, we add its extensions to
+                // included-extensions unless it's in excluded-extensions.
+                // If a tool is not listed by tui, we add its extensions
+                // to excluded-extensions unless it's in included-extensions.
+                // If there are no included extensions, that means all extensions
+                // are allowed unless excluded, so we don't add anything.
+                for (String ext : tui.extensions) {
+                    if (hasIncludedExtensions()) {
+                        if (!containsIgnoreCase(includedExtensions, ext)
+                                && !containsIgnoreCase(excludedExtensions, ext)) {
+                            includedExtensions.add(ext);
+                        }
+                    }
+                }
+            } else {
+                for (String ext : tui.extensions) {
+                    if (!containsIgnoreCase(excludedExtensions, ext) && !containsIgnoreCase(includedExtensions, ext)) {
+                        excludedExtensions.add(ext);
+                    }
+                }
+            }
+        }
+    }
+
+    /* A case-independent surrogate for List.contains */
+    private boolean containsIgnoreCase(List<String> lst, String s) {
+        for (String s1 : lst) {
+            if (s1.equalsIgnoreCase(s)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public ToolOutput getOutput() {
+        return output;
+    }
+
+    public void resetOutput() {
+        output = null;
+        caughtThrowable = null;
+    }
+
+    public long getDuration() {
+        return duration;
+    }
+
+    public void setDuration(long duration) {
+        this.duration = duration;
+    }
+
+    public RunStatus getRunStatus() {
+        return runStatus;
+    }
+
+    public void setRunStatus(RunStatus runStatus) {
+        this.runStatus = runStatus;
+    }
+
+    /*
+     * Save an exception for reporting.
+     */
+    private void setCaughtThrowable(Throwable e) {
+        caughtThrowable = e;
+    }
+
+    public Throwable getCaughtThrowable() {
+        return caughtThrowable;
+    }
+
+    /**
+     * Called to extract metadata when this tool's thread is kicked off.
+     * We capture any error (Throwable) so that it can be reported later.
+     *
+     * @see java.lang.Runnable#run()
+     */
+    public void run() {
+        try {
+            output = extractInfo(inputFile);
+        } catch (Throwable e) {
+            setCaughtThrowable(e);
+        }
+    }
+
+    public SAXBuilder getSaxBuilder() {
+        return saxBuilder;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/ToolBelt.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/ToolBelt.java
@@ -10,419 +10,427 @@
 
 package edu.harvard.hul.ois.fits.tools;
 
-
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import edu.harvard.hul.ois.fits.identity.ToolIdentity;
+import edu.harvard.hul.ois.fits.tools.utils.ParentLastClassLoader;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.commons.lang.StringUtils;
-
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
-import edu.harvard.hul.ois.fits.identity.ToolIdentity;
-import edu.harvard.hul.ois.fits.tools.utils.ParentLastClassLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ToolBelt {
 
-	// Represent the URL of the fit.jar file (or class directory) where this file lives.
-	// This is used for building custom class loaders representing all FITS class files.
-	private URL fitsUrl;
+    // Represent the URL of the fit.jar file (or class directory) where this file lives.
+    // This is used for building custom class loaders representing all FITS class files.
+    private URL fitsUrl;
 
-	private static Logger logger = LoggerFactory.getLogger(ToolBelt.class);
+    private static Logger logger = LoggerFactory.getLogger(ToolBelt.class);
 
     /** The representation of one tools-used element in the config file */
     public class ToolsUsedItem {
         public List<String> extensions;
         public List<String> toolNames;
 
-        public ToolsUsedItem (List<String> exts, List<String> tools) {
+        public ToolsUsedItem(List<String> exts, List<String> tools) {
             extensions = exts;
             toolNames = tools;
         }
     }
 
-	private List<Tool> tools;
+    private List<Tool> tools;
 
-	/**
-	 * Constructor
-	 *
-	 * @param config XMLConfiguration of FITS configuration file.
-	 * @param fits Fits for referencing member variables.
-	 */
-	public ToolBelt(XMLConfiguration config, Fits fits) {
-		init(config, fits);
-	}
+    /**
+     * Constructor
+     *
+     * @param config XMLConfiguration of FITS configuration file.
+     * @param fits Fits for referencing member variables.
+     */
+    public ToolBelt(XMLConfiguration config, Fits fits) {
+        init(config, fits);
+    }
 
-	/*
-	 * Common initialization of all constructors.
-	 */
-	private void init(XMLConfiguration config, Fits fits) {
+    /*
+     * Common initialization of all constructors.
+     */
+    private void init(XMLConfiguration config, Fits fits) {
 
-		fitsUrl = getClass().getProtectionDomain().getCodeSource().getLocation();
+        fitsUrl = getClass().getProtectionDomain().getCodeSource().getLocation();
 
-		// Collect the tools-used elements
-		List<ToolsUsedItem> toolsUsedList = processToolsUsed(config);
+        // Collect the tools-used elements
+        List<ToolsUsedItem> toolsUsedList = processToolsUsed(config);
 
-		tools = new ArrayList<Tool>();
+        tools = new ArrayList<Tool>();
 
-		// get number of tools
-		int size = config.getList("tools.tool[@class]").size();
-		ClassLoader savedClassLoader = ToolBelt.class.getClassLoader();
-		// for each tools get the class path and any excluded extensions
-		for(int i=0;i<size;i++) {
-			String tClass = config.getString("tools.tool("+i+")[@class]");
-			@SuppressWarnings("unchecked")
-			List<String> excludes = (List<String>)(List<?>)config.getList("tools.tool("+i+")[@exclude-exts]");
-			@SuppressWarnings("unchecked")
-			List<String> includes = (List<String>)(List<?>)config.getList("tools.tool("+i+")[@include-exts]");
-			@SuppressWarnings("unchecked")
-			List<String> classpathDirs = (List<String>)(List<?>)config.getList("tools.tool("+i+")[@classpath-dirs]");
-
-			ClassLoader toolClassLoader = null;
-			try {
-				// If fits.xml Tool element contains values in the classpath-dirs attribute that return files,
-				// it's necessary to create and use a custom class loader.
-				// Otherwise, just use the system (application) class loader.
-				// Will need to replace original class loader after (possibly) using a different one with current thread.
-				toolClassLoader = createClassLoader(classpathDirs);
-				if (toolClassLoader != null) {
-					Thread.currentThread().setContextClassLoader(toolClassLoader);
-				} else {
-					toolClassLoader = savedClassLoader;
-				}
-
-				logger.debug("Will attempt to load class: " + tClass + " -- with ClassLoader: " + toolClassLoader.getClass().getName());
-				Class<?> toolClass = Class.forName(tClass, true, toolClassLoader);
-
-				// Looooong debugging block if using custom class loader
-				// verify the tool's class loader is the custom one and that it's class loader has
-				// loaded the Tool interface from the main class loader so it can be cast here to Tool
-				if (toolClassLoader != savedClassLoader && logger.isTraceEnabled()) { // yes, we want an this type of exact equals comparison
-					ClassLoader tcl = toolClass.getClassLoader();
-					logger.trace("Specific tool: " + tClass + " -- ClassLoader: " + tcl);
-
-					// Tool interface loaded from custom class loader
-					Class<?> toolInterfaceCustomClassLoader = Class.forName("edu.harvard.hul.ois.fits.tools.Tool", true, tcl);
-					logger.trace("Tool ClassLoader via custom class loader: " + toolInterfaceCustomClassLoader.getClassLoader());
-
-					// Tool interface loaded from system class loader which will be used for casting immediately below.
-					Class<?> toolInterfaceClass = Tool.class.getClassLoader().loadClass(Tool.class.getName());
-					logger.trace("Tool ClassLoader " + Tool.class.getName() + " -- ClassLoader: " + Tool.class.getClassLoader());
-
-					// verify that specific tool from custom class loader can be assigned to Tool
-					boolean isAssignable = toolInterfaceClass.isAssignableFrom(toolClass);
-					logger.trace("Tool from custom ClassLoader isAssignableFrom(toolClass): " + isAssignable);
-				}
-
-				Tool t = createToolClassInstance(toolClass, fits);
-
-				if(t != null) {
-					t.setName(bareClassName(tClass));
-					for(String ext : excludes) {
-						t.addExcludedExtension(ext);
-					}
-					for(String ext : includes) {
-						t.addIncludedExtension(ext);
-					}
-					// Modify included and excluded extensions by tools-used
-					t.applyToolsUsed (toolsUsedList);
-					tools.add(t);
-				}
-			} catch(MalformedURLException | ReflectiveOperationException ex) {
-				// Catch and report any exception during tool instantiation.
-			    // Cannot use this particular tool, but continue with other tools.
-			    logger.error ("Thread ["+Thread.currentThread().getId() +
-			    				"] Error instantiating class: " + tClass +
-			    				" -- Exception thrown: " + ex.getClass().getName() +
-			    				" -- Error message: " + ex.getMessage());
-
-				// Capture exception so the failure can be reported later for this tool, then move on to next tool
-				ToolInfo info = new ToolInfo(bareClassName(tClass), "[could not launch tool]", null);
-				Tool tool = getFailedTool(info, ex);
-				tools.add(tool);
-
-			} finally {
-				// ***** IMPORTANT: set back original ClassLoader if changed *****
-				if (Thread.currentThread().getContextClassLoader() != savedClassLoader) {
-					Thread.currentThread().setContextClassLoader(savedClassLoader);
-				}
-			}
-		}
-	}
-	
-	/*
-	 * Instantiate a Tool class using Reflection by passing Fits into the constructor.
-	 * Note: All Tool class implementations can have a 1-argument constructor with Fits as the argument.
-	 * If it does not, then the standard newInstance() method fall-back will be used which results in a no-arg constructor being called.
-	 * Note: Any exception thrown in a Tool constructor will result in a ReflectiveOperationException, not the thrown exception
-	 * propagating up from the constructor.
-	 */
-	private Tool createToolClassInstance(Class<?> toolClass, Fits fits) throws ReflectiveOperationException {
-		Object instanceOfTheClass = null;
-		try {
-			Constructor<?> ctor = toolClass.getConstructor(Fits.class);
-			instanceOfTheClass = ctor.newInstance(fits);
-			logger.debug("1-arg constructor for instantiating tool class: {}", toolClass.getName());
-		} catch (NoSuchMethodException e) {
-			// now try a no-arg constructor
-			logger.debug("No Fits 1-arg constructor for tool class: {} -- trying no-arg constructor. Error message: {}", toolClass.getName(), e.getMessage());
-			instanceOfTheClass = toolClass.getDeclaredConstructor().newInstance();
-			logger.debug("Instantiated no-arg constructor for tool class: {}", toolClass.getName());
-		}
-		return (Tool)instanceOfTheClass;
-	}
-
-	public List<Tool> getTools() {
-		return tools;
-	}
-
-	public void printToolInfo(boolean includeSysInfo) {
-		if(includeSysInfo) {
-			//system info
-			logger.info("OS Name = "+System.getProperty("os.name"));
-			logger.info("OS Arch = "+System.getProperty("os.arch"));
-			logger.info("OS Version = "+System.getProperty("os.version"));
-			logger.info("------------------------------------");
-		}
-
-		for(Tool t : tools) {
-			logger.info(t.getToolInfo().print());
-		}
-
-	}
-
-	/* Process the tools-used elements and return a list of
-	 * ... something */
-	private List<ToolsUsedItem> processToolsUsed (XMLConfiguration config) {
-	    int size = config.getList("tools-used[@exts]").size();
-	    List<ToolsUsedItem> results = new ArrayList<ToolsUsedItem> (size);
-	    for (int i = 0; i < size; i++) {
+        // get number of tools
+        int size = config.getList("tools.tool[@class]").size();
+        ClassLoader savedClassLoader = ToolBelt.class.getClassLoader();
+        // for each tools get the class path and any excluded extensions
+        for (int i = 0; i < size; i++) {
+            String tClass = config.getString("tools.tool(" + i + ")[@class]");
             @SuppressWarnings("unchecked")
-            List<String> exts = (List<String>)(List<?>)config.getList("tools-used("+i+")[@exts]");
+            List<String> excludes = (List<String>) (List<?>) config.getList("tools.tool(" + i + ")[@exclude-exts]");
             @SuppressWarnings("unchecked")
-            List<String> tools = (List<String>)(List<?>)config.getList("tools-used("+i+")[@tools]");
-            results.add (new ToolsUsedItem (exts, tools));
-	    }
-	    return results;
-	}
+            List<String> includes = (List<String>) (List<?>) config.getList("tools.tool(" + i + ")[@include-exts]");
+            @SuppressWarnings("unchecked")
+            List<String> classpathDirs =
+                    (List<String>) (List<?>) config.getList("tools.tool(" + i + ")[@classpath-dirs]");
 
-	/* Extract the last component of the class name to use as the
-	 * tool's name field */
-	private String bareClassName(String cname) {
-	    int n = cname.lastIndexOf(".");
-	    return cname.substring(n + 1);
-	}
+            ClassLoader toolClassLoader = null;
+            try {
+                // If fits.xml Tool element contains values in the classpath-dirs attribute that return files,
+                // it's necessary to create and use a custom class loader.
+                // Otherwise, just use the system (application) class loader.
+                // Will need to replace original class loader after (possibly) using a different one with current
+                // thread.
+                toolClassLoader = createClassLoader(classpathDirs);
+                if (toolClassLoader != null) {
+                    Thread.currentThread().setContextClassLoader(toolClassLoader);
+                } else {
+                    toolClassLoader = savedClassLoader;
+                }
 
-	/*
-	 * Create a custom class loader specifically for a set of resources as designated by a list of directories
-	 * which are specified for each tool in fits.xml. If the parameter is null or empty OR
-	 * there are no resources within any of the list of given directories then this method will return null.
-	 *
-	 * @return custom class loader ONLY if JAR files in tool-specific lib directory; <code>null</code> otherwise.
-	 */
-	private ClassLoader createClassLoader(List<String> classpathDirs) throws MalformedURLException {
+                logger.debug("Will attempt to load class: " + tClass + " -- with ClassLoader: "
+                        + toolClassLoader.getClass().getName());
+                Class<?> toolClass = Class.forName(tClass, true, toolClassLoader);
 
-		if (classpathDirs == null || classpathDirs.isEmpty()) {
-			return null;
-		}
+                // Looooong debugging block if using custom class loader
+                // verify the tool's class loader is the custom one and that it's class loader has
+                // loaded the Tool interface from the main class loader so it can be cast here to Tool
+                if (toolClassLoader != savedClassLoader
+                        && logger.isTraceEnabled()) { // yes, we want an this type of exact equals comparison
+                    ClassLoader tcl = toolClass.getClassLoader();
+                    logger.trace("Specific tool: " + tClass + " -- ClassLoader: " + tcl);
 
-		// collect all files from all specified directories
-		List<URL> directoriesUrls = new ArrayList<URL>();
-		for (String dir : classpathDirs) {
-			List<URL> urls = gatherClassLoaderUrls(null, dir);
-			// special case: If a root directory contains artifacts then add that root directory
-			// so as to create a custom class loader.
-			if (urls != null & !urls.isEmpty()) {
-				File dirFile = getFileFromName(dir);
-				urls.add(  dirFile.toURI().toURL() );
-			}
-			directoriesUrls.addAll( urls );
-		}
+                    // Tool interface loaded from custom class loader
+                    Class<?> toolInterfaceCustomClassLoader =
+                            Class.forName("edu.harvard.hul.ois.fits.tools.Tool", true, tcl);
+                    logger.trace("Tool ClassLoader via custom class loader: "
+                            + toolInterfaceCustomClassLoader.getClassLoader());
 
-		// If nothing returned from directories then return null; Don't create ClassLoader if nothing to load.
-		if (directoriesUrls.isEmpty()) {
-			return null;
-		}
+                    // Tool interface loaded from system class loader which will be used for casting immediately below.
+                    Class<?> toolInterfaceClass = Tool.class.getClassLoader().loadClass(Tool.class.getName());
+                    logger.trace("Tool ClassLoader " + Tool.class.getName() + " -- ClassLoader: "
+                            + Tool.class.getClassLoader());
 
-		// Create list of resources for custom ClassLoader.
-		List<URL> classLoaderUrls = new ArrayList<URL>();
-		// Must always add FITS classes first
-		classLoaderUrls.add(fitsUrl);
-		// add all other resources next
-		classLoaderUrls.addAll(directoriesUrls);
-		logger.debug("URL's" + classLoaderUrls);
+                    // verify that specific tool from custom class loader can be assigned to Tool
+                    boolean isAssignable = toolInterfaceClass.isAssignableFrom(toolClass);
+                    logger.trace("Tool from custom ClassLoader isAssignableFrom(toolClass): " + isAssignable);
+                }
 
-		final ParentLastClassLoader cl = new ParentLastClassLoader(classLoaderUrls);
+                Tool t = createToolClassInstance(toolClass, fits);
 
-		return cl;
-	}
+                if (t != null) {
+                    t.setName(bareClassName(tClass));
+                    for (String ext : excludes) {
+                        t.addExcludedExtension(ext);
+                    }
+                    for (String ext : includes) {
+                        t.addIncludedExtension(ext);
+                    }
+                    // Modify included and excluded extensions by tools-used
+                    t.applyToolsUsed(toolsUsedList);
+                    tools.add(t);
+                }
+            } catch (MalformedURLException | ReflectiveOperationException ex) {
+                // Catch and report any exception during tool instantiation.
+                // Cannot use this particular tool, but continue with other tools.
+                logger.error("Thread [" + Thread.currentThread().getId() + "] Error instantiating class: "
+                        + tClass + " -- Exception thrown: "
+                        + ex.getClass().getName() + " -- Error message: "
+                        + ex.getMessage());
 
-	/*
-	 * Recursive method to create a list of URL's of all files in a directory and all of its sub-directories.
-	 * All files that end in ".txt" or begin with "." will be ignored. Also, simple directory URL's will not be added.
-	 */
-	private List<URL> gatherClassLoaderUrls(List<URL> urls, String rootDir) throws MalformedURLException {
+                // Capture exception so the failure can be reported later for this tool, then move on to next tool
+                ToolInfo info = new ToolInfo(bareClassName(tClass), "[could not launch tool]", null);
+                Tool tool = getFailedTool(info, ex);
+                tools.add(tool);
 
-		if (urls == null) {
-			urls = new ArrayList<URL>();
-		}
+            } finally {
+                // ***** IMPORTANT: set back original ClassLoader if changed *****
+                if (Thread.currentThread().getContextClassLoader() != savedClassLoader) {
+                    Thread.currentThread().setContextClassLoader(savedClassLoader);
+                }
+            }
+        }
+    }
 
-		File dirFile = getFileFromName(rootDir);
-		File[] directoryListing = dirFile.listFiles();
-		if (directoryListing != null) {
-			for (File file : directoryListing) {
-				// recursive call to sub-directories
-				if (file.isDirectory()) {
-					gatherClassLoaderUrls(urls, rootDir + File.separator + file.getName());
-					logger.debug("finished with directory: " + file.getAbsolutePath());
+    /*
+     * Instantiate a Tool class using Reflection by passing Fits into the constructor.
+     * Note: All Tool class implementations can have a 1-argument constructor with Fits as the argument.
+     * If it does not, then the standard newInstance() method fall-back will be used which results in a no-arg constructor being called.
+     * Note: Any exception thrown in a Tool constructor will result in a ReflectiveOperationException, not the thrown exception
+     * propagating up from the constructor.
+     */
+    private Tool createToolClassInstance(Class<?> toolClass, Fits fits) throws ReflectiveOperationException {
+        Object instanceOfTheClass = null;
+        try {
+            Constructor<?> ctor = toolClass.getConstructor(Fits.class);
+            instanceOfTheClass = ctor.newInstance(fits);
+            logger.debug("1-arg constructor for instantiating tool class: {}", toolClass.getName());
+        } catch (NoSuchMethodException e) {
+            // now try a no-arg constructor
+            logger.debug(
+                    "No Fits 1-arg constructor for tool class: {} -- trying no-arg constructor. Error message: {}",
+                    toolClass.getName(),
+                    e.getMessage());
+            instanceOfTheClass = toolClass.getDeclaredConstructor().newInstance();
+            logger.debug("Instantiated no-arg constructor for tool class: {}", toolClass.getName());
+        }
+        return (Tool) instanceOfTheClass;
+    }
 
-				} else if (!file.exists() || !file.isFile() || !file.canRead() ||
-						file.getName().endsWith(".txt") ||file.getName().startsWith(".", 0)) {
-					// ignoring any .txt files -- used as placeholder for directories, OSX .DS_Store, etc.
-					logger.debug("Not processing file: " + file.getName());
-					continue;
-				}
-				urls.add( file.toURI().toURL() );
-			}
-		}
-		return urls;
-	}
+    public List<Tool> getTools() {
+        return tools;
+    }
 
-	/*
-	 * Creates and returns a File object from a full path to a directory (or file).
-	 */
-	private File getFileFromName(String dirName) throws MalformedURLException {
+    public void printToolInfo(boolean includeSysInfo) {
+        if (includeSysInfo) {
+            // system info
+            logger.info("OS Name = " + System.getProperty("os.name"));
+            logger.info("OS Arch = " + System.getProperty("os.arch"));
+            logger.info("OS Version = " + System.getProperty("os.version"));
+            logger.info("------------------------------------");
+        }
 
-		String fullPathPrefix = StringUtils.isEmpty(Fits.FITS_HOME) ? "" : Fits.FITS_HOME + File.separator;
-		File dirFile = new File(fullPathPrefix + dirName);
-		return dirFile;
-	}
-	
-	/*
-	 * Creates a skeletal instance of Tool when a tool's class cannot even be instantiated.
-	 * Minimal information about the tool is contained here.
-	 *  
-	 * @param toolInfo Contains tool name and version (which is unknown in this situation).
-	 * @param throwable The Throwable resulting from the inability to instantiate the tool.
-	 * @return Tool which indicates a failed state and not enabled.
-	 */
-	private Tool getFailedTool(final ToolInfo toolInfo, Throwable throwable) {
+        for (Tool t : tools) {
+            logger.info(t.getToolInfo().print());
+        }
+    }
 
-		final Throwable t = throwable;
+    /* Process the tools-used elements and return a list of
+     * ... something */
+    private List<ToolsUsedItem> processToolsUsed(XMLConfiguration config) {
+        int size = config.getList("tools-used[@exts]").size();
+        List<ToolsUsedItem> results = new ArrayList<ToolsUsedItem>(size);
+        for (int i = 0; i < size; i++) {
+            @SuppressWarnings("unchecked")
+            List<String> exts = (List<String>) (List<?>) config.getList("tools-used(" + i + ")[@exts]");
+            @SuppressWarnings("unchecked")
+            List<String> tools = (List<String>) (List<?>) config.getList("tools-used(" + i + ")[@tools]");
+            results.add(new ToolsUsedItem(exts, tools));
+        }
+        return results;
+    }
 
-		Tool failedTool = new Tool() {
-			
-			
-			@Override
-			public void run() {}
+    /* Extract the last component of the class name to use as the
+     * tool's name field */
+    private String bareClassName(String cname) {
+        int n = cname.lastIndexOf(".");
+        return cname.substring(n + 1);
+    }
 
-			@Override
-			public ToolOutput extractInfo(File file) throws FitsToolException {
-				return null;
-			}
+    /*
+     * Create a custom class loader specifically for a set of resources as designated by a list of directories
+     * which are specified for each tool in fits.xml. If the parameter is null or empty OR
+     * there are no resources within any of the list of given directories then this method will return null.
+     *
+     * @return custom class loader ONLY if JAR files in tool-specific lib directory; <code>null</code> otherwise.
+     */
+    private ClassLoader createClassLoader(List<String> classpathDirs) throws MalformedURLException {
 
-			@Override
-			public boolean isIdentityKnown(ToolIdentity identity) {
-				return false;
-			}
+        if (classpathDirs == null || classpathDirs.isEmpty()) {
+            return null;
+        }
 
-			@Override
-			public ToolInfo getToolInfo() {
-				return toolInfo;
-			}
+        // collect all files from all specified directories
+        List<URL> directoriesUrls = new ArrayList<URL>();
+        for (String dir : classpathDirs) {
+            List<URL> urls = gatherClassLoaderUrls(null, dir);
+            // special case: If a root directory contains artifacts then add that root directory
+            // so as to create a custom class loader.
+            if (urls != null & !urls.isEmpty()) {
+                File dirFile = getFileFromName(dir);
+                urls.add(dirFile.toURI().toURL());
+            }
+            directoriesUrls.addAll(urls);
+        }
 
-			@Override
-			public Boolean canIdentify() {
-				return false;
-			}
+        // If nothing returned from directories then return null; Don't create ClassLoader if nothing to load.
+        if (directoriesUrls.isEmpty()) {
+            return null;
+        }
 
-			@Override
-			public String getName() {
-				return toolInfo.getName();
-			}
+        // Create list of resources for custom ClassLoader.
+        List<URL> classLoaderUrls = new ArrayList<URL>();
+        // Must always add FITS classes first
+        classLoaderUrls.add(fitsUrl);
+        // add all other resources next
+        classLoaderUrls.addAll(directoriesUrls);
+        logger.debug("URL's" + classLoaderUrls);
 
-			@Override
-			public void setName(String name) {}
+        final ParentLastClassLoader cl = new ParentLastClassLoader(classLoaderUrls);
 
-			@Override
-			public void addExcludedExtension(String ext) {}
+        return cl;
+    }
 
-			@Override
-			public void addIncludedExtension(String ext) {}
+    /*
+     * Recursive method to create a list of URL's of all files in a directory and all of its sub-directories.
+     * All files that end in ".txt" or begin with "." will be ignored. Also, simple directory URL's will not be added.
+     */
+    private List<URL> gatherClassLoaderUrls(List<URL> urls, String rootDir) throws MalformedURLException {
 
-			@Override
-			public boolean hasExcludedExtension(String ext) {
-				return true;
-			}
+        if (urls == null) {
+            urls = new ArrayList<URL>();
+        }
 
-			@Override
-			public boolean hasIncludedExtension(String ext) {
-				return false;
-			}
+        File dirFile = getFileFromName(rootDir);
+        File[] directoryListing = dirFile.listFiles();
+        if (directoryListing != null) {
+            for (File file : directoryListing) {
+                // recursive call to sub-directories
+                if (file.isDirectory()) {
+                    gatherClassLoaderUrls(urls, rootDir + File.separator + file.getName());
+                    logger.debug("finished with directory: " + file.getAbsolutePath());
 
-			@Override
-			public boolean hasIncludedExtensions() {
-				return false;
-			}
+                } else if (!file.exists()
+                        || !file.isFile()
+                        || !file.canRead()
+                        || file.getName().endsWith(".txt")
+                        || file.getName().startsWith(".", 0)) {
+                    // ignoring any .txt files -- used as placeholder for directories, OSX .DS_Store, etc.
+                    logger.debug("Not processing file: " + file.getName());
+                    continue;
+                }
+                urls.add(file.toURI().toURL());
+            }
+        }
+        return urls;
+    }
 
-			@Override
-			public boolean hasExcludedExtensions() {
-				return false;
-			}
+    /*
+     * Creates and returns a File object from a full path to a directory (or file).
+     */
+    private File getFileFromName(String dirName) throws MalformedURLException {
 
-			@Override
-			public void applyToolsUsed(List<ToolsUsedItem> toolsUsedItems) {}
+        String fullPathPrefix = StringUtils.isEmpty(Fits.FITS_HOME) ? "" : Fits.FITS_HOME + File.separator;
+        File dirFile = new File(fullPathPrefix + dirName);
+        return dirFile;
+    }
 
-			@Override
-			public void resetOutput() {}
+    /*
+     * Creates a skeletal instance of Tool when a tool's class cannot even be instantiated.
+     * Minimal information about the tool is contained here.
+     *
+     * @param toolInfo Contains tool name and version (which is unknown in this situation).
+     * @param throwable The Throwable resulting from the inability to instantiate the tool.
+     * @return Tool which indicates a failed state and not enabled.
+     */
+    private Tool getFailedTool(final ToolInfo toolInfo, Throwable throwable) {
 
-			/**
-			 * Indicates that the tool is not enabled so should be no attempt to run tool.
-			 */
-			@Override
-			public boolean isEnabled() {
-				return false;
-			}
+        final Throwable t = throwable;
 
-			@Override
-			public void setEnabled(boolean value) {}
+        Tool failedTool = new Tool() {
 
-			@Override
-			public void setInputFile(File file) {}
+            @Override
+            public void run() {}
 
-			@Override
-			public ToolOutput getOutput() {
-				return null;
-			}
+            @Override
+            public ToolOutput extractInfo(File file) throws FitsToolException {
+                return null;
+            }
 
-			@Override
-			public long getDuration() {
-				return 0;
-			}
+            @Override
+            public boolean isIdentityKnown(ToolIdentity identity) {
+                return false;
+            }
 
-			/**
-			 * Return status that shows the tool failed.
-			 */
-			@Override
-			public RunStatus getRunStatus() {
-				return RunStatus.FAILED;
-			}
+            @Override
+            public ToolInfo getToolInfo() {
+                return toolInfo;
+            }
 
-			@Override
-			public void setRunStatus(RunStatus runStatus) {}
+            @Override
+            public Boolean canIdentify() {
+                return false;
+            }
 
-			@Override
-			public Throwable getCaughtThrowable() {
-				return t;
-			}
-		};
+            @Override
+            public String getName() {
+                return toolInfo.getName();
+            }
 
-		return failedTool;
-	}
+            @Override
+            public void setName(String name) {}
+
+            @Override
+            public void addExcludedExtension(String ext) {}
+
+            @Override
+            public void addIncludedExtension(String ext) {}
+
+            @Override
+            public boolean hasExcludedExtension(String ext) {
+                return true;
+            }
+
+            @Override
+            public boolean hasIncludedExtension(String ext) {
+                return false;
+            }
+
+            @Override
+            public boolean hasIncludedExtensions() {
+                return false;
+            }
+
+            @Override
+            public boolean hasExcludedExtensions() {
+                return false;
+            }
+
+            @Override
+            public void applyToolsUsed(List<ToolsUsedItem> toolsUsedItems) {}
+
+            @Override
+            public void resetOutput() {}
+
+            /**
+             * Indicates that the tool is not enabled so should be no attempt to run tool.
+             */
+            @Override
+            public boolean isEnabled() {
+                return false;
+            }
+
+            @Override
+            public void setEnabled(boolean value) {}
+
+            @Override
+            public void setInputFile(File file) {}
+
+            @Override
+            public ToolOutput getOutput() {
+                return null;
+            }
+
+            @Override
+            public long getDuration() {
+                return 0;
+            }
+
+            /**
+             * Return status that shows the tool failed.
+             */
+            @Override
+            public RunStatus getRunStatus() {
+                return RunStatus.FAILED;
+            }
+
+            @Override
+            public void setRunStatus(RunStatus runStatus) {}
+
+            @Override
+            public Throwable getCaughtThrowable() {
+                return t;
+            }
+        };
+
+        return failedTool;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/ToolErrorHandler.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/ToolErrorHandler.java
@@ -33,6 +33,6 @@ public class ToolErrorHandler implements ErrorHandler {
 
     @Override
     public void warning(SAXParseException e) throws SAXException {
-    	logger.warn("SAX warning", e);
+        logger.warn("SAX warning", e);
     }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/ToolInfo.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/ToolInfo.java
@@ -14,95 +14,92 @@ package edu.harvard.hul.ois.fits.tools;
  */
 public class ToolInfo {
 
-	private String name;
-	private String version;
-	private String date;
-	private String note;
+    private String name;
+    private String version;
+    private String date;
+    private String note;
 
-	public ToolInfo() {
+    public ToolInfo() {}
 
-	}
+    public ToolInfo(String name, String version, String date) {
+        this.name = name;
+        this.version = version;
+        this.date = date;
+    }
 
-	public ToolInfo(String name, String version, String date) {
-		this.name = name;
-		this.version = version;
-		this.date = date;
-	}
-
-	/**
-	 * Returns the name of the software, not to be confused with
-	 * the name of the Tool object.
-	 */
-	public String getName() {
-		return name;
-	}
-
+    /**
+     * Returns the name of the software, not to be confused with
+     * the name of the Tool object.
+     */
+    public String getName() {
+        return name;
+    }
 
     /**
      * Sets the name of the software, not to be confused with
      * the name of the Tool object.
      */
-	public void setName(String name) {
-		this.name = name;
-	}
-	
-	public String getVersion() {
-		return version;
-	}
-	
-	/**
-	 * Sets the current version of the tool.
-	 * 
-	 * @param version The current version of the tool.
-	 */
-	public void setVersion(String version) {
-		this.version = version;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	/**
-	 * Returns the publication date reported by the software (or
-	 * which FITS has hard-coded based on available information).
-	 */
-	public String getDate() {
-		return date;
-	}
-	public void setDate(String date) {
-		this.date = date;
-	}
+    public String getVersion() {
+        return version;
+    }
 
-	/**
-	 * Returns a String with human-readable information about the tool.
-	 */
-	public String print() {
-		String value = "Name= "+name+"\nVersion= "+version+"\nDate= "+date+"\n";
-		if(note != null && note.length() > 0) {
-			value = value +"Note= " + note + "\n";
-		}
-		return value;
-	}
+    /**
+     * Sets the current version of the tool.
+     *
+     * @param version The current version of the tool.
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
 
-	public String getNote() {
-		return note;
-	}
+    /**
+     * Returns the publication date reported by the software (or
+     * which FITS has hard-coded based on available information).
+     */
+    public String getDate() {
+        return date;
+    }
 
-	/**
-	 * Set any optional additional information for a given tool.
-	 * 
-	 * @param note The information
-	 */
-	public void setNote(String note) {
-		this.note = note;
-	}
+    public void setDate(String date) {
+        this.date = date;
+    }
 
-	@Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder("ToolInfo: [");
-		sb.append("name: ");
-		sb.append(getName());
-		sb.append(", version: ");
-		sb.append(getVersion());
-		sb.append("]");
-		return sb.toString();
-	}
+    /**
+     * Returns a String with human-readable information about the tool.
+     */
+    public String print() {
+        String value = "Name= " + name + "\nVersion= " + version + "\nDate= " + date + "\n";
+        if (note != null && note.length() > 0) {
+            value = value + "Note= " + note + "\n";
+        }
+        return value;
+    }
 
+    public String getNote() {
+        return note;
+    }
+
+    /**
+     * Set any optional additional information for a given tool.
+     *
+     * @param note The information
+     */
+    public void setNote(String note) {
+        this.note = note;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("ToolInfo: [");
+        sb.append("name: ");
+        sb.append(getName());
+        sb.append(", version: ");
+        sb.append(getVersion());
+        sb.append("]");
+        return sb.toString();
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/ToolOutput.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/ToolOutput.java
@@ -10,13 +10,15 @@
 
 package edu.harvard.hul.ois.fits.tools;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import edu.harvard.hul.ois.fits.identity.ExternalIdentifier;
+import edu.harvard.hul.ois.fits.identity.ToolIdentity;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -29,153 +31,149 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
-import edu.harvard.hul.ois.fits.identity.ExternalIdentifier;
-import edu.harvard.hul.ois.fits.identity.ToolIdentity;
-
 /**
  *   The output created by a Tool. A ToolOutput object holds JDOM objects
  *   representing the FITS output and the raw form of the output.
  */
 public class ToolOutput {
 
-	private static Logger logger = LoggerFactory.getLogger(ToolOutput.class);
+    private static Logger logger = LoggerFactory.getLogger(ToolOutput.class);
 
     private DocumentBuilderFactory docBuilderFactory;
 
-    private static Namespace fitsNS = Namespace.getNamespace("fits",Fits.XML_NAMESPACE);
+    private static Namespace fitsNS = Namespace.getNamespace("fits", Fits.XML_NAMESPACE);
     private XPathFactory xFactory = XPathFactory.instance();
 
-	//The FITS formatted XML
-	private Document fitsXml = null;
-	//Wrapper for raw output from the tool
-	private Document toolOutput = null;
-	//Reference to the tool the output was created with
-	private Tool tool;
-	//Identification data about the input file
-	private List<ToolIdentity> identity = new ArrayList<ToolIdentity>();
+    // The FITS formatted XML
+    private Document fitsXml = null;
+    // Wrapper for raw output from the tool
+    private Document toolOutput = null;
+    // Reference to the tool the output was created with
+    private Tool tool;
+    // Identification data about the input file
+    private List<ToolIdentity> identity = new ArrayList<ToolIdentity>();
 
-	/** Constructor
-	 *
-	 *  @param tool       The Tool creating this output
-	 * @param fitsXml    JDOM Document following the FITS output schema
-	 * @param toolOutput Raw XML JDOM Document representing the original output
-	 *                    of the tool
-	 * @param fits TODO
-	 */
-	public ToolOutput(Tool tool, Document fitsXml, Document toolOutput, Fits fits) throws FitsToolException {
+    /** Constructor
+     *
+     *  @param tool       The Tool creating this output
+     * @param fitsXml    JDOM Document following the FITS output schema
+     * @param toolOutput Raw XML JDOM Document representing the original output
+     *                    of the tool
+     * @param fits TODO
+     */
+    public ToolOutput(Tool tool, Document fitsXml, Document toolOutput, Fits fits) throws FitsToolException {
         docBuilderFactory = DocumentBuilderFactory.newInstance();
         docBuilderFactory.setNamespaceAware(true);
         docBuilderFactory.setValidating(true);
-        docBuilderFactory.setAttribute("http://java.sun.com/xml/jaxp/properties/schemaLanguage", "http://www.w3.org/2001/XMLSchema");
+        docBuilderFactory.setAttribute(
+                "http://java.sun.com/xml/jaxp/properties/schemaLanguage", "http://www.w3.org/2001/XMLSchema");
         String internalSchemaLocation = Fits.FITS_HOME + fits.getInternalOutputSchema();
         docBuilderFactory.setAttribute("http://java.sun.com/xml/jaxp/properties/schemaSource", internalSchemaLocation);
 
-        if(fits.validateToolOutput() && fitsXml !=null && !validateXmlOutput(fitsXml)) {
-			throw new FitsToolException(tool.getToolInfo().getName()+" "+
-					tool.getToolInfo().getVersion() + " produced invalid FITS XML output");
-		}
+        if (fits.validateToolOutput() && fitsXml != null && !validateXmlOutput(fitsXml)) {
+            throw new FitsToolException(tool.getToolInfo().getName() + " "
+                    + tool.getToolInfo().getVersion() + " produced invalid FITS XML output");
+        }
 
-		this.tool = tool;
-		this.toolOutput = toolOutput;
-		//map values and get identities from fitsXML if not null
-		if(fitsXml != null) {
-			//fitsxml doc is mapped here before identities are extracted
-			this.fitsXml = fits.getFitsXmlMapper().applyMap(tool,fitsXml); // Perform any last-chance transformations/normalizations of FITS output.
-			identity = createFileIdentities(fitsXml,tool.getToolInfo());
-		}
-	}
+        this.tool = tool;
+        this.toolOutput = toolOutput;
+        // map values and get identities from fitsXML if not null
+        if (fitsXml != null) {
+            // fitsxml doc is mapped here before identities are extracted
+            this.fitsXml = fits.getFitsXmlMapper()
+                    .applyMap(tool, fitsXml); // Perform any last-chance transformations/normalizations of FITS output.
+            identity = createFileIdentities(fitsXml, tool.getToolInfo());
+        }
+    }
 
-	/** Returns the Tool that created this object */
-	public Tool getTool() {
-		return tool;
-	}
+    /** Returns the Tool that created this object */
+    public Tool getTool() {
+        return tool;
+    }
 
-	/** Returns the FITS-structured XML as a JDOM Document */
-	public Document getFitsXml() {
-		return fitsXml;
-	}
+    /** Returns the FITS-structured XML as a JDOM Document */
+    public Document getFitsXml() {
+        return fitsXml;
+    }
 
-	/** Sets the FITS-structured XML as a JDOM Document */
-	public void setFitsXml(Document fitsXml) {
-		this.fitsXml = fitsXml;
-	}
+    /** Sets the FITS-structured XML as a JDOM Document */
+    public void setFitsXml(Document fitsXml) {
+        this.fitsXml = fitsXml;
+    }
 
-	/** Returns the raw XML from the tool */
-	public Document getToolOutput() {
-		return toolOutput;
-	}
+    /** Returns the raw XML from the tool */
+    public Document getToolOutput() {
+        return toolOutput;
+    }
 
-	/** Returns a List of identity information objects about the file,
-	 *  one for each reporting tool */
-	public List<ToolIdentity> getFileIdentity() {
-		return identity;
-	}
+    /** Returns a List of identity information objects about the file,
+     *  one for each reporting tool */
+    public List<ToolIdentity> getFileIdentity() {
+        return identity;
+    }
 
-	/** Add a tool's identity information on a file to the identity list
-	 */
-	public void addFileIdentity(ToolIdentity id) {
-		identity.add(id);
-	}
+    /** Add a tool's identity information on a file to the identity list
+     */
+    public void addFileIdentity(ToolIdentity id) {
+        identity.add(id);
+    }
 
-	private boolean validateXmlOutput(Document output) {
+    private boolean validateXmlOutput(Document output) {
 
-		try {
-			DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
-			docBuilder.setErrorHandler (new ToolErrorHandler());
+        try {
+            DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
+            docBuilder.setErrorHandler(new ToolErrorHandler());
 
-			XMLOutputter outputter = new XMLOutputter();
-			String xml = outputter.outputString(output);
+            XMLOutputter outputter = new XMLOutputter();
+            String xml = outputter.outputString(output);
 
-			docBuilder.parse(new InputSource(new StringReader(xml)));
-		} catch(Exception e) {
-			logger.error("tool returned invalid XML",e);
-			return false;
-		}
-		return true;
-	}
+            docBuilder.parse(new InputSource(new StringReader(xml)));
+        } catch (Exception e) {
+            logger.error("tool returned invalid XML", e);
+            return false;
+        }
+        return true;
+    }
 
-	private List<ToolIdentity> createFileIdentities(Document dom, ToolInfo info) {
-		List<ToolIdentity> identities = new ArrayList<ToolIdentity>();
-		XPathExpression<Element> expr = xFactory.compile("//fits:identity", Filters.element(), null, fitsNS);
+    private List<ToolIdentity> createFileIdentities(Document dom, ToolInfo info) {
+        List<ToolIdentity> identities = new ArrayList<ToolIdentity>();
+        XPathExpression<Element> expr = xFactory.compile("//fits:identity", Filters.element(), null, fitsNS);
         List<Element> identElements = (List<Element>) expr.evaluate(dom);
-		for(Element element : identElements) {
-			Attribute formatAttr = element.getAttribute("format");
-			Attribute mimetypeAttr = element.getAttribute("mimetype");
-			Element versionElement = element.getChild("version",fitsNS);
+        for (Element element : identElements) {
+            Attribute formatAttr = element.getAttribute("format");
+            Attribute mimetypeAttr = element.getAttribute("mimetype");
+            Element versionElement = element.getChild("version", fitsNS);
 
-			String format = null;
-			String mimetype = null;
-			String version = null;
+            String format = null;
+            String mimetype = null;
+            String version = null;
 
-			if(formatAttr != null) {
-				format = formatAttr.getValue();
-			}
-			if(mimetypeAttr != null) {
-				mimetype = mimetypeAttr.getValue();
-			}
-			if(versionElement != null) {
-				version = versionElement.getText();
-			}
-			ToolIdentity identity = new ToolIdentity(mimetype,format,version,info);
-			List<Element> xIDElements = element.getChildren("externalIdentifier",fitsNS);
-			for(Element xIDElement : xIDElements) {
-				String type = xIDElement.getAttributeValue("type");
-				String value = xIDElement.getText();
-				ExternalIdentifier xid = new ExternalIdentifier(type,value,info);
-				identity.addExternalIdentifier(xid);
-			}
-			identities.add(identity);
-		}
-		return identities;
-	}
+            if (formatAttr != null) {
+                format = formatAttr.getValue();
+            }
+            if (mimetypeAttr != null) {
+                mimetype = mimetypeAttr.getValue();
+            }
+            if (versionElement != null) {
+                version = versionElement.getText();
+            }
+            ToolIdentity identity = new ToolIdentity(mimetype, format, version, info);
+            List<Element> xIDElements = element.getChildren("externalIdentifier", fitsNS);
+            for (Element xIDElement : xIDElements) {
+                String type = xIDElement.getAttributeValue("type");
+                String value = xIDElement.getText();
+                ExternalIdentifier xid = new ExternalIdentifier(type, value, info);
+                identity.addExternalIdentifier(xid);
+            }
+            identities.add(identity);
+        }
+        return identities;
+    }
 
-	public String toString() {
-		StringBuilder sb = new StringBuilder("ToolOutput[");
-		sb.append(tool.getName());
-		sb.append("]");
-		return sb.toString();
-	}
-
+    public String toString() {
+        StringBuilder sb = new StringBuilder("ToolOutput[");
+        sb.append(tool.getName());
+        sb.append("]");
+        return sb.toString();
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/droid/ArchiveContentIdentifier.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/droid/ArchiveContentIdentifier.java
@@ -1,7 +1,7 @@
 /**
  * This file has been modified by Harvard University, June, 2017, for the purposes of incorporating
  * into the FITS application. The original can be found here: https://github.com/digital-preservation/droid
- * 
+ *
  * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
  * All rights reserved.
  *
@@ -38,9 +38,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
-
 import org.apache.commons.compress.archivers.zip.UnsupportedZipFeatureException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.nationalarchives.droid.command.action.CommandExecutionException;
@@ -79,10 +77,14 @@ public abstract class ArchiveContentIdentifier {
      * @param expandWebArchives             optionally expand (W)ARC files
      * @param puidFormatMap                 map of puids to formats
      */
-    public ArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
-                                       final ContainerSignatureDefinitions containerSignatureDefinitions,
-                                       final String path, final String slash, final String slash1,
-                                       final Boolean expandWebArchives, final Map<String, Format> puidFormatMap) {
+    public ArchiveContentIdentifier(
+            final BinarySignatureIdentifier binarySignatureIdentifier,
+            final ContainerSignatureDefinitions containerSignatureDefinitions,
+            final String path,
+            final String slash,
+            final String slash1,
+            final Boolean expandWebArchives,
+            final Map<String, Format> puidFormatMap) {
 
         synchronized (this) {
             setBinarySignatureIdentifier(binarySignatureIdentifier);
@@ -113,7 +115,7 @@ public abstract class ArchiveContentIdentifier {
      * @return container element delimiter
      */
     protected String getSlash1() {
-        return  slash1;
+        return slash1;
     }
     /**
      * @param newSlash1 container element delimiter
@@ -125,7 +127,7 @@ public abstract class ArchiveContentIdentifier {
      * @return binary signature identifier
      */
     protected BinarySignatureIdentifier getBinarySignatureIdentifier() {
-        return  binarySignatureIdentifier;
+        return binarySignatureIdentifier;
     }
     /**
      * @param bis binary signature identifier
@@ -200,29 +202,37 @@ public abstract class ArchiveContentIdentifier {
      * @param aggregator Aggregates ZIP file container information
      * @throws CommandExecutionException When an exception happens during execution
      */
-    protected void expandContainer(IdentificationRequest request, InputStream in, String newPath, ContainerAggregator aggregator)
-        throws CommandExecutionException, UnsupportedZipFeatureException {
+    protected void expandContainer(
+            IdentificationRequest request, InputStream in, String newPath, ContainerAggregator aggregator)
+            throws CommandExecutionException, UnsupportedZipFeatureException {
 
         try {
             request.open(in);
             IdentificationResultCollection results =
                     getBinarySignatureIdentifier().matchBinarySignatures(request);
-            
+
             if (results.getResults().isEmpty()) {
-            	results = binarySignatureIdentifier.matchExtensions(request, true);
+                results = binarySignatureIdentifier.matchExtensions(request, true);
             }
 
-            final ResultPrinter resultPrinter =
-                    new ResultPrinter(getBinarySignatureIdentifier(),
-                            getContainerSignatureDefinitions(), newPath, getSlash(), getSlash1(), true,
-                            getExpandWebArchives(), aggregator, puidFormatMap);
+            final ResultPrinter resultPrinter = new ResultPrinter(
+                    getBinarySignatureIdentifier(),
+                    getContainerSignatureDefinitions(),
+                    newPath,
+                    getSlash(),
+                    getSlash1(),
+                    true,
+                    getExpandWebArchives(),
+                    aggregator,
+                    puidFormatMap);
 
             resultPrinter.print(results, request);
             request.close();
         } catch (UnsupportedZipFeatureException e) {
-        	// output: org.apache.commons.compress.archivers.zip.UnsupportedZipFeatureException: unsupported feature encryption used in entry Book_pdfx1a.pdf
-        	throw e;
-        }  catch (IOException ioe) {
+            // output: org.apache.commons.compress.archivers.zip.UnsupportedZipFeatureException: unsupported feature
+            // encryption used in entry Book_pdfx1a.pdf
+            throw e;
+        } catch (IOException ioe) {
             logger.warn(ioe + " " + newPath);
         } finally {
             try {
@@ -234,5 +244,4 @@ public abstract class ArchiveContentIdentifier {
             }
         }
     }
-
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/droid/ContainerAggregator.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/droid/ContainerAggregator.java
@@ -11,155 +11,153 @@
 package edu.harvard.hul.ois.fits.tools.droid;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.zip.ZipEntry;
 
 /**
  * This class aggregates data from Droid about container (ZIP) type files.
- * 
+ *
  * @author dan179
  */
 public class ContainerAggregator {
-	
-	// Maps format type to number of these types of files with a ZIP file
-	private Map<String, Integer> formatToCount;
-	
-	// Aggregated original size of all files contained within the ZIP file.
-	private long originalSize;
 
-	// Aggregated compressed size of all files contained within the ZIP file.
-	// If ZIP is not compressed then should equal the original size.
-	private long compressedSize;
-	
-	private boolean isEncrypted = false;
-	
-	private static final String UNKNOWN_FORMAT = "Unknown";
+    // Maps format type to number of these types of files with a ZIP file
+    private Map<String, Integer> formatToCount;
 
-	public ContainerAggregator() {
-		formatToCount = new TreeMap<>(); // order entries by key for the sake of XMLUnit tests
-	}
+    // Aggregated original size of all files contained within the ZIP file.
+    private long originalSize;
 
-	/**
-	 * Aggregated original size of files with a ZIP file.
-	 * 
-	 * @return Original size of all files within ZIP file in bytes.
-	 */
-	public long getOriginalSize() {
-		return originalSize;
-	}
+    // Aggregated compressed size of all files contained within the ZIP file.
+    // If ZIP is not compressed then should equal the original size.
+    private long compressedSize;
 
-	/**
-	 * Increment the calculated original size of the examined ZIP file by the original size of a contained file.
-	 */
-	public void incrementOriginalSize(long originalSize) {
-		this.originalSize += originalSize;
-	}
+    private boolean isEncrypted = false;
 
-	/**
-	 * Aggregated compressed size of files with a ZIP file.
-	 * 
-	 * @return Compressed size of all files within ZIP file in bytes.
-	 */
-	public long getCompressedSize() {
-		return compressedSize;
-	}
+    private static final String UNKNOWN_FORMAT = "Unknown";
 
-	/**
-	 * Increment the compressed size of the examined ZIP file by the original size of a contained file.
-	 */
-	public void incrementCompressedSize(long compressedSize) {
-		this.compressedSize += compressedSize;
-	}
-	
-	/**
-	 * Add a format type to this collection and increment count for this type.
-	 */
-	public void addFormat(String format) {
-		if (format !=null) {
-			Integer cnt = formatToCount.get(format);
-			if (cnt == null) {
-				formatToCount.put(format, 1);
-			} else {
-				cnt++;
-				formatToCount.put(format, cnt);
-			}
-		}
-	}
-	
-	public void incrementUnknownFormat() {
-		Integer cnt = formatToCount.get(UNKNOWN_FORMAT);
-		if (cnt == null) {
-			formatToCount.put(UNKNOWN_FORMAT, 1);
-		} else {
-			cnt++;
-			formatToCount.put(UNKNOWN_FORMAT, cnt);
-		}
-	}
-	
-	/**
-	 * A Map of format type to number of each format type.
-	 * 
-	 * @return Format to count mapping
-	 */
-	public Map<String, Integer> getFormatCounts() {
-		return Collections.unmodifiableMap(formatToCount);
-	}
-	
-	/**
-	 * Total number of all format types added to this collection.
-	 * 
-	 * @return Total number for formats added to this collection.
-	 */
-	public int getTotalEntriesCount() {
-		int total = 0;
-		for (Integer val : formatToCount.values()) {
-			total += val;
-		}
-		return total;
-	}
-	
-	/**
-	 * The compression method as defined the Java ZipEntry. Currently only values for 'stored' (uncompressed)
-	 * and 'deflate' (compressed) are used.
-	 * 
-	 * @return The value corresponding to
-	 * @see java.util.zip.ZipEntry
-	 */
-	public int getCompressionMethod() {
-		return getCompressedSize() < getOriginalSize() ? ZipEntry.DEFLATED : ZipEntry.STORED;
-	}
+    public ContainerAggregator() {
+        formatToCount = new TreeMap<>(); // order entries by key for the sake of XMLUnit tests
+    }
 
-	/**
-	 * Whether the container being examined is encrypted.
-	 */
-	public boolean isEncrypted() {
-		return isEncrypted;
-	}
+    /**
+     * Aggregated original size of files with a ZIP file.
+     *
+     * @return Original size of all files within ZIP file in bytes.
+     */
+    public long getOriginalSize() {
+        return originalSize;
+    }
 
-	/**
-	 * Sets whether this container being examined is encrypted.
-	 */
-	public void setEncrypted(boolean isEncrypted) {
-		this.isEncrypted = isEncrypted;
-	}
+    /**
+     * Increment the calculated original size of the examined ZIP file by the original size of a contained file.
+     */
+    public void incrementOriginalSize(long originalSize) {
+        this.originalSize += originalSize;
+    }
 
-	@Override
-	public String toString() {
-		StringBuilder builder = new StringBuilder();
-		builder.append("ContainerAggregator [formatToCount=");
-		builder.append(formatToCount);
-		builder.append("]");
-		builder.append(" total count: ");
-		builder.append(getTotalEntriesCount());
-		builder.append(", originalSize: ");
-		builder.append(originalSize);
-		builder.append(", compressedSize: ");
-		builder.append(compressedSize);
-		builder.append(", isEncrypted: ");
-		builder.append(isEncrypted);
-		return builder.toString();
-	}
+    /**
+     * Aggregated compressed size of files with a ZIP file.
+     *
+     * @return Compressed size of all files within ZIP file in bytes.
+     */
+    public long getCompressedSize() {
+        return compressedSize;
+    }
 
+    /**
+     * Increment the compressed size of the examined ZIP file by the original size of a contained file.
+     */
+    public void incrementCompressedSize(long compressedSize) {
+        this.compressedSize += compressedSize;
+    }
+
+    /**
+     * Add a format type to this collection and increment count for this type.
+     */
+    public void addFormat(String format) {
+        if (format != null) {
+            Integer cnt = formatToCount.get(format);
+            if (cnt == null) {
+                formatToCount.put(format, 1);
+            } else {
+                cnt++;
+                formatToCount.put(format, cnt);
+            }
+        }
+    }
+
+    public void incrementUnknownFormat() {
+        Integer cnt = formatToCount.get(UNKNOWN_FORMAT);
+        if (cnt == null) {
+            formatToCount.put(UNKNOWN_FORMAT, 1);
+        } else {
+            cnt++;
+            formatToCount.put(UNKNOWN_FORMAT, cnt);
+        }
+    }
+
+    /**
+     * A Map of format type to number of each format type.
+     *
+     * @return Format to count mapping
+     */
+    public Map<String, Integer> getFormatCounts() {
+        return Collections.unmodifiableMap(formatToCount);
+    }
+
+    /**
+     * Total number of all format types added to this collection.
+     *
+     * @return Total number for formats added to this collection.
+     */
+    public int getTotalEntriesCount() {
+        int total = 0;
+        for (Integer val : formatToCount.values()) {
+            total += val;
+        }
+        return total;
+    }
+
+    /**
+     * The compression method as defined the Java ZipEntry. Currently only values for 'stored' (uncompressed)
+     * and 'deflate' (compressed) are used.
+     *
+     * @return The value corresponding to
+     * @see java.util.zip.ZipEntry
+     */
+    public int getCompressionMethod() {
+        return getCompressedSize() < getOriginalSize() ? ZipEntry.DEFLATED : ZipEntry.STORED;
+    }
+
+    /**
+     * Whether the container being examined is encrypted.
+     */
+    public boolean isEncrypted() {
+        return isEncrypted;
+    }
+
+    /**
+     * Sets whether this container being examined is encrypted.
+     */
+    public void setEncrypted(boolean isEncrypted) {
+        this.isEncrypted = isEncrypted;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("ContainerAggregator [formatToCount=");
+        builder.append(formatToCount);
+        builder.append("]");
+        builder.append(" total count: ");
+        builder.append(getTotalEntriesCount());
+        builder.append(", originalSize: ");
+        builder.append(originalSize);
+        builder.append(", compressedSize: ");
+        builder.append(compressedSize);
+        builder.append(", isEncrypted: ");
+        builder.append(isEncrypted);
+        return builder.toString();
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/droid/Droid.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/droid/Droid.java
@@ -10,6 +10,12 @@
 
 package edu.harvard.hul.ois.fits.tools.droid;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsMetadataValues;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import edu.harvard.hul.ois.fits.tools.ToolBase;
+import edu.harvard.hul.ois.fits.tools.ToolInfo;
+import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -18,15 +24,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.commons.configuration.XMLConfiguration;
-
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsMetadataValues;
-import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
-import edu.harvard.hul.ois.fits.tools.ToolBase;
-import edu.harvard.hul.ois.fits.tools.ToolInfo;
-import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.nationalarchives.droid.command.action.VersionCommand;
@@ -53,7 +51,7 @@ import uk.gov.nationalarchives.droid.signature.SignatureParser;
  */
 public class Droid extends ToolBase {
 
-	private boolean enabled = true;
+    private boolean enabled = true;
     private final Fits fits;
     private final List<String> includeExts;
     private long kbReadLimit;
@@ -63,146 +61,151 @@ public class Droid extends ToolBase {
     private static final ContainerIdentifierFactory containerIdentifierFactory = new ContainerIdentifierFactoryImpl();
     private static final ArchiveFormatResolver containerFormatResolver = new ArchiveFormatResolverImpl();
     private static ContainerSignatureDefinitions containerSignatureDefinitions;
-	private static final Map<String, Format> puidFormatMap = new HashMap<>(2500);
+    private static final Map<String, Format> puidFormatMap = new HashMap<>(2500);
 
-    private final static List<String> CONTAINER_TYPE_MIMETYPES = Arrays.asList("application/zip");
+    private static final List<String> CONTAINER_TYPE_MIMETYPES = Arrays.asList("application/zip");
 
-	private static final Logger logger = LoggerFactory.getLogger(Droid.class);
+    private static final Logger logger = LoggerFactory.getLogger(Droid.class);
 
-	public Droid(Fits fits) throws FitsToolException {
-		super();
-		this.fits = fits;
-        logger.debug ("Initializing Droid");
-		info = new ToolInfo("Droid", getDroidVersion(), null);
+    public Droid(Fits fits) throws FitsToolException {
+        super();
+        this.fits = fits;
+        logger.debug("Initializing Droid");
+        info = new ToolInfo("Droid", getDroidVersion(), null);
 
-		try {
-			String droid_conf = Fits.FITS_TOOLS_DIR+"droid"+File.separator;
-			XMLConfiguration config = fits.getConfig();
-			// only need a single Droid signature file.
-			if (sigFile == null) {
-				synchronized(this) {
-					if (sigFile == null) {
-						sigFile = new File(droid_conf + config.getString("droid_sigfile"));
-						sigIdentifier.setSignatureFile(sigFile.getAbsolutePath());
-						sigIdentifier.init();
+        try {
+            String droid_conf = Fits.FITS_TOOLS_DIR + "droid" + File.separator;
+            XMLConfiguration config = fits.getConfig();
+            // only need a single Droid signature file.
+            if (sigFile == null) {
+                synchronized (this) {
+                    if (sigFile == null) {
+                        sigFile = new File(droid_conf + config.getString("droid_sigfile"));
+                        sigIdentifier.setSignatureFile(sigFile.getAbsolutePath());
+                        sigIdentifier.init();
 
-						// The following is necessary to init the code that identifies formats like docx, xlsx, etc
-						SignatureParser sigParser = new SaxSignatureFileParser(sigFile.toURI());
-						sigParser.formats(format -> {
-							puidFormatMap.put(format.getPuid(), format);
-						});
+                        // The following is necessary to init the code that identifies formats like docx, xlsx, etc
+                        SignatureParser sigParser = new SaxSignatureFileParser(sigFile.toURI());
+                        sigParser.formats(format -> {
+                            puidFormatMap.put(format.getPuid(), format);
+                        });
 
-						String containerSigFile = droid_conf + config.getString("droid_container_sigfile");
-						ContainerSignatureFileReader signatureReader = new ContainerSignatureFileReader(containerSigFile);
+                        String containerSigFile = droid_conf + config.getString("droid_container_sigfile");
+                        ContainerSignatureFileReader signatureReader =
+                                new ContainerSignatureFileReader(containerSigFile);
 
-						containerSignatureDefinitions = signatureReader.getDefinitions();
+                        containerSignatureDefinitions = signatureReader.getDefinitions();
 
-						ZipIdentifierEngine zipIdentifierEngine = new ZipIdentifierEngine();
-						zipIdentifierEngine.setRequestFactory(new ContainerFileIdentificationRequestFactory());
+                        ZipIdentifierEngine zipIdentifierEngine = new ZipIdentifierEngine();
+                        zipIdentifierEngine.setRequestFactory(new ContainerFileIdentificationRequestFactory());
 
-						ZipIdentifier zipIdentifier = new ZipIdentifier();
-						zipIdentifier.setContainerType("ZIP");
-						zipIdentifier.setContainerIdentifierFactory(containerIdentifierFactory);
-						zipIdentifier.setContainerFormatResolver(containerFormatResolver);
-						zipIdentifier.setDroidCore(sigIdentifier);
-						zipIdentifier.setIdentifierEngine(zipIdentifierEngine);
-						zipIdentifier.setSignatureReader(signatureReader);
-						zipIdentifier.init();
+                        ZipIdentifier zipIdentifier = new ZipIdentifier();
+                        zipIdentifier.setContainerType("ZIP");
+                        zipIdentifier.setContainerIdentifierFactory(containerIdentifierFactory);
+                        zipIdentifier.setContainerFormatResolver(containerFormatResolver);
+                        zipIdentifier.setDroidCore(sigIdentifier);
+                        zipIdentifier.setIdentifierEngine(zipIdentifierEngine);
+                        zipIdentifier.setSignatureReader(signatureReader);
+                        zipIdentifier.init();
 
-						Ole2IdentifierEngine ole2IdentifierEngine = new Ole2IdentifierEngine();
-						ole2IdentifierEngine.setRequestFactory(new ContainerFileIdentificationRequestFactory());
+                        Ole2IdentifierEngine ole2IdentifierEngine = new Ole2IdentifierEngine();
+                        ole2IdentifierEngine.setRequestFactory(new ContainerFileIdentificationRequestFactory());
 
-						Ole2Identifier ole2Identifier = new Ole2Identifier();
-						ole2Identifier.setContainerType("OLE2");
-						ole2Identifier.setContainerIdentifierFactory(containerIdentifierFactory);
-						ole2Identifier.setContainerFormatResolver(containerFormatResolver);
-						ole2Identifier.setDroidCore(sigIdentifier);
-						ole2Identifier.setIdentifierEngine(ole2IdentifierEngine);
-						ole2Identifier.setSignatureReader(signatureReader);
-						ole2Identifier.init();
-					}
-				}
-			}
-	        includeExts = (List<String>)(List<?>)config.getList("droid_read_limit[@include-exts]");
-	        String limit = config.getString("droid_read_limit[@read-limit-kb]");
-	        kbReadLimit = -1l;
-	        if (limit != null) {
-	        	try {
-	        		kbReadLimit = Long.parseLong(limit);
-	        	} catch (NumberFormatException nfe) {
-	        		throw new FitsToolException("Invalid long value in fits.xml droid_read_limit[@read-limit-kb]: " + limit, nfe);
-	        	}
-	        }
-		} catch (Throwable e) {
-			throw new FitsToolException("Error initilizing DROID",e);
-		}
-	}
+                        Ole2Identifier ole2Identifier = new Ole2Identifier();
+                        ole2Identifier.setContainerType("OLE2");
+                        ole2Identifier.setContainerIdentifierFactory(containerIdentifierFactory);
+                        ole2Identifier.setContainerFormatResolver(containerFormatResolver);
+                        ole2Identifier.setDroidCore(sigIdentifier);
+                        ole2Identifier.setIdentifierEngine(ole2IdentifierEngine);
+                        ole2Identifier.setSignatureReader(signatureReader);
+                        ole2Identifier.init();
+                    }
+                }
+            }
+            includeExts = (List<String>) (List<?>) config.getList("droid_read_limit[@include-exts]");
+            String limit = config.getString("droid_read_limit[@read-limit-kb]");
+            kbReadLimit = -1l;
+            if (limit != null) {
+                try {
+                    kbReadLimit = Long.parseLong(limit);
+                } catch (NumberFormatException nfe) {
+                    throw new FitsToolException(
+                            "Invalid long value in fits.xml droid_read_limit[@read-limit-kb]: " + limit, nfe);
+                }
+            }
+        } catch (Throwable e) {
+            throw new FitsToolException("Error initilizing DROID", e);
+        }
+    }
 
-	@Override
-	public ToolOutput extractInfo(File file) throws FitsToolException {
+    @Override
+    public ToolOutput extractInfo(File file) throws FitsToolException {
         logger.debug("Droid.extractInfo starting on " + file.getName());
-		long startTime = System.currentTimeMillis();
-		IdentificationResultCollection results;
-		ContainerAggregator aggregator = null;
-		try {
-			DroidQuery droidQuery = new DroidQuery (sigIdentifier, containerIdentifierFactory, containerFormatResolver,
-					puidFormatMap, containerSignatureDefinitions, includeExts, kbReadLimit, file);
-			// the following will almost always return a single result
-		    results = droidQuery.queryFile();
-	        for (IdentificationResult res : results.getResults()) {
-	            String mimeType = res.getMimeType();
+        long startTime = System.currentTimeMillis();
+        IdentificationResultCollection results;
+        ContainerAggregator aggregator = null;
+        try {
+            DroidQuery droidQuery = new DroidQuery(
+                    sigIdentifier,
+                    containerIdentifierFactory,
+                    containerFormatResolver,
+                    puidFormatMap,
+                    containerSignatureDefinitions,
+                    includeExts,
+                    kbReadLimit,
+                    file);
+            // the following will almost always return a single result
+            results = droidQuery.queryFile();
+            for (IdentificationResult res : results.getResults()) {
+                String mimeType = res.getMimeType();
 
-	            if(FitsMetadataValues.getInstance().normalizeMimeType(mimeType) != null) {
-	            	mimeType = FitsMetadataValues.getInstance().normalizeMimeType(mimeType);
-	            }
-	            
-	            String fileName = file.getName();
-	            int lastDot = fileName.lastIndexOf('.');
-	            String extension = "";
-	            if (lastDot > -1) {
-	            	extension = fileName.substring(lastDot + 1);
-	            }
-	            
-	            if (CONTAINER_TYPE_MIMETYPES.contains(mimeType) && "zip".equals(extension)) {
-	            	aggregator = droidQuery.queryContainerData(results);
-	            }
-	        }
+                if (FitsMetadataValues.getInstance().normalizeMimeType(mimeType) != null) {
+                    mimeType = FitsMetadataValues.getInstance().normalizeMimeType(mimeType);
+                }
 
-		}
-		catch (IOException e) {
-		    throw new FitsToolException("DROID can't query file " + file.getAbsolutePath(),
-		            e);
-		} catch (SignatureParseException e) {
-			throw new FitsToolException("Problem with DROID signature file");
-		}
-		DroidToolOutputter outputter = new DroidToolOutputter(this, results, fits, aggregator);
-		ToolOutput output = outputter.toToolOutput();
+                String fileName = file.getName();
+                int lastDot = fileName.lastIndexOf('.');
+                String extension = "";
+                if (lastDot > -1) {
+                    extension = fileName.substring(lastDot + 1);
+                }
 
-		duration = System.currentTimeMillis()-startTime;
-		runStatus = RunStatus.SUCCESSFUL;
+                if (CONTAINER_TYPE_MIMETYPES.contains(mimeType) && "zip".equals(extension)) {
+                    aggregator = droidQuery.queryContainerData(results);
+                }
+            }
+
+        } catch (IOException e) {
+            throw new FitsToolException("DROID can't query file " + file.getAbsolutePath(), e);
+        } catch (SignatureParseException e) {
+            throw new FitsToolException("Problem with DROID signature file");
+        }
+        DroidToolOutputter outputter = new DroidToolOutputter(this, results, fits, aggregator);
+        ToolOutput output = outputter.toToolOutput();
+
+        duration = System.currentTimeMillis() - startTime;
+        runStatus = RunStatus.SUCCESSFUL;
         logger.debug("Droid.extractInfo finished on " + file.getName());
-		return output;
-	}
+        return output;
+    }
 
-	public boolean isEnabled() {
-		return enabled;
-	}
+    public boolean isEnabled() {
+        return enabled;
+    }
 
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
 
-	private String getDroidVersion () {
-	    StringWriter sw = new StringWriter ();
-	    PrintWriter pw = new PrintWriter (sw);
-	    VersionCommand vcmd = new VersionCommand (pw);
-	    try {
-	        vcmd.execute ();
-	    }
-	    catch (Exception e) {
-	        return "(Version unknown)";
-	    }
-	    return sw.toString().trim();
-	}
-
+    private String getDroidVersion() {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        VersionCommand vcmd = new VersionCommand(pw);
+        try {
+            vcmd.execute();
+        } catch (Exception e) {
+            return "(Version unknown)";
+        }
+        return sw.toString().trim();
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/droid/DroidQuery.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/droid/DroidQuery.java
@@ -8,21 +8,18 @@
 // See the License for the specific language governing permission and limitations under the License.
 //
 
-
-
 /* Droid 6.1 has no nicely packaged way to make simple queries. This
  * class attempts to fill that gap for FITS, in a way that will let it
  * be lifted for other uses and perhaps incorporated into Droid itself.
  */
 package edu.harvard.hul.ois.fits.tools.droid;
 
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-
-import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
 import uk.gov.nationalarchives.droid.command.action.CommandExecutionException;
 import uk.gov.nationalarchives.droid.container.ContainerSignatureDefinitions;
 import uk.gov.nationalarchives.droid.core.BinarySignatureIdentifier;
@@ -50,8 +47,7 @@ public class DroidQuery {
     private long bytesToRead = -1;
     private List<String> fileExtensions; // file extensions for files on which to apply file read limit
     private File file; // input file that is being processed
-    
-    
+
     /**
      * Create a DroidQuery object. This can be retained for any number of
      * different queries.
@@ -66,14 +62,17 @@ public class DroidQuery {
      * @param file The file to be processed by DROID.
      * @throws SignatureParseException If there is a problem processing the DROID signature file.
      */
-    public DroidQuery(BinarySignatureIdentifier sigIdentifier,
-                      ContainerIdentifierFactory containerIdentifierFactory,
-                      ArchiveFormatResolver containerFormatResolver,
-                      Map<String, Format> puidFormatMap,
-                      ContainerSignatureDefinitions containerSignatureDefinitions,
-                      List<String> includeExts,
-                      long kbReadLimit, File file)  throws SignatureParseException, FileNotFoundException    {
-    	this.sigIdentifier = sigIdentifier;
+    public DroidQuery(
+            BinarySignatureIdentifier sigIdentifier,
+            ContainerIdentifierFactory containerIdentifierFactory,
+            ArchiveFormatResolver containerFormatResolver,
+            Map<String, Format> puidFormatMap,
+            ContainerSignatureDefinitions containerSignatureDefinitions,
+            List<String> includeExts,
+            long kbReadLimit,
+            File file)
+            throws SignatureParseException, FileNotFoundException {
+        this.sigIdentifier = sigIdentifier;
         this.containerIdentifierFactory = containerIdentifierFactory;
         this.containerFormatResolver = containerFormatResolver;
         this.puidFormatMap = puidFormatMap;
@@ -90,29 +89,29 @@ public class DroidQuery {
      * @return A collection of results from DROID. Usually a single result.
      * @throws IOException
      */
-    IdentificationResultCollection queryFile()
-            throws IOException {
-    	
+    IdentificationResultCollection queryFile() throws IOException {
+
         // For certain file types, set max. number of bytes at beginning of file to process.
         // See https://groups.google.com/forum/#!msg/droid-list/HqN6lKOATJk/i-qTEI-XEwAJ;context-place=forum/droid-list
-        // which indicates minimum number of bytes required to identify certain input file types.    	
-    	long bytesToExamine = file.length();
-    	String filename = file.getName();
-    	int lastDot = filename.lastIndexOf('.');
-    	if (lastDot > 0 && filename.length() > lastDot) {
-    		String fileExtension = filename.substring(++lastDot).toLowerCase(); // examine extension past the last dot
-    		if (fileExtensions != null && fileExtensions.contains(fileExtension) && bytesToRead > 0) {
-    			bytesToExamine = Math.min(file.length(), bytesToRead);
-    		}
-    	}
+        // which indicates minimum number of bytes required to identify certain input file types.
+        long bytesToExamine = file.length();
+        String filename = file.getName();
+        int lastDot = filename.lastIndexOf('.');
+        if (lastDot > 0 && filename.length() > lastDot) {
+            String fileExtension = filename.substring(++lastDot).toLowerCase(); // examine extension past the last dot
+            if (fileExtensions != null && fileExtensions.contains(fileExtension) && bytesToRead > 0) {
+                bytesToExamine = Math.min(file.length(), bytesToRead);
+            }
+        }
         RequestMetaData metadata = new RequestMetaData(bytesToExamine, file.lastModified(), file.getName());
-        RequestIdentifier identifier = new RequestIdentifier (file.toURI());
+        RequestIdentifier identifier = new RequestIdentifier(file.toURI());
         FileSystemIdentificationRequest req = null;
         try {
             req = new FileSystemIdentificationRequest(metadata, identifier);
             req.open(file.toPath());
 
-            // This logic is based on https://github.com/digital-preservation/droid/blob/master/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmissionGateway.java
+            // This logic is based on
+            // https://github.com/digital-preservation/droid/blob/master/droid-results/src/main/java/uk/gov/nationalarchives/droid/submitter/SubmissionGateway.java
 
             IdentificationResultCollection results = sigIdentifier.matchBinarySignatures(req);
             IdentificationResultCollection containerResults = handleContainer(req, results);
@@ -123,20 +122,19 @@ public class DroidQuery {
 
             sigIdentifier.removeLowerPriorityHits(results);
             if (results.getResults().isEmpty()) {
-                results = sigIdentifier.matchExtensions(req,false);
+                results = sigIdentifier.matchExtensions(req, false);
             }
 
             return results;
-        }
-        finally {
+        } finally {
             if (req != null) {
-                req.close ();
+                req.close();
             }
         }
     }
 
-    private IdentificationResultCollection handleContainer(IdentificationRequest request,
-                                                           IdentificationResultCollection results) throws IOException {
+    private IdentificationResultCollection handleContainer(
+            IdentificationRequest request, IdentificationResultCollection results) throws IOException {
         String containerFormat = getContainerFormat(results);
 
         if (containerFormat != null) {
@@ -174,32 +172,32 @@ public class DroidQuery {
 
     /**
      * Provides additional results from DROID for processing ZIP files.
-     * 
+     *
      * @param results This is the same value returned from the call to queryFile().
      * @return Aggregated data of all files contained within the ZIP file.
      * @throws IOException If the file cannot be read.
      * @throws FitsToolException If the file is not a ZIP file.
      */
-    ContainerAggregator queryContainerData(IdentificationResultCollection results) throws IOException, FitsToolException {
+    ContainerAggregator queryContainerData(IdentificationResultCollection results)
+            throws IOException, FitsToolException {
 
         RequestMetaData metadata = new RequestMetaData(bytesToRead, file.lastModified(), file.getName());
-    	RequestIdentifier identifier = new RequestIdentifier (file.toURI());
-    	FileSystemIdentificationRequest request = null;
-    	request = new FileSystemIdentificationRequest(metadata, identifier);
-    	request.open(file.toPath());
-    	
-    	ZipArchiveContentIdentifier zipArchiveIdentifier =
-                new ZipArchiveContentIdentifier(this.sigIdentifier,
-                    containerSignatureDefinitions, "", File.separator, File.separator, puidFormatMap);
+        RequestIdentifier identifier = new RequestIdentifier(file.toURI());
+        FileSystemIdentificationRequest request = null;
+        request = new FileSystemIdentificationRequest(metadata, identifier);
+        request.open(file.toPath());
+
+        ZipArchiveContentIdentifier zipArchiveIdentifier = new ZipArchiveContentIdentifier(
+                this.sigIdentifier, containerSignatureDefinitions, "", File.separator, File.separator, puidFormatMap);
         try {
-        	ContainerAggregator aggregator = zipArchiveIdentifier.identify(results.getUri(), request);
-        	return aggregator;
-		} catch (CommandExecutionException e) {
-			throw new FitsToolException("DROID can't execute zipArchiveIdentifier" , e);
-		} finally {
+            ContainerAggregator aggregator = zipArchiveIdentifier.identify(results.getUri(), request);
+            return aggregator;
+        } catch (CommandExecutionException e) {
+            throw new FitsToolException("DROID can't execute zipArchiveIdentifier", e);
+        } finally {
             if (request != null) {
-            	request.close();
+                request.close();
             }
-		}
+        }
     }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/droid/DroidToolOutputter.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/droid/DroidToolOutputter.java
@@ -10,6 +10,11 @@
 
 package edu.harvard.hul.ois.fits.tools.droid;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsMetadataValues;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import edu.harvard.hul.ois.fits.tools.ToolBase;
+import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -17,7 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
-
 import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -26,12 +30,6 @@ import org.jdom2.input.SAXBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
-
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsMetadataValues;
-import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
-import edu.harvard.hul.ois.fits.tools.ToolBase;
-import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationResult;
 import uk.gov.nationalarchives.droid.core.interfaces.IdentificationResultCollection;
 
@@ -42,23 +40,24 @@ import uk.gov.nationalarchives.droid.core.interfaces.IdentificationResultCollect
  */
 public class DroidToolOutputter {
 
-    private final static Namespace fitsNS = Namespace.getNamespace (Fits.XML_NAMESPACE);
-    private final static Map<Integer, String> COMPRESSION_METHOD_TO_STRING_VALUE;
-    
+    private static final Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
+    private static final Map<Integer, String> COMPRESSION_METHOD_TO_STRING_VALUE;
+
     private static final Logger logger = LoggerFactory.getLogger(DroidToolOutputter.class);
 
     private IdentificationResultCollection results;
     private ToolBase toolBase;
     private Fits fits;
     private ContainerAggregator aggregator; // could be null!!!
-    
+
     static {
-    	COMPRESSION_METHOD_TO_STRING_VALUE = new HashMap<>();
-    	COMPRESSION_METHOD_TO_STRING_VALUE.put(ZipEntry.STORED, "stored");
-    	COMPRESSION_METHOD_TO_STRING_VALUE.put(ZipEntry.DEFLATED, "deflate");
+        COMPRESSION_METHOD_TO_STRING_VALUE = new HashMap<>();
+        COMPRESSION_METHOD_TO_STRING_VALUE.put(ZipEntry.STORED, "stored");
+        COMPRESSION_METHOD_TO_STRING_VALUE.put(ZipEntry.DEFLATED, "deflate");
     }
 
-    public DroidToolOutputter (ToolBase toolBase, IdentificationResultCollection results, Fits fits, ContainerAggregator aggregator) {
+    public DroidToolOutputter(
+            ToolBase toolBase, IdentificationResultCollection results, Fits fits, ContainerAggregator aggregator) {
         this.toolBase = toolBase;
         this.results = results;
         this.fits = fits;
@@ -68,21 +67,21 @@ public class DroidToolOutputter {
     /** Produce a JDOM document with fits as its root element. This
      *  will contain just identification, not metadata elements.
      */
-    public ToolOutput toToolOutput () throws FitsToolException {
+    public ToolOutput toToolOutput() throws FitsToolException {
         List<IdentificationResult> resList = results.getResults();
-        Document fitsXml = createToolData ();
-        Document rawOut = buildRawData (resList);
-        ToolOutput output = new ToolOutput(toolBase,fitsXml,rawOut, fits);
+        Document fitsXml = createToolData();
+        Document rawOut = buildRawData(resList);
+        ToolOutput output = new ToolOutput(toolBase, fitsXml, rawOut, fits);
         return output;
     }
 
     /** Create a base tool data document and add elements
      *  for each format. */
-    private Document createToolData () throws FitsToolException {
+    private Document createToolData() throws FitsToolException {
         List<IdentificationResult> resList = results.getResults();
-        Element fitsElem = new Element ("fits", fitsNS);
-        Document toolDoc = new Document (fitsElem);
-        Element idElem = new Element ("identification", fitsNS);
+        Element fitsElem = new Element("fits", fitsNS);
+        Document toolDoc = new Document(fitsElem);
+        Element idElem = new Element("identification", fitsNS);
         fitsElem.addContent(idElem);
         for (IdentificationResult res : resList) {
             String filePuid = res.getPuid();
@@ -90,135 +89,124 @@ public class DroidToolOutputter {
             formatName = mapFormatName(formatName);
             String mimeType = res.getMimeType();
 
-            if(FitsMetadataValues.getInstance().normalizeMimeType(mimeType) != null) {
-            	mimeType = FitsMetadataValues.getInstance().normalizeMimeType(mimeType);
+            if (FitsMetadataValues.getInstance().normalizeMimeType(mimeType) != null) {
+                mimeType = FitsMetadataValues.getInstance().normalizeMimeType(mimeType);
             }
 
             // maybe this block should be moved to mapFormatName() ???
-            if(formatName.equals("Digital Negative (DNG)")) {
-            	mimeType="image/x-adobe-dng";
+            if (formatName.equals("Digital Negative (DNG)")) {
+                mimeType = "image/x-adobe-dng";
             }
 
             String version = res.getVersion();
             version = mapVersion(version);
 
-            Element identityElem = new Element ("identity", fitsNS);
+            Element identityElem = new Element("identity", fitsNS);
             Attribute attr = null;
             if (formatName != null) {
-                attr = new Attribute ("format", formatName);
+                attr = new Attribute("format", formatName);
                 identityElem.setAttribute(attr);
             }
             if (mimeType != null) {
-                attr = new Attribute ("mimetype", mimeType);
-                identityElem.setAttribute (attr);
+                attr = new Attribute("mimetype", mimeType);
+                identityElem.setAttribute(attr);
             }
 
             // Is there anything to put into the fileinfo or metadata elements?
             // Both are optional, so they can be left out if they'd be empty.
-            idElem.addContent (identityElem);
+            idElem.addContent(identityElem);
 
             // If there's a version, report it
             if (version != null && !version.isEmpty()) {
-                Element versionElem = new Element ("version", fitsNS);
+                Element versionElem = new Element("version", fitsNS);
                 identityElem.addContent(versionElem);
-                versionElem.addContent (version);
+                versionElem.addContent(version);
             }
 
             // If there's a PUID, report it as an external identifier
             if (filePuid != null) {
-                Element puidElem = new Element ("externalIdentifier", fitsNS);
-                identityElem.addContent (puidElem);
-                puidElem.addContent (filePuid);
-                attr = new Attribute ("type", "puid");
-                puidElem.setAttribute (attr);
+                Element puidElem = new Element("externalIdentifier", fitsNS);
+                identityElem.addContent(puidElem);
+                puidElem.addContent(filePuid);
+                attr = new Attribute("type", "puid");
+                puidElem.setAttribute(attr);
             }
         }
-        
+
         // The only time there will be a metadata section from DROID is when
         // there is an aggregator for ZIP files and there are file entries.
         if (aggregator != null && aggregator.getTotalEntriesCount() > 0) {
-        	Element metadataElem = new Element ("metadata", fitsNS);
-        	fitsElem.addContent(metadataElem);
-        	Element containerElem = new Element ("container", fitsNS);
-    		metadataElem.addContent(containerElem);
-        	
-        	Element origSizeElem = new Element("originalSize", fitsNS);
-    		origSizeElem.addContent( String.valueOf(aggregator.getOriginalSize()) );
-    		containerElem.addContent(origSizeElem);
-        	
-        	Element compressionMethodElem = new Element("compressionMethod", fitsNS);
-    		compressionMethodElem.addContent( COMPRESSION_METHOD_TO_STRING_VALUE.get( aggregator.getCompressionMethod() ) );
-    		containerElem.addContent(compressionMethodElem);
-        	
-        	Element entriesElem = new Element("entries", fitsNS);
-    		Attribute totalEntriesCountAttr = new Attribute("totalEntries", String.valueOf(aggregator.getTotalEntriesCount()) );
-			entriesElem.setAttribute(totalEntriesCountAttr);
-    		containerElem.addContent(entriesElem);
-        	
-        	for ( Map.Entry<String, Integer> formatEntry : aggregator.getFormatCounts().entrySet() ) {
-        		Element entryElem = new Element("format", fitsNS);
-        		Attribute nameAttr = new Attribute("name", formatEntry.getKey());
-        		entryElem.setAttribute(nameAttr);
-        		
-        		Attribute numberAttr = new Attribute("number", String.valueOf(formatEntry.getValue()) );
-        		entryElem.setAttribute(numberAttr);
-        		
-        		entriesElem.addContent(entryElem);
-        	}
-        }
+            Element metadataElem = new Element("metadata", fitsNS);
+            fitsElem.addContent(metadataElem);
+            Element containerElem = new Element("container", fitsNS);
+            metadataElem.addContent(containerElem);
 
+            Element origSizeElem = new Element("originalSize", fitsNS);
+            origSizeElem.addContent(String.valueOf(aggregator.getOriginalSize()));
+            containerElem.addContent(origSizeElem);
+
+            Element compressionMethodElem = new Element("compressionMethod", fitsNS);
+            compressionMethodElem.addContent(COMPRESSION_METHOD_TO_STRING_VALUE.get(aggregator.getCompressionMethod()));
+            containerElem.addContent(compressionMethodElem);
+
+            Element entriesElem = new Element("entries", fitsNS);
+            Attribute totalEntriesCountAttr =
+                    new Attribute("totalEntries", String.valueOf(aggregator.getTotalEntriesCount()));
+            entriesElem.setAttribute(totalEntriesCountAttr);
+            containerElem.addContent(entriesElem);
+
+            for (Map.Entry<String, Integer> formatEntry :
+                    aggregator.getFormatCounts().entrySet()) {
+                Element entryElem = new Element("format", fitsNS);
+                Attribute nameAttr = new Attribute("name", formatEntry.getKey());
+                entryElem.setAttribute(nameAttr);
+
+                Attribute numberAttr = new Attribute("number", String.valueOf(formatEntry.getValue()));
+                entryElem.setAttribute(numberAttr);
+
+                entriesElem.addContent(entryElem);
+            }
+        }
 
         return toolDoc;
     }
 
     public static String mapFormatName(String formatName) {
 
-    	if(formatName == null || formatName.length() == 0) {
-    		return FitsMetadataValues.DEFAULT_FORMAT;
-    	}
-    	else if(formatName.startsWith("JPEG2000") || formatName.startsWith("JP2 (JPEG 2000")) {
-    		return "JPEG 2000 JP2";
-    	}
-    	else if(formatName.startsWith("Exchangeable Image File Format (Compressed)")) {
-    		return "JPEG EXIF";
-    	}
-    	else if(formatName.startsWith("Exchangeable Image File Format (Uncompressed)")) {
-    		return "TIFF EXIF";
-    	}
-    	else if(formatName.contains("PDF/A")) {
-    		return "PDF/A";
-    	}
-    	else if(formatName.contains("PDF/X")) {
-    		return "PDF/X";
-    	}
-    	else if(formatName.contains("Portable Document Format")) {
-    		return "Portable Document Format";
-    	}
-    	else if(formatName.startsWith("Microsoft Word") && !formatName.equals("Microsoft Word for Windows")) {
-    		return "Microsoft Word Binary File Format";
-    	}
-    	else if(formatName.startsWith("Microsoft Excel") && !formatName.equals("Microsoft Excel for Windows")) {
-    		return "Microsoft Excel";
-    	}
-    	else if(FitsMetadataValues.getInstance().normalizeFormat(formatName) != null){
-    		return FitsMetadataValues.getInstance().normalizeFormat(formatName);
-    	}
-    	else {
-    		return formatName;
-    	}
+        if (formatName == null || formatName.length() == 0) {
+            return FitsMetadataValues.DEFAULT_FORMAT;
+        } else if (formatName.startsWith("JPEG2000") || formatName.startsWith("JP2 (JPEG 2000")) {
+            return "JPEG 2000 JP2";
+        } else if (formatName.startsWith("Exchangeable Image File Format (Compressed)")) {
+            return "JPEG EXIF";
+        } else if (formatName.startsWith("Exchangeable Image File Format (Uncompressed)")) {
+            return "TIFF EXIF";
+        } else if (formatName.contains("PDF/A")) {
+            return "PDF/A";
+        } else if (formatName.contains("PDF/X")) {
+            return "PDF/X";
+        } else if (formatName.contains("Portable Document Format")) {
+            return "Portable Document Format";
+        } else if (formatName.startsWith("Microsoft Word") && !formatName.equals("Microsoft Word for Windows")) {
+            return "Microsoft Word Binary File Format";
+        } else if (formatName.startsWith("Microsoft Excel") && !formatName.equals("Microsoft Excel for Windows")) {
+            return "Microsoft Excel";
+        } else if (FitsMetadataValues.getInstance().normalizeFormat(formatName) != null) {
+            return FitsMetadataValues.getInstance().normalizeFormat(formatName);
+        } else {
+            return formatName;
+        }
     }
 
     private String mapVersion(String version) {
 
-    	if(version == null || version.length() == 0) {
-    		return version;
-    	}
-    	else if(version.equals("1987a")) {
-    		return "87a";
-    	}
-    	else {
-    		return version;
-    	}
+        if (version == null || version.length() == 0) {
+            return version;
+        } else if (version.equals("1987a")) {
+            return "87a";
+        } else {
+            return version;
+        }
     }
 
     /**
@@ -228,80 +216,80 @@ public class DroidToolOutputter {
      * @throws FitsToolException
      * @throws SAXException
      */
-    private Document buildRawData (List<IdentificationResult> resList) throws FitsToolException {
+    private Document buildRawData(List<IdentificationResult> resList) throws FitsToolException {
 
-            StringWriter out = new StringWriter();
+        StringWriter out = new StringWriter();
 
-            out.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        out.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        out.write("\n");
+        out.write("<results>");
+        out.write("\n");
+        for (IdentificationResult res : resList) {
+            String filePuid = res.getPuid();
+            String formatName = res.getName();
+            String mimeType = res.getMimeType();
+            String version = res.getVersion();
+            out.write("<result>");
             out.write("\n");
-            out.write("<results>");
+            out.write("<filePuid>" + filePuid + "</filePuid>");
             out.write("\n");
-            for (IdentificationResult res : resList) {
-                String filePuid = res.getPuid();
-                String formatName = res.getName();
-                String mimeType = res.getMimeType();
-                String version = res.getVersion();
-                out.write("<result>");
-                out.write("\n");
-                out.write("<filePuid>" + filePuid + "</filePuid>");
-                out.write("\n");
-                out.write("<formatName>" + formatName + "</formatName>");
-                out.write("\n");
-                out.write("<mimeType>" + mimeType + "</mimeType>");
-                out.write("\n");
-                out.write("<version>" + version + "</version>");
-                out.write("</result>");
-            }
-            
-            if (aggregator != null && aggregator.getTotalEntriesCount() > 0) {
-            	out.write("<container originalSize='");
-            	out.write( String.valueOf(aggregator.getOriginalSize()) );
-            	
-            	String method = COMPRESSION_METHOD_TO_STRING_VALUE.get( aggregator.getCompressionMethod() );
-            	out.write("' method='");
-            	out.write(method);
-            	
-            	out.write("'>");
-                out.write("\n");
-            	
-            	out.write("<entries totalEntries='");
-            	out.write( String.valueOf(aggregator.getTotalEntriesCount()) );
-            	out.write("'>");
-                out.write("\n");
-
-                for ( Map.Entry<String, Integer> entry : aggregator.getFormatCounts().entrySet() ) {
-                	out.write("<entry formatName='");
-                	out.write(entry.getKey());
-                	out.write("' count='");
-                	out.write( String.valueOf(entry.getValue()) );
-                	out.write("'></entry>");
-                	out.write("\n");
-                }
-            	out.write("</entries>");
-            	out.write("\n");
-            	
-            	out.write("</container>");
-            	out.write("\n");
-            }
-            
-            out.write("  </results>");
+            out.write("<formatName>" + formatName + "</formatName>");
             out.write("\n");
-
-            out.flush();
-
-            try {
-                out.close();
-            } catch (IOException e) {
-                throw new FitsToolException("Error closing DROID XML output stream",e);
-            }
-
-            Document doc = null;
-            try {
-                SAXBuilder saxBuilder = toolBase.getSaxBuilder();
-                doc = saxBuilder.build(new StringReader(out.toString()));
-            } catch (Exception e) {
-                throw new FitsToolException("Error parsing DROID XML Output",e);
-            }
-            return doc;
+            out.write("<mimeType>" + mimeType + "</mimeType>");
+            out.write("\n");
+            out.write("<version>" + version + "</version>");
+            out.write("</result>");
         }
+
+        if (aggregator != null && aggregator.getTotalEntriesCount() > 0) {
+            out.write("<container originalSize='");
+            out.write(String.valueOf(aggregator.getOriginalSize()));
+
+            String method = COMPRESSION_METHOD_TO_STRING_VALUE.get(aggregator.getCompressionMethod());
+            out.write("' method='");
+            out.write(method);
+
+            out.write("'>");
+            out.write("\n");
+
+            out.write("<entries totalEntries='");
+            out.write(String.valueOf(aggregator.getTotalEntriesCount()));
+            out.write("'>");
+            out.write("\n");
+
+            for (Map.Entry<String, Integer> entry : aggregator.getFormatCounts().entrySet()) {
+                out.write("<entry formatName='");
+                out.write(entry.getKey());
+                out.write("' count='");
+                out.write(String.valueOf(entry.getValue()));
+                out.write("'></entry>");
+                out.write("\n");
+            }
+            out.write("</entries>");
+            out.write("\n");
+
+            out.write("</container>");
+            out.write("\n");
+        }
+
+        out.write("  </results>");
+        out.write("\n");
+
+        out.flush();
+
+        try {
+            out.close();
+        } catch (IOException e) {
+            throw new FitsToolException("Error closing DROID XML output stream", e);
+        }
+
+        Document doc = null;
+        try {
+            SAXBuilder saxBuilder = toolBase.getSaxBuilder();
+            doc = saxBuilder.build(new StringReader(out.toString()));
+        } catch (Exception e) {
+            throw new FitsToolException("Error parsing DROID XML Output", e);
+        }
+        return doc;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/droid/ResultPrinter.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/droid/ResultPrinter.java
@@ -1,7 +1,7 @@
 /**
  * This file has been modified by Harvard University, June, 2017, for the purposes of incorporating
  * into the FITS application. The original can be found here: https://github.com/digital-preservation/droid
- * 
+ *
  * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
  * All rights reserved.
  *
@@ -37,7 +37,6 @@ package edu.harvard.hul.ois.fits.tools.droid;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.nationalarchives.droid.command.action.CommandExecutionException;
@@ -59,17 +58,17 @@ import uk.gov.nationalarchives.droid.profile.referencedata.Format;
 /**
  * File identification results printer.
  *
- * NB: This class is called recursively when archive files are opened 
- * 
+ * NB: This class is called recursively when archive files are opened
+ *
  * @author rbrennan
  */
 public class ResultPrinter {
-    
+
     private static final String R_SLASH = "/";
     private static final String L_BRACKET = "(";
     private static final String R_BRACKET = ")";
     private static final String SPACE = " ";
-    
+
     private BinarySignatureIdentifier binarySignatureIdentifier;
     private ContainerSignatureDefinitions containerSignatureDefinitions;
     private List<TriggerPuid> triggerPuids;
@@ -89,18 +88,18 @@ public class ResultPrinter {
     private final String ARC_ARCHIVE = "x-fmt/219";
     private final String OTHERARC_ARCHIVE = "fmt/410";
     private final String WARC_ARCHIVE = "fmt/289";
-    
+
     private ContainerAggregator aggregator;
     private Map<String, Format> puidFormatMap;
-    
+
     private static final Logger logger = LoggerFactory.getLogger(ResultPrinter.class);
 
     /**
      * Store signature files.
-     * 
+     *
      * @param binarySignatureIdentifier     binary signature identifier
      * @param containerSignatureDefinitions container signatures
-     * @param path                          current file/container path 
+     * @param path                          current file/container path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
      * @param archives                      Should archives be examined?
@@ -108,11 +107,17 @@ public class ResultPrinter {
      * @param aggregator
      * @param puidFormatMap                 map of puids to formats
      */
-    public ResultPrinter(final BinarySignatureIdentifier binarySignatureIdentifier,
+    public ResultPrinter(
+            final BinarySignatureIdentifier binarySignatureIdentifier,
             final ContainerSignatureDefinitions containerSignatureDefinitions,
-            final String path, final String slash, final String slash1, boolean archives, boolean webArchives,
-            final ContainerAggregator aggregator, final Map<String, Format> puidFormatMap) {
-    
+            final String path,
+            final String slash,
+            final String slash1,
+            boolean archives,
+            boolean webArchives,
+            final ContainerAggregator aggregator,
+            final Map<String, Format> puidFormatMap) {
+
         this.binarySignatureIdentifier = binarySignatureIdentifier;
         this.containerSignatureDefinitions = containerSignatureDefinitions;
         this.path = path;
@@ -127,21 +132,20 @@ public class ResultPrinter {
         this.aggregator = aggregator;
         this.puidFormatMap = puidFormatMap;
     }
-    
+
     /**
      * Output identification for this file.
-     * 
+     *
      * @param results                       identification Results
      * @param request                       identification Request
-     * 
+     *
      * @throws CommandExecutionException    if unexpected container type encountered
      */
-    public void print(final IdentificationResultCollection results,
-            final IdentificationRequest request) throws CommandExecutionException {
-        
+    public void print(final IdentificationResultCollection results, final IdentificationRequest request)
+            throws CommandExecutionException {
+
         final String fileName = (path + request.getFileName()).replace(wrongSlash, slash);
-        final IdentificationResultCollection containerResults =
-                getContainerResults(results, request, fileName);
+        final IdentificationResultCollection containerResults = getContainerResults(results, request, fileName);
 
         IdentificationResultCollection finalResults = new IdentificationResultCollection(request);
         boolean container = false;
@@ -155,24 +159,25 @@ public class ResultPrinter {
             binarySignatureIdentifier.removeLowerPriorityHits(finalResults);
         }
         if (finalResults.getResults().size() > 0) {
-        	int cnt = 0;
+            int cnt = 0;
             for (IdentificationResult identResult : finalResults.getResults()) {
-            	if (+cnt > 1) {
-            		logger.warn("Count: " + cnt);
-            	}
-            	String formatName = identResult.getName();
+                if (+cnt > 1) {
+                    logger.warn("Count: " + cnt);
+                }
+                String formatName = identResult.getName();
                 String puid = identResult.getPuid();
                 if (!container && JIP_ARCHIVE.equals(puid)) {
                     puid = ZIP_ARCHIVE;
                 }
-                
+
                 String normalizedFormat = DroidToolOutputter.mapFormatName(formatName);
-                String output = String.format("fileName: %s,\n mimeType: %s,\n formatName: %s,\n normalizedFormat: %s,\n puid: %s",
-                		fileName, identResult.getMimeType(), formatName, normalizedFormat, puid);
+                String output = String.format(
+                        "fileName: %s,\n mimeType: %s,\n formatName: %s,\n normalizedFormat: %s,\n puid: %s",
+                        fileName, identResult.getMimeType(), formatName, normalizedFormat, puid);
                 logger.debug(output);
                 // add a single format type
                 aggregator.addFormat(normalizedFormat);
-            }   
+            }
         } else {
             aggregator.incrementUnknownFormat();
             logger.debug(fileName + " -- Unknown filetype");
@@ -180,51 +185,48 @@ public class ResultPrinter {
     }
 
     private IdentificationResultCollection getContainerResults(
-        final IdentificationResultCollection results,
-        final IdentificationRequest request, final String fileName) throws CommandExecutionException {
-    
-        IdentificationResultCollection containerResults =
-                new IdentificationResultCollection(request);
-                
+            final IdentificationResultCollection results, final IdentificationRequest request, final String fileName)
+            throws CommandExecutionException {
+
+        IdentificationResultCollection containerResults = new IdentificationResultCollection(request);
+
         if (results.getResults().size() > 0 && containerSignatureDefinitions != null) {
-        	int cnt = 0;
+            int cnt = 0;
             for (IdentificationResult identResult : results.getResults()) {
-            	if (+cnt > 1) {
-            		logger.info("IdentificationResult count: " + cnt);
-            	}
+                if (+cnt > 1) {
+                    logger.info("IdentificationResult count: " + cnt);
+                }
                 String filePuid = identResult.getPuid();
                 if (filePuid != null) {
                     TriggerPuid containerPuid = getTriggerPuidByPuid(filePuid);
                     if (containerPuid != null) {
-                            
+
                         requestFactory = new ContainerFileIdentificationRequestFactory();
                         String containerType = containerPuid.getContainerType();
 
                         if (OLE2_CONTAINER.equals(containerType)) {
                             try {
-                                Ole2ContainerContentIdentifier ole2Identifier =
-                                        new Ole2ContainerContentIdentifier();
+                                Ole2ContainerContentIdentifier ole2Identifier = new Ole2ContainerContentIdentifier();
                                 ole2Identifier.init(containerSignatureDefinitions, containerType);
                                 Ole2IdentifierEngine ole2IdentifierEngine = new Ole2IdentifierEngine();
                                 ole2IdentifierEngine.setRequestFactory(requestFactory);
                                 ole2Identifier.setIdentifierEngine(ole2IdentifierEngine);
-                                containerResults = ole2Identifier.process(
-                                    request.getSourceInputStream(), containerResults);
-                            } catch (IOException e) {   // carry on after container i/o problems
+                                containerResults =
+                                        ole2Identifier.process(request.getSourceInputStream(), containerResults);
+                            } catch (IOException e) { // carry on after container i/o problems
                                 logger.warn(e + SPACE + L_BRACKET + fileName + R_BRACKET);
                             }
                         } else if (ZIP_CONTAINER.equals(containerType)) {
                             try {
-                                ZipContainerContentIdentifier zipIdentifier =
-                                            new ZipContainerContentIdentifier();
+                                ZipContainerContentIdentifier zipIdentifier = new ZipContainerContentIdentifier();
                                 zipIdentifier.init(containerSignatureDefinitions, containerType);
                                 ZipIdentifierEngine zipIdentifierEngine = new ZipIdentifierEngine();
                                 zipIdentifierEngine.setRequestFactory(requestFactory);
                                 zipIdentifier.setIdentifierEngine(zipIdentifierEngine);
-                                containerResults = zipIdentifier.process(
-                                    request.getSourceInputStream(), containerResults);
-                            } catch (IOException e) {   // carry on after container i/o problems
-                            	logger.warn(e + SPACE + L_BRACKET + fileName + R_BRACKET);
+                                containerResults =
+                                        zipIdentifier.process(request.getSourceInputStream(), containerResults);
+                            } catch (IOException e) { // carry on after container i/o problems
+                                logger.warn(e + SPACE + L_BRACKET + fileName + R_BRACKET);
                             }
                         } else {
                             throw new CommandExecutionException("Unknown container type: " + containerPuid);
@@ -247,7 +249,7 @@ public class ResultPrinter {
 
         return containerResults;
     }
-    
+
     private TriggerPuid getTriggerPuidByPuid(final String puid) {
         for (final TriggerPuid tp : triggerPuids) {
             if (tp.getPuid().equals(puid)) {

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/droid/ZipArchiveContentIdentifier.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/droid/ZipArchiveContentIdentifier.java
@@ -1,7 +1,7 @@
 /**
  * This file has been modified by Harvard University, June, 2017, for the purposes of incorporating
  * into the FITS application. The original can be found here: https://github.com/digital-preservation/droid
- * 
+ *
  * Copyright (c) 2016, The National Archives <pronom@nationalarchives.gsi.gov.uk>
  * All rights reserved.
  *
@@ -38,11 +38,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
-
 import org.apache.commons.compress.archivers.zip.UnsupportedZipFeatureException;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.nationalarchives.droid.command.action.CommandExecutionException;
@@ -56,31 +54,33 @@ import uk.gov.nationalarchives.droid.profile.referencedata.Format;
 
 /**
  * Identifier for files held in a ZIP archive.
- * 
+ *
  * @author rbrennan
  */
 public class ZipArchiveContentIdentifier extends ArchiveContentIdentifier {
 
     private static final Logger logger = LoggerFactory.getLogger(ZipArchiveContentIdentifier.class);
-	 
+
     /**
-     * 
+     *
      * @param binarySignatureIdentifier     binary signature identifier
      * @param containerSignatureDefinitions container signatures
-     * @param path                          current archive path 
+     * @param path                          current archive path
      * @param slash                         local path element delimiter
      * @param slash1                        local first container prefix delimiter
      * @param puidFormatMap                 map of puids to formats
      */
-    public ZipArchiveContentIdentifier(final BinarySignatureIdentifier binarySignatureIdentifier,
+    public ZipArchiveContentIdentifier(
+            final BinarySignatureIdentifier binarySignatureIdentifier,
             final ContainerSignatureDefinitions containerSignatureDefinitions,
-            final String path, final String slash, final String slash1,
-                                       final Map<String, Format> puidFormatMap) {
-    
-            super(binarySignatureIdentifier, containerSignatureDefinitions,
-        path, slash, slash1, false, puidFormatMap);
+            final String path,
+            final String slash,
+            final String slash1,
+            final Map<String, Format> puidFormatMap) {
+
+        super(binarySignatureIdentifier, containerSignatureDefinitions, path, slash, slash1, false, puidFormatMap);
     }
-    
+
     /**
      * @param uri The URI of the file to identify
      * @param request The Identification Request
@@ -88,8 +88,8 @@ public class ZipArchiveContentIdentifier extends ArchiveContentIdentifier {
      * @throws CommandExecutionException When an exception happens during execution
      * @throws CommandExecutionException When an exception happens during archive file access
      */
-    public ContainerAggregator identify(final URI uri, final IdentificationRequest  request)
-        throws CommandExecutionException {
+    public ContainerAggregator identify(final URI uri, final IdentificationRequest request)
+            throws CommandExecutionException {
 
         final String newPath = makeContainerURI("zip", request.getFileName());
         setSlash1("");
@@ -106,30 +106,32 @@ public class ZipArchiveContentIdentifier extends ArchiveContentIdentifier {
                     if (!entry.isDirectory()) {
                         final RequestMetaData metaData = new RequestMetaData(entry.getSize(), 2L, name);
                         final RequestIdentifier identifier = new RequestIdentifier(uri);
-                        final ZipEntryIdentificationRequest zipRequest =
-                            new ZipEntryIdentificationRequest(metaData, identifier, getTmpDir().toPath(), false);
-                        
+                        final ZipEntryIdentificationRequest zipRequest = new ZipEntryIdentificationRequest(
+                                metaData, identifier, getTmpDir().toPath(), false);
+
                         if (compressionMethod != null && !compressionMethod.equals(entry.getMethod())) {
-                        	logger.warn("Different compression method: " + compressionMethod + ", entry method: " + entry.getMethod());
+                            logger.warn("Different compression method: " + compressionMethod + ", entry method: "
+                                    + entry.getMethod());
                         }
 
                         compressionMethod = entry.getMethod(); // throws UnsupportedZipFeatureException
-                        expandContainer(zipRequest, in, newPath, aggregator);  // zipRequest.size() is uncompressed
-                        logger.debug("zipRequest size(): " + zipRequest.size() + " -- entry.getCompressedSize(): " + entry.getCompressedSize() + " -- entry.getSize(): " + entry.getSize());
+                        expandContainer(zipRequest, in, newPath, aggregator); // zipRequest.size() is uncompressed
+                        logger.debug("zipRequest size(): " + zipRequest.size() + " -- entry.getCompressedSize(): "
+                                + entry.getCompressedSize() + " -- entry.getSize(): " + entry.getSize());
                         if (entry.getCompressedSize() > 0) {
-                        	aggregator.incrementCompressedSize(entry.getCompressedSize());
+                            aggregator.incrementCompressedSize(entry.getCompressedSize());
                         }
                         // in some situations the value returned is -1
                         if (entry.getSize() > 0) {
-                        	aggregator.incrementOriginalSize(entry.getSize());
+                            aggregator.incrementOriginalSize(entry.getSize());
                         } else if (zipRequest.size() > 0) {
-                        	aggregator.incrementOriginalSize(zipRequest.size());
+                            aggregator.incrementOriginalSize(zipRequest.size());
                         }
                     }
                 }
             } catch (UnsupportedZipFeatureException e) {
-            	// For now this indicates that we're attempting (and failing) to read from an encrypted ZIP file.
-            	aggregator.setEncrypted(true);
+                // For now this indicates that we're attempting (and failing) to read from an encrypted ZIP file.
+                aggregator.setEncrypted(true);
             } finally {
                 if (in != null) {
                     in.close();
@@ -140,7 +142,7 @@ public class ZipArchiveContentIdentifier extends ArchiveContentIdentifier {
                 logger.debug("--------------");
             }
         } catch (IOException ioe) {
-        	logger.warn(ioe + " (" + newPath + ")"); // continue after corrupt archive 
+            logger.warn(ioe + " (" + newPath + ")"); // continue after corrupt archive
         } finally {
             if (zipIn != null) {
                 try {
@@ -153,4 +155,3 @@ public class ZipArchiveContentIdentifier extends ArchiveContentIdentifier {
         return aggregator;
     }
 }
-

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/embarc/EmbARC.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/embarc/EmbARC.java
@@ -1,34 +1,22 @@
-/* 
+/*
  * Copyright 2022 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.tools.embarc;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-
-import org.jdom2.Attribute;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.Namespace;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.portalmedia.embarc.cli.Main;
 import com.portalmedia.embarc.cli.XmlWriterDpx;
@@ -39,7 +27,6 @@ import com.portalmedia.embarc.parser.dpx.DPXColumn;
 import com.portalmedia.embarc.parser.dpx.DPXFileInformation;
 import com.portalmedia.embarc.parser.dpx.DPXFileListHelper;
 import com.portalmedia.embarc.parser.dpx.DPXMetadata;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.FitsMetadataValues;
 import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
@@ -47,317 +34,327 @@ import edu.harvard.hul.ois.fits.tools.ToolBase;
 import edu.harvard.hul.ois.fits.tools.ToolInfo;
 import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import edu.harvard.hul.ois.fits.util.DateTimeUtil;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import org.jdom2.Attribute;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class EmbARC extends ToolBase {
-	private boolean enabled = true;
-	private Fits fits;
-	private final static Namespace fitsNS = Namespace.getNamespace (Fits.XML_NAMESPACE);
+    private boolean enabled = true;
+    private Fits fits;
+    private static final Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
 
-	private static final Logger logger = LoggerFactory.getLogger(EmbARC.class);
+    private static final Logger logger = LoggerFactory.getLogger(EmbARC.class);
 
-	public EmbARC(Fits fits) throws FitsToolException {
-		super();
-		this.fits = fits;
-		logger.debug("Initializing embARC");
-		info = new ToolInfo("embARC", Main.version, null);
-	}
+    public EmbARC(Fits fits) throws FitsToolException {
+        super();
+        this.fits = fits;
+        logger.debug("Initializing embARC");
+        info = new ToolInfo("embARC", Main.version, null);
+    }
 
-	@Override
-	public ToolOutput extractInfo(File file) throws FitsToolException {
-		logger.debug("embARC extractInfo starting on {}", file.getName());
-		long startTime = System.currentTimeMillis();
+    @Override
+    public ToolOutput extractInfo(File file) throws FitsToolException {
+        logger.debug("embARC extractInfo starting on {}", file.getName());
+        long startTime = System.currentTimeMillis();
 
-		String absPath = file.getAbsolutePath();
-		FileFormat fileFormat = FileFormatDetection.getFileFormat(absPath);
+        String absPath = file.getAbsolutePath();
+        FileFormat fileFormat = FileFormatDetection.getFileFormat(absPath);
 
-		// embARC should only run for dpx files
-		if (fileFormat != FileFormat.DPX) {
-			throw new FitsToolException("embARC processing failed: non-dpx file detected");
-		}
+        // embARC should only run for dpx files
+        if (fileFormat != FileFormat.DPX) {
+            throw new FitsToolException("embARC processing failed: non-dpx file detected");
+        }
 
-		DPXFileInformation dpxFileInfo = DPXFileListHelper.createDPXFileInformation(absPath);
+        DPXFileInformation dpxFileInfo = DPXFileListHelper.createDPXFileInformation(absPath);
 
-		Document fitsXml = createToolData(file, dpxFileInfo);
-		Document rawData = null;
-		try {
-			rawData = createRawDataXml(dpxFileInfo);
-		} catch (FitsToolException ex) {
-			logger.debug("embARC caught error creating raw tool output {}", ex.toString());
-		}
-		ToolOutput output = new ToolOutput(this, fitsXml, rawData, fits);
+        Document fitsXml = createToolData(file, dpxFileInfo);
+        Document rawData = null;
+        try {
+            rawData = createRawDataXml(dpxFileInfo);
+        } catch (FitsToolException ex) {
+            logger.debug("embARC caught error creating raw tool output {}", ex.toString());
+        }
+        ToolOutput output = new ToolOutput(this, fitsXml, rawData, fits);
 
-		duration = System.currentTimeMillis()-startTime;
-		runStatus = RunStatus.SUCCESSFUL;
-		logger.debug("embARC extractInfo finished on {}", file.getName());
-		return output;
-	}
+        duration = System.currentTimeMillis() - startTime;
+        runStatus = RunStatus.SUCCESSFUL;
+        logger.debug("embARC extractInfo finished on {}", file.getName());
+        return output;
+    }
 
-	@Override
-	public boolean isEnabled() {
-		return enabled;
-	}
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
 
-	@Override
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
+    @Override
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
 
-	private Document createToolData(File file, DPXFileInformation dpxFileInfo) {
-		Element fitsElement = new Element("fits", fitsNS);
-		Document toolDocument = new Document(fitsElement);
+    private Document createToolData(File file, DPXFileInformation dpxFileInfo) {
+        Element fitsElement = new Element("fits", fitsNS);
+        Document toolDocument = new Document(fitsElement);
 
-		Element identificationElement = createIdentificationElement(dpxFileInfo);
-		fitsElement.addContent(identificationElement);
+        Element identificationElement = createIdentificationElement(dpxFileInfo);
+        fitsElement.addContent(identificationElement);
 
-		Element fileInfoElement = createFileInfoElement(file, dpxFileInfo);
-		fitsElement.addContent(fileInfoElement);
+        Element fileInfoElement = createFileInfoElement(file, dpxFileInfo);
+        fitsElement.addContent(fileInfoElement);
 
-		Element metadataElement = createMetadataElement(dpxFileInfo);
-		fitsElement.addContent(metadataElement);
+        Element metadataElement = createMetadataElement(dpxFileInfo);
+        fitsElement.addContent(metadataElement);
 
-		return toolDocument;
-	}
+        return toolDocument;
+    }
 
-	private Element createIdentificationElement(DPXFileInformation dpxFileInfo) {
-		Element identificationElement = new Element("identification", fitsNS);
-		Element identityElem = new Element("identity", fitsNS);
+    private Element createIdentificationElement(DPXFileInformation dpxFileInfo) {
+        Element identificationElement = new Element("identification", fitsNS);
+        Element identityElem = new Element("identity", fitsNS);
 
-		String format = "Digital Picture Exchange";
-		String mimeType = FitsMetadataValues.getInstance().normalizeMimeType(dpxFileInfo.getMimeType());
+        String format = "Digital Picture Exchange";
+        String mimeType = FitsMetadataValues.getInstance().normalizeMimeType(dpxFileInfo.getMimeType());
 
-		identityElem.setAttribute(new Attribute("format", format));
-		identityElem.setAttribute(new Attribute("mimetype", mimeType));
+        identityElem.setAttribute(new Attribute("format", format));
+        identityElem.setAttribute(new Attribute("mimetype", mimeType));
 
-		identificationElement.addContent(identityElem);
-		return identificationElement;
-	}
+        identificationElement.addContent(identityElem);
+        return identificationElement;
+    }
 
-	private Element createFileInfoElement(File file, DPXFileInformation dpxFileInfo) {
-		DPXMetadata metadata = dpxFileInfo.getFileData();
-		Element fileInfoElement = new Element("fileinfo", fitsNS);
+    private Element createFileInfoElement(File file, DPXFileInformation dpxFileInfo) {
+        DPXMetadata metadata = dpxFileInfo.getFileData();
+        Element fileInfoElement = new Element("fileinfo", fitsNS);
 
-		String copyrightNote = getValueForColumn(metadata, DPXColumn.COPYRIGHT_STATEMENT);
-		String created = DateTimeUtil.standardize(getValueForColumn(metadata, DPXColumn.CREATION_DATETIME));
-		String filePath = file.getAbsolutePath();
-		String fileName = file.getName();
-		String fileSize = Long.toString(file.length());
+        String copyrightNote = getValueForColumn(metadata, DPXColumn.COPYRIGHT_STATEMENT);
+        String created = DateTimeUtil.standardize(getValueForColumn(metadata, DPXColumn.CREATION_DATETIME));
+        String filePath = file.getAbsolutePath();
+        String fileName = file.getName();
+        String fileSize = Long.toString(file.length());
 
-		if (!created.isEmpty()) {
-			addElement(fileInfoElement, FitsMetadataValues.CREATED, created);
-		}
+        if (!created.isEmpty()) {
+            addElement(fileInfoElement, FitsMetadataValues.CREATED, created);
+        }
 
-		if (!copyrightNote.isEmpty()) {
-			addElement(fileInfoElement, FitsMetadataValues.COPYRIGHT_NOTE, copyrightNote);
-		}
+        if (!copyrightNote.isEmpty()) {
+            addElement(fileInfoElement, FitsMetadataValues.COPYRIGHT_NOTE, copyrightNote);
+        }
 
-		if (!filePath.isEmpty()) {
-			addElement(fileInfoElement, "filepath", filePath);
-		}
+        if (!filePath.isEmpty()) {
+            addElement(fileInfoElement, "filepath", filePath);
+        }
 
-		if (!fileName.isEmpty()) {
-			addElement(fileInfoElement, "filename", fileName);
-		}
+        if (!fileName.isEmpty()) {
+            addElement(fileInfoElement, "filename", fileName);
+        }
 
-		if (!fileSize.isEmpty()) {
-			addElement(fileInfoElement, FitsMetadataValues.SIZE, fileSize);
-		}
+        if (!fileSize.isEmpty()) {
+            addElement(fileInfoElement, FitsMetadataValues.SIZE, fileSize);
+        }
 
-		return fileInfoElement;
-	}
+        return fileInfoElement;
+    }
 
-	private Element createMetadataElement(DPXFileInformation dpxFileInfo) {
-		DPXMetadata metadata = dpxFileInfo.getFileData();
-		Element metadataElement = new Element("metadata", fitsNS);
-		Element imageElement = new Element(FitsMetadataValues.IMAGE, fitsNS);
+    private Element createMetadataElement(DPXFileInformation dpxFileInfo) {
+        DPXMetadata metadata = dpxFileInfo.getFileData();
+        Element metadataElement = new Element("metadata", fitsNS);
+        Element imageElement = new Element(FitsMetadataValues.IMAGE, fitsNS);
 
-		String bitDepth = getValueForColumn(metadata, DPXColumn.BIT_DEPTH_1);
-		String byteOrder = mapMagicNumberToByteOrder(getValueForColumn(metadata, DPXColumn.MAGIC_NUMBER));
-		String colorSpace = mapDescriptorToColorSpace(getValueForColumn(metadata, DPXColumn.DESCRIPTOR_1));
-		String linesPerImageElement = getValueForColumn(metadata, DPXColumn.LINES_PER_IMAGE_ELEMENT);
-		String creator = getValueForColumn(metadata, DPXColumn.CREATOR);
-		String pixelsPerLine = getValueForColumn(metadata, DPXColumn.PIXELS_PER_LINE);
-		String orientation = mapImageOrientationToOrientation(getValueForColumn(metadata, DPXColumn.IMAGE_ORIENTATION));
-		String inputDeviceName = getValueForColumn(metadata, DPXColumn.INPUT_DEVICE_NAME);
-		String inputDeviceSerialNumber = getValueForColumn(metadata, DPXColumn.INPUT_DEVICE_SERIAL_NUMBER);
+        String bitDepth = getValueForColumn(metadata, DPXColumn.BIT_DEPTH_1);
+        String byteOrder = mapMagicNumberToByteOrder(getValueForColumn(metadata, DPXColumn.MAGIC_NUMBER));
+        String colorSpace = mapDescriptorToColorSpace(getValueForColumn(metadata, DPXColumn.DESCRIPTOR_1));
+        String linesPerImageElement = getValueForColumn(metadata, DPXColumn.LINES_PER_IMAGE_ELEMENT);
+        String creator = getValueForColumn(metadata, DPXColumn.CREATOR);
+        String pixelsPerLine = getValueForColumn(metadata, DPXColumn.PIXELS_PER_LINE);
+        String orientation = mapImageOrientationToOrientation(getValueForColumn(metadata, DPXColumn.IMAGE_ORIENTATION));
+        String inputDeviceName = getValueForColumn(metadata, DPXColumn.INPUT_DEVICE_NAME);
+        String inputDeviceSerialNumber = getValueForColumn(metadata, DPXColumn.INPUT_DEVICE_SERIAL_NUMBER);
 
-		if (!bitDepth.isEmpty()) {
-			addElement(imageElement, FitsMetadataValues.BITS_PER_SAMPLE, bitDepth);
-		}
+        if (!bitDepth.isEmpty()) {
+            addElement(imageElement, FitsMetadataValues.BITS_PER_SAMPLE, bitDepth);
+        }
 
-		if (!byteOrder.isEmpty()) {
-			addElement(imageElement, FitsMetadataValues.BYTE_ORDER, byteOrder);
-		}
+        if (!byteOrder.isEmpty()) {
+            addElement(imageElement, FitsMetadataValues.BYTE_ORDER, byteOrder);
+        }
 
-		if (!colorSpace.isEmpty()) {
-			addElement(imageElement, FitsMetadataValues.COLOR_SPACE, colorSpace);
-		}
+        if (!colorSpace.isEmpty()) {
+            addElement(imageElement, FitsMetadataValues.COLOR_SPACE, colorSpace);
+        }
 
-		if (!linesPerImageElement.isEmpty()) {
-			addElement(imageElement, FitsMetadataValues.IMAGE_HEIGHT, linesPerImageElement);
-		}
+        if (!linesPerImageElement.isEmpty()) {
+            addElement(imageElement, FitsMetadataValues.IMAGE_HEIGHT, linesPerImageElement);
+        }
 
-		if (!pixelsPerLine.isEmpty()) {
-			addElement(imageElement, FitsMetadataValues.IMAGE_WIDTH, pixelsPerLine);
-		}
+        if (!pixelsPerLine.isEmpty()) {
+            addElement(imageElement, FitsMetadataValues.IMAGE_WIDTH, pixelsPerLine);
+        }
 
-		if (!creator.isEmpty()) {
-			addElement(imageElement, FitsMetadataValues.IMAGE_PRODUCER, creator);
-		}
+        if (!creator.isEmpty()) {
+            addElement(imageElement, FitsMetadataValues.IMAGE_PRODUCER, creator);
+        }
 
-		if (!orientation.isEmpty()) {
-			addElement(imageElement, FitsMetadataValues.ORIENTATION, orientation);
-		}
+        if (!orientation.isEmpty()) {
+            addElement(imageElement, FitsMetadataValues.ORIENTATION, orientation);
+        }
 
-		if (!inputDeviceName.isEmpty()) {
-			addElement(imageElement, FitsMetadataValues.SCANNER_MODEL_NAME, inputDeviceName);
-		}
+        if (!inputDeviceName.isEmpty()) {
+            addElement(imageElement, FitsMetadataValues.SCANNER_MODEL_NAME, inputDeviceName);
+        }
 
-		if (!inputDeviceSerialNumber.isEmpty()) {
-			addElement(imageElement, FitsMetadataValues.SCANNER_MODEL_SERIAL_NO, inputDeviceSerialNumber);
-		}
+        if (!inputDeviceSerialNumber.isEmpty()) {
+            addElement(imageElement, FitsMetadataValues.SCANNER_MODEL_SERIAL_NO, inputDeviceSerialNumber);
+        }
 
-		metadataElement.addContent(imageElement);
-		return metadataElement;
-	}
+        metadataElement.addContent(imageElement);
+        return metadataElement;
+    }
 
-	private Document createRawDataXml(DPXFileInformation dpxFileInfo) throws FitsToolException {
-		StringWriter out = new StringWriter();
-		out.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-		out.write("\n");
-		out.write("<embARC>");
-		out.write("\n");
-		out.write("<rawOutput>\n");
-		String dpxXml = XmlWriterDpx.createDpxMetadataXml(dpxFileInfo);
-		if (dpxXml != null) {
-			out.write(dpxXml);
-		}
-		out.write("</rawOutput>");
-		out.write("\n");
-		out.write("</embARC>");
-		out.write("\n");
-		out.flush();
+    private Document createRawDataXml(DPXFileInformation dpxFileInfo) throws FitsToolException {
+        StringWriter out = new StringWriter();
+        out.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        out.write("\n");
+        out.write("<embARC>");
+        out.write("\n");
+        out.write("<rawOutput>\n");
+        String dpxXml = XmlWriterDpx.createDpxMetadataXml(dpxFileInfo);
+        if (dpxXml != null) {
+            out.write(dpxXml);
+        }
+        out.write("</rawOutput>");
+        out.write("\n");
+        out.write("</embARC>");
+        out.write("\n");
+        out.flush();
 
-		try {
-			out.close();
-		} catch (IOException e) {
-			throw new FitsToolException("Error closing embARC tool XML output stream");
-		}
+        try {
+            out.close();
+        } catch (IOException e) {
+            throw new FitsToolException("Error closing embARC tool XML output stream");
+        }
 
-		try {
-			return saxBuilder.build(new StringReader(out.toString()));
-		} catch (Exception e) {
-			throw new FitsToolException("Error parsing embARC tool XML raw output");
-		}
-	}
+        try {
+            return saxBuilder.build(new StringReader(out.toString()));
+        } catch (Exception e) {
+            throw new FitsToolException("Error parsing embARC tool XML raw output");
+        }
+    }
 
-	private String getValueForColumn(DPXMetadata metadata, DPXColumn column) {
-		MetadataColumn metadataColumn = metadata.getColumn(column);
-		String stdValue = metadataColumn.getStandardizedValue();
-		if (metadataColumn == null || metadataColumn.isNull() || "NULL".equals(stdValue)) {
-			return "";
-		}
-		return stripInvalidXmlChars(stdValue);
-	}
+    private String getValueForColumn(DPXMetadata metadata, DPXColumn column) {
+        MetadataColumn metadataColumn = metadata.getColumn(column);
+        String stdValue = metadataColumn.getStandardizedValue();
+        if (metadataColumn == null || metadataColumn.isNull() || "NULL".equals(stdValue)) {
+            return "";
+        }
+        return stripInvalidXmlChars(stdValue);
+    }
 
-	private String stripInvalidXmlChars(String input) {
-		String invalidChars = "[^"
-			+ "\u0001-\uD7FF"
-			+ "\u0009\r\n"
-			+ "\u0020-\uD7FF"
-			+ "\uE000-\uFFFD"
-			+ "\ud800\udc00-\udbff\udfff"
-			+ "]";
-		return input.replaceAll(invalidChars, "");
-	}
+    private String stripInvalidXmlChars(String input) {
+        String invalidChars = "[^"
+                + "\u0001-\uD7FF"
+                + "\u0009\r\n"
+                + "\u0020-\uD7FF"
+                + "\uE000-\uFFFD"
+                + "\ud800\udc00-\udbff\udfff"
+                + "]";
+        return input.replaceAll(invalidChars, "");
+    }
 
-	private void addElement(Element parent, String tag, String value ) {
-		Element newElem = new Element(tag, fitsNS);
-		newElem.addContent(value);
-		parent.addContent(newElem);
-	}
+    private void addElement(Element parent, String tag, String value) {
+        Element newElem = new Element(tag, fitsNS);
+        newElem.addContent(value);
+        parent.addContent(newElem);
+    }
 
-	private String mapMagicNumberToByteOrder(String magicNumber) {
-		if (magicNumber.charAt(0) == 'S') {
-			return "big endian";
-		} else if (magicNumber.charAt(0) == 'X') {
-			return "little endian";
-		}
-		return "";
-	}
+    private String mapMagicNumberToByteOrder(String magicNumber) {
+        if (magicNumber.charAt(0) == 'S') {
+            return "big endian";
+        } else if (magicNumber.charAt(0) == 'X') {
+            return "little endian";
+        }
+        return "";
+    }
 
-	private String mapDescriptorToColorSpace(String descriptor) {
-		switch (descriptor) {
-			case "0":
-				return "User defined (or unspecified single component)";
-			case "1":
-				return "Red (R)";
-			case "2":
-				return "Green (G)";
-			case "3":
-				return "Blue (B)";
-			case "4":
-				return "Alpha (matte)";
-			case "6":
-				return "Luma (Y)";
-			case "7":
-				return "Color Difference (CB, CR, subsampled by two)";
-			case "8":
-				return "Depth (Z)";
-			case "9":
-				return "Composite video";
-			case "50":
-				return "R,G,B";
-			case "51":
-				return "R,G,B, Alpha (A)";
-			case "52":
-				return "A,B,G,R";
-			case "100":
-				return "CB, Y, CR, Y (4:2:2)";
-			case "101":
-				return "CB, Y, A, CR, Y, A (4:2:2:4)";
-			case "102":
-				return "CB, Y, CR (4:4:4)";
-			case "103":
-				return "CB, Y, CR, A (4:4:4:4)";
-			case "150":
-				return "User-defined 2-component element";
-			case "151":
-				return "User-defined 3-component element";
-			case "152":
-				return "User-defined 4-component element";
-			case "153":
-				return "User-defined 5-component element";
-			case "154":
-				return "User-defined 6-component element";
-			case "155":
-				return "User-defined 7-component element";
-			case "156":
-				return "User-defined 8-component element";
-			default:
-				return "";
-		}
-	}
+    private String mapDescriptorToColorSpace(String descriptor) {
+        switch (descriptor) {
+            case "0":
+                return "User defined (or unspecified single component)";
+            case "1":
+                return "Red (R)";
+            case "2":
+                return "Green (G)";
+            case "3":
+                return "Blue (B)";
+            case "4":
+                return "Alpha (matte)";
+            case "6":
+                return "Luma (Y)";
+            case "7":
+                return "Color Difference (CB, CR, subsampled by two)";
+            case "8":
+                return "Depth (Z)";
+            case "9":
+                return "Composite video";
+            case "50":
+                return "R,G,B";
+            case "51":
+                return "R,G,B, Alpha (A)";
+            case "52":
+                return "A,B,G,R";
+            case "100":
+                return "CB, Y, CR, Y (4:2:2)";
+            case "101":
+                return "CB, Y, A, CR, Y, A (4:2:2:4)";
+            case "102":
+                return "CB, Y, CR (4:4:4)";
+            case "103":
+                return "CB, Y, CR, A (4:4:4:4)";
+            case "150":
+                return "User-defined 2-component element";
+            case "151":
+                return "User-defined 3-component element";
+            case "152":
+                return "User-defined 4-component element";
+            case "153":
+                return "User-defined 5-component element";
+            case "154":
+                return "User-defined 6-component element";
+            case "155":
+                return "User-defined 7-component element";
+            case "156":
+                return "User-defined 8-component element";
+            default:
+                return "";
+        }
+    }
 
-	private String mapImageOrientationToOrientation(String imageOrientation) {
-		switch (imageOrientation) {
-			case "0":
-				return "normal*";
-			case "1":
-				return "normal, image flipped";
-			case "2":
-				return "normal, image flipped, rotated 180°";
-			case "3":
-				return "normal, rotated 180°";
-			case "4":
-				return "normal, image flipped, rotated ccw 90°";
-			case "5":
-				return "normal, rotated cw 90°";
-			case "6":
-				return "normal, rotated ccw 90°";
-			case "7":
-				return "normal, image flipped, rotated cw 90°";
-			default:
-				return "";
-		}
-	}
+    private String mapImageOrientationToOrientation(String imageOrientation) {
+        switch (imageOrientation) {
+            case "0":
+                return "normal*";
+            case "1":
+                return "normal, image flipped";
+            case "2":
+                return "normal, image flipped, rotated 180°";
+            case "3":
+                return "normal, rotated 180°";
+            case "4":
+                return "normal, image flipped, rotated ccw 90°";
+            case "5":
+                return "normal, rotated cw 90°";
+            case "6":
+                return "normal, rotated ccw 90°";
+            case "7":
+                return "normal, image flipped, rotated cw 90°";
+            default:
+                return "";
+        }
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/exiftool/Exiftool.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/exiftool/Exiftool.java
@@ -8,27 +8,7 @@
 // See the License for the specific language governing permission and limitations under the License.
 //
 
-
 package edu.harvard.hul.ois.fits.tools.exiftool;
-
-
-import java.io.File;
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import org.apache.commons.lang.StringEscapeUtils;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.Namespace;
-import org.jdom2.filter.Filters;
-import org.jdom2.xpath.XPathExpression;
-import org.jdom2.xpath.XPathFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.exceptions.FitsException;
@@ -40,223 +20,233 @@ import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import edu.harvard.hul.ois.fits.tools.utils.CommandLine;
 import edu.harvard.hul.ois.fits.tools.utils.XsltTransformMap;
 import edu.harvard.hul.ois.fits.util.DateTimeUtil;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.jdom2.filter.Filters;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *  The glue class for invoking Exiftool under FITS.
  */
 public class Exiftool extends ToolBase {
 
-	private boolean osIsWindows = false;
-	private boolean osHasPerl = false;
-	private List<String> winCommand = new ArrayList<String>(Arrays.asList(Fits.FITS_TOOLS_DIR+"exiftool/windows/exiftool.exe"));
-	private List<String> unixCommand = new ArrayList<String>(Arrays.asList("perl",Fits.FITS_TOOLS_DIR+"exiftool/perl/exiftool"));
-	private List<String> perlTestCommand = Arrays.asList("which", "perl");
-	private final static String TOOL_NAME = "Exiftool";
-	private boolean enabled = true;
+    private boolean osIsWindows = false;
+    private boolean osHasPerl = false;
+    private List<String> winCommand =
+            new ArrayList<String>(Arrays.asList(Fits.FITS_TOOLS_DIR + "exiftool/windows/exiftool.exe"));
+    private List<String> unixCommand =
+            new ArrayList<String>(Arrays.asList("perl", Fits.FITS_TOOLS_DIR + "exiftool/perl/exiftool"));
+    private List<String> perlTestCommand = Arrays.asList("which", "perl");
+    private static final String TOOL_NAME = "Exiftool";
+    private boolean enabled = true;
     private Fits fits;
 
-    private final static String exiftoolFitsConfig = Fits.FITS_XML_DIR+"exiftool"+File.separator;
-    private final static String genericTransform = "exiftool_generic_to_fits.xslt";
+    private static final String exiftoolFitsConfig = Fits.FITS_XML_DIR + "exiftool" + File.separator;
+    private static final String genericTransform = "exiftool_generic_to_fits.xslt";
 
-    private static Namespace fitsNS = Namespace.getNamespace("fits",Fits.XML_NAMESPACE);
+    private static Namespace fitsNS = Namespace.getNamespace("fits", Fits.XML_NAMESPACE);
     private XPathFactory xFactory = XPathFactory.instance();
 
-	private static final Logger logger = LoggerFactory.getLogger(Exiftool.class);
+    private static final Logger logger = LoggerFactory.getLogger(Exiftool.class);
 
-	public Exiftool(Fits fits) throws FitsException {
-		super();
-		this.fits = fits;
-        logger.debug ("Initializing Exiftool");
+    public Exiftool(Fits fits) throws FitsException {
+        super();
+        this.fits = fits;
+        logger.debug("Initializing Exiftool");
 
-		String osName = System.getProperty("os.name");
-		info = new ToolInfo();
-		info.setName(TOOL_NAME);
-		String versionOutput = null;
-		List<String> infoCommand = new ArrayList<String>();
-		if (osName.startsWith("Windows")) {
-			//use provided Windows exiftool.exe
-			osIsWindows = true;
-			infoCommand.addAll(winCommand);
-			info.setNote("exiftool for windows");
-			logger.debug("Exiftool will use Windows environment");
-		}
-		else if (testOSForPerl()){
-			osHasPerl = true;
-			//use OS version of perl and the provided perl version of exiftool
-			infoCommand.addAll(unixCommand);
-			info.setNote("exiftool for unix");
+        String osName = System.getProperty("os.name");
+        info = new ToolInfo();
+        info.setName(TOOL_NAME);
+        String versionOutput = null;
+        List<String> infoCommand = new ArrayList<String>();
+        if (osName.startsWith("Windows")) {
+            // use provided Windows exiftool.exe
+            osIsWindows = true;
+            infoCommand.addAll(winCommand);
+            info.setNote("exiftool for windows");
+            logger.debug("Exiftool will use Windows environment");
+        } else if (testOSForPerl()) {
+            osHasPerl = true;
+            // use OS version of perl and the provided perl version of exiftool
+            infoCommand.addAll(unixCommand);
+            info.setNote("exiftool for unix");
             logger.debug("Exiftool will use Unix Perl environment");
-		}
+        } else {
+            logger.error("Perl and Windows not supported, not running Exiftool");
+            throw new FitsToolException("Exiftool cannot be used on this system");
+        }
+        infoCommand.add("-ver");
+        versionOutput = CommandLine.exec(infoCommand, null);
+        info.setVersion(versionOutput.trim());
+        transformMap = XsltTransformMap.getMap(exiftoolFitsConfig + "exiftool_xslt_map.xml");
+    }
 
-		else {
-		    logger.error ("Perl and Windows not supported, not running Exiftool");
-			throw new FitsToolException("Exiftool cannot be used on this system");
-		}
-		infoCommand.add("-ver");
-		versionOutput = CommandLine.exec(infoCommand,null);
-		info.setVersion(versionOutput.trim());
-		transformMap = XsltTransformMap.getMap(exiftoolFitsConfig+"exiftool_xslt_map.xml");
-	}
-
-	public ToolOutput extractInfo(File file) throws FitsToolException {
+    public ToolOutput extractInfo(File file) throws FitsToolException {
         logger.debug("Exiftool.extractInfo starting on " + file.getName());
-		long startTime = System.currentTimeMillis();
-		List<String> execCommand = new ArrayList<String>();
-		//determine if the file can be used on the current platform
-		if (osIsWindows) {
-			//use provided Windows File Utility
-			execCommand.addAll(winCommand);
-			execCommand.add(file.getPath());
-		}
-		else if(osHasPerl) {
-			//use file command in operating system
-			execCommand.addAll(unixCommand);
-			execCommand.add(file.getPath());
-		}
-		else {
-			//Tool cannot be used on this file on this system
-			return null;
-		}
-		//Output in tabbed format with tag names instead of descriptive names
-		execCommand.add("-t");
-		execCommand.add("-s");
-		execCommand.add("-a");
+        long startTime = System.currentTimeMillis();
+        List<String> execCommand = new ArrayList<String>();
+        // determine if the file can be used on the current platform
+        if (osIsWindows) {
+            // use provided Windows File Utility
+            execCommand.addAll(winCommand);
+            execCommand.add(file.getPath());
+        } else if (osHasPerl) {
+            // use file command in operating system
+            execCommand.addAll(unixCommand);
+            execCommand.add(file.getPath());
+        } else {
+            // Tool cannot be used on this file on this system
+            return null;
+        }
+        // Output in tabbed format with tag names instead of descriptive names
+        execCommand.add("-t");
+        execCommand.add("-s");
+        execCommand.add("-a");
 
-		logger.debug("Launching Exiftool, command = " + execCommand);
-		String execOut = CommandLine.exec(execCommand,null);
-		logger.debug("Finished running Exiftool");
+        logger.debug("Launching Exiftool, command = " + execCommand);
+        String execOut = CommandLine.exec(execCommand, null);
+        logger.debug("Finished running Exiftool");
 
-		String[] outParts = execOut.split("\n");
-		String format = null;
-		for(String s : outParts) {
-			s = s.toLowerCase();
-			String[] lineParts = s.split("\t");
-			if(lineParts[0].equalsIgnoreCase("filetype")) {
-				format = lineParts[1].trim();
-				break;
-			}
-		}
+        String[] outParts = execOut.split("\n");
+        String format = null;
+        for (String s : outParts) {
+            s = s.toLowerCase();
+            String[] lineParts = s.split("\t");
+            if (lineParts[0].equalsIgnoreCase("filetype")) {
+                format = lineParts[1].trim();
+                break;
+            }
+        }
 
-		Document rawOut = createXml(execOut);
+        Document rawOut = createXml(execOut);
 
-		/*
-		Document exifDoc = null;
-		try {
-			exifDoc = saxBuilder.build(new StringReader(execOut));
-		} catch (Exception e) {
-			throw new FitsToolException("Error parsing ffident XML Output",e);
-		}
+        /*
+        Document exifDoc = null;
+        try {
+        	exifDoc = saxBuilder.build(new StringReader(execOut));
+        } catch (Exception e) {
+        	throw new FitsToolException("Error parsing ffident XML Output",e);
+        }
 
-		String format = XmlUtils.getDomValue(exifDoc.getDocument(),"File:FileType");
-		exifDoc.getRootElement().getChild("rdf:Description/File:FileType");
-		Namespace ns = Namespace.getNamespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#");
-		String test = exifDoc.getRootElement().getChildText("rdf:Description",ns);
-		*/
+        String format = XmlUtils.getDomValue(exifDoc.getDocument(),"File:FileType");
+        exifDoc.getRootElement().getChild("rdf:Description/File:FileType");
+        Namespace ns = Namespace.getNamespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+        String test = exifDoc.getRootElement().getChildText("rdf:Description",ns);
+        */
 
-		String xsltTransform = null;
-		if(format != null) {
-			xsltTransform = (String)transformMap.get(format.toUpperCase());
-		}
+        String xsltTransform = null;
+        if (format != null) {
+            xsltTransform = (String) transformMap.get(format.toUpperCase());
+        }
 
-		Document fitsXml = null;
-		if(xsltTransform != null) {
-			fitsXml = transform(exiftoolFitsConfig+xsltTransform,rawOut);
-		}
-		else {
-			//use generic transform
-			fitsXml = transform(exiftoolFitsConfig+genericTransform,rawOut);
-		}
+        Document fitsXml = null;
+        if (xsltTransform != null) {
+            fitsXml = transform(exiftoolFitsConfig + xsltTransform, rawOut);
+        } else {
+            // use generic transform
+            fitsXml = transform(exiftoolFitsConfig + genericTransform, rawOut);
+        }
 
-		standardizeTimestamp("//fits:fileinfo/fits:created", fitsXml);
-		standardizeTimestamp("//fits:fileinfo/fits:lastmodified", fitsXml);
+        standardizeTimestamp("//fits:fileinfo/fits:created", fitsXml);
+        standardizeTimestamp("//fits:fileinfo/fits:lastmodified", fitsXml);
 
-		output = new ToolOutput(this,fitsXml,rawOut, fits);
-		//}
+        output = new ToolOutput(this, fitsXml, rawOut, fits);
+        // }
 
-		duration = System.currentTimeMillis()-startTime;
-		runStatus = RunStatus.SUCCESSFUL;
+        duration = System.currentTimeMillis() - startTime;
+        runStatus = RunStatus.SUCCESSFUL;
         logger.debug("Exiftool.extractInfo finished on " + file.getName());
-		return output;
-	}
+        return output;
+    }
 
-	public boolean testOSForPerl() throws FitsToolCLIException {
-		String output = CommandLine.exec(perlTestCommand,null);
-		if(output == null || output.length() == 0) {
-			return false;
-		}
-		else {
-			return true;
-		}
-	}
+    public boolean testOSForPerl() throws FitsToolCLIException {
+        String output = CommandLine.exec(perlTestCommand, null);
+        if (output == null || output.length() == 0) {
+            return false;
+        } else {
+            return true;
+        }
+    }
 
-	private Document createXml(String execOut) throws FitsToolException {
-    	StringWriter out = new StringWriter();
+    private Document createXml(String execOut) throws FitsToolException {
+        StringWriter out = new StringWriter();
 
         out.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         out.write("\n");
         out.write("<exiftool>");
         out.write("\n");
 
-    	String[] lines = execOut.split("\n");
-    	for(String line : lines) {
-    		String[] parts = line.split("\t");
-    		String field = parts[0].trim();
-    		if(parts.length > 1 && field.length() > 0) {
-    			String value = parts[1].trim();
-    			out.write("<"+field+">"+StringEscapeUtils.escapeXml(value)+"</"+field+">");
-    			out.write("\n");
-    		}
-    	}
+        String[] lines = execOut.split("\n");
+        for (String line : lines) {
+            String[] parts = line.split("\t");
+            String field = parts[0].trim();
+            if (parts.length > 1 && field.length() > 0) {
+                String value = parts[1].trim();
+                out.write("<" + field + ">" + StringEscapeUtils.escapeXml(value) + "</" + field + ">");
+                out.write("\n");
+            }
+        }
         out.write("</exiftool>");
         out.write("\n");
 
         out.flush();
         try {
-			out.close();
-		} catch (IOException e) {
-			throw new FitsToolException("Error closing Exiftool XML output stream",e);
-		}
+            out.close();
+        } catch (IOException e) {
+            throw new FitsToolException("Error closing Exiftool XML output stream", e);
+        }
         Document doc = null;
-		try {
-			doc = saxBuilder.build(new StringReader(out.toString()));
-		} catch (Exception e) {
-			throw new FitsToolException("Error parsing Exiftool XML Output",e);
-		}
+        try {
+            doc = saxBuilder.build(new StringReader(out.toString()));
+        } catch (Exception e) {
+            throw new FitsToolException("Error parsing Exiftool XML Output", e);
+        }
         return doc;
     }
-	/*
-	public boolean isIdentityKnown(FileIdentity identity) {
-		//identity and mimetype must not be null or empty strings for an identity to be "known"
-		if(identity == null
-				|| identity.getMime() == null
-				|| identity.getMime().length() == 0
-				|| identity.getFormat() == null
-				|| identity.getFormat().length() == 0) {
-			return false;
-		}
-		String mime = identity.getMime();
-		if(mime.equals("application/unknown")) {
-			return false;
-		}
-		else {
-			return true;
-		}
-	}*/
+    /*
+    public boolean isIdentityKnown(FileIdentity identity) {
+    	//identity and mimetype must not be null or empty strings for an identity to be "known"
+    	if(identity == null
+    			|| identity.getMime() == null
+    			|| identity.getMime().length() == 0
+    			|| identity.getFormat() == null
+    			|| identity.getFormat().length() == 0) {
+    		return false;
+    	}
+    	String mime = identity.getMime();
+    	if(mime.equals("application/unknown")) {
+    		return false;
+    	}
+    	else {
+    		return true;
+    	}
+    }*/
 
-	public boolean isEnabled() {
-		return enabled;
-	}
+    public boolean isEnabled() {
+        return enabled;
+    }
 
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
 
-	private void standardizeTimestamp(String path, Document document) {
+    private void standardizeTimestamp(String path, Document document) {
         XPathExpression<Element> expr = xFactory.compile(path, Filters.element(), null, fitsNS);
         Element element = (Element) expr.evaluateFirst(document);
-		if (element != null) {
-			element.setText(DateTimeUtil.standardize(element.getText()));
-		}
-	}
-
+        if (element != null) {
+            element.setText(DateTimeUtil.standardize(element.getText()));
+        }
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/ffident/FFIdent.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/ffident/FFIdent.java
@@ -8,9 +8,13 @@
 // See the License for the specific language governing permission and limitations under the License.
 //
 
-
 package edu.harvard.hul.ois.fits.tools.ffident;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import edu.harvard.hul.ois.fits.tools.ToolBase;
+import edu.harvard.hul.ois.fits.tools.ToolInfo;
+import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -18,14 +22,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.jdom2.Document;
-
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
-import edu.harvard.hul.ois.fits.tools.ToolBase;
-import edu.harvard.hul.ois.fits.tools.ToolInfo;
-import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,99 +31,98 @@ import org.slf4j.LoggerFactory;
  */
 public class FFIdent extends ToolBase {
 
-    private final static String TOOL_NAME = "ffident";
-    private final static String TOOL_VERSION = "0.2";
-    private final static String TOOL_DATE = "2005-10-21";
+    private static final String TOOL_NAME = "ffident";
+    private static final String TOOL_VERSION = "0.2";
+    private static final String TOOL_DATE = "2005-10-21";
 
-	private FormatIdentification identifier = null;
-	private final static String xslt =Fits.FITS_XML_DIR+"/ffident/ffident_to_fits.xslt";
-	private boolean enabled = true;
+    private FormatIdentification identifier = null;
+    private static final String xslt = Fits.FITS_XML_DIR + "/ffident/ffident_to_fits.xslt";
+    private boolean enabled = true;
     private Fits fits;
 
-	private static final Logger logger = LoggerFactory.getLogger(FFIdent.class);
+    private static final Logger logger = LoggerFactory.getLogger(FFIdent.class);
 
-	public FFIdent(Fits fits) throws FitsToolException{
-		super();
-		this.fits = fits;
-        logger.debug ("Initializing FFIdent");
-		info = new ToolInfo(TOOL_NAME, TOOL_VERSION, TOOL_DATE);
+    public FFIdent(Fits fits) throws FitsToolException {
+        super();
+        this.fits = fits;
+        logger.debug("Initializing FFIdent");
+        info = new ToolInfo(TOOL_NAME, TOOL_VERSION, TOOL_DATE);
 
-		try {
-			File config = new File(Fits.FITS_TOOLS_DIR+"ffident/formats.txt");
-			identifier = new FormatIdentification(config.getPath());
-		} catch (FileNotFoundException e) {
-			throw new FitsToolException(Fits.FITS_TOOLS_DIR+"ffident/formats.txt could not be found",e);
-		}
-	}
+        try {
+            File config = new File(Fits.FITS_TOOLS_DIR + "ffident/formats.txt");
+            identifier = new FormatIdentification(config.getPath());
+        } catch (FileNotFoundException e) {
+            throw new FitsToolException(Fits.FITS_TOOLS_DIR + "ffident/formats.txt could not be found", e);
+        }
+    }
 
-	public ToolOutput extractInfo(File file) throws FitsToolException {
-	    logger.debug ("FFIdent.extractInfo starting on " + file.getName());
-		long startTime = System.currentTimeMillis();
-		FormatDescription desc = identifier.identify(file);
-		//FileIdentity identity = null;
-		Document rawOut = null;
-		Document fitsXml = null;
-		//if (desc != null) {
-			//desc.getShortName();
-			//desc.getMimeTypes();
-			//identity = new FileIdentity(desc.getMimeType(),desc.getShortName(),null);
-			rawOut = createXml(desc);
-			fitsXml = transform(xslt,rawOut);
-		//}
-		output = new ToolOutput(this,fitsXml,rawOut, fits);
-		duration = System.currentTimeMillis()-startTime;
-		runStatus = RunStatus.SUCCESSFUL;
-        logger.debug ("FFIdent.extractInfo finished on " + file.getName());
-		return output;
-	}
+    public ToolOutput extractInfo(File file) throws FitsToolException {
+        logger.debug("FFIdent.extractInfo starting on " + file.getName());
+        long startTime = System.currentTimeMillis();
+        FormatDescription desc = identifier.identify(file);
+        // FileIdentity identity = null;
+        Document rawOut = null;
+        Document fitsXml = null;
+        // if (desc != null) {
+        // desc.getShortName();
+        // desc.getMimeTypes();
+        // identity = new FileIdentity(desc.getMimeType(),desc.getShortName(),null);
+        rawOut = createXml(desc);
+        fitsXml = transform(xslt, rawOut);
+        // }
+        output = new ToolOutput(this, fitsXml, rawOut, fits);
+        duration = System.currentTimeMillis() - startTime;
+        runStatus = RunStatus.SUCCESSFUL;
+        logger.debug("FFIdent.extractInfo finished on " + file.getName());
+        return output;
+    }
 
-   private Document createXml(FormatDescription desc) throws FitsToolException {
-    	StringWriter out = new StringWriter();
+    private Document createXml(FormatDescription desc) throws FitsToolException {
+        StringWriter out = new StringWriter();
 
-    	String shortname;
-    	String longname;
-    	String group;
-    	List<String> mimetypes = new ArrayList<String>();
-    	List<String> exts = new ArrayList<String>();
+        String shortname;
+        String longname;
+        String group;
+        List<String> mimetypes = new ArrayList<String>();
+        List<String> exts = new ArrayList<String>();
 
-    	if(desc == null) {
-    		shortname = "";
-    		longname = "Unknown Binary";
-    		group = "";
-    		mimetypes.add("application/octet-stream");
-    	}
-    	else {
-    		shortname = desc.getShortName();
-    		longname = desc.getLongName();
-    		group = desc.getGroup();
-    		mimetypes = desc.getMimeTypes();
-    		exts = desc.getFileExtensions();
-    	}
+        if (desc == null) {
+            shortname = "";
+            longname = "Unknown Binary";
+            group = "";
+            mimetypes.add("application/octet-stream");
+        } else {
+            shortname = desc.getShortName();
+            longname = desc.getLongName();
+            group = desc.getGroup();
+            mimetypes = desc.getMimeTypes();
+            exts = desc.getFileExtensions();
+        }
 
         out.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         out.write("\n");
         out.write("<ffidentOutput>");
         out.write("\n");
-        out.write("  <shortName>"+shortname+"</shortName>");
+        out.write("  <shortName>" + shortname + "</shortName>");
         out.write("\n");
-        out.write("  <longName>"+longname+"</longName>");
+        out.write("  <longName>" + longname + "</longName>");
         out.write("\n");
-        out.write("  <group>"+group+"</group>");
+        out.write("  <group>" + group + "</group>");
         out.write("\n");
         out.write("  <mimetypes>");
         out.write("\n");
-        for(String mime : mimetypes) {
-        	out.write("    <mimetype>"+mime+"</mimetype>");
-        	out.write("\n");
+        for (String mime : mimetypes) {
+            out.write("    <mimetype>" + mime + "</mimetype>");
+            out.write("\n");
         }
         out.write("  </mimetypes>");
         out.write("\n");
 
         out.write("  <fileExtensions>");
         out.write("\n");
-        for(String ext : exts) {
-        	out.write("    <extension>"+ext+"</extension>");
-        	out.write("\n");
+        for (String ext : exts) {
+            out.write("    <extension>" + ext + "</extension>");
+            out.write("\n");
         }
         out.write("  </fileExtensions>");
         out.write("\n");
@@ -134,28 +130,28 @@ public class FFIdent extends ToolBase {
         out.write("\n");
         out.flush();
         try {
-			out.close();
-		} catch (IOException e) {
-		    logger.debug ("Error closing ffident XML output stream: " + e.getClass().getName());
-			throw new FitsToolException("Error closing ffident XML output stream",e);
-		}
+            out.close();
+        } catch (IOException e) {
+            logger.debug(
+                    "Error closing ffident XML output stream: " + e.getClass().getName());
+            throw new FitsToolException("Error closing ffident XML output stream", e);
+        }
 
         Document doc = null;
-		try {
-			doc = saxBuilder.build(new StringReader(out.toString()));
-		} catch (Exception e) {
-		    logger.debug("Error parsing ffident XML Output: " + e.getClass().getName());
-			throw new FitsToolException("Error parsing ffident XML Output",e);
-		}
+        try {
+            doc = saxBuilder.build(new StringReader(out.toString()));
+        } catch (Exception e) {
+            logger.debug("Error parsing ffident XML Output: " + e.getClass().getName());
+            throw new FitsToolException("Error parsing ffident XML Output", e);
+        }
         return doc;
     }
 
-	public boolean isEnabled() {
-		return enabled;
-	}
+    public boolean isEnabled() {
+        return enabled;
+    }
 
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
-
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/ffident/FormatDescription.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/ffident/FormatDescription.java
@@ -8,7 +8,6 @@
 // See the License for the specific language governing permission and limitations under the License.
 //
 
-
 package edu.harvard.hul.ois.fits.tools.ffident;
 
 import java.io.UnsupportedEncodingException;
@@ -20,317 +19,247 @@ import java.util.List;
  * Data class to store information on a file format.
  * @author Marco Schmidt
  */
-public class FormatDescription implements Comparable<FormatDescription>
-{
-	private List<String> fileExtensions;
-	private String group;
-	private String longName;
-	private byte[] magicBytes;
-	private List<String> mimeTypes;
-	private Integer minimumSize;
-	private Integer offset;
-	private String shortName;
+public class FormatDescription implements Comparable<FormatDescription> {
+    private List<String> fileExtensions;
+    private String group;
+    private String longName;
+    private byte[] magicBytes;
+    private List<String> mimeTypes;
+    private Integer minimumSize;
+    private Integer offset;
+    private String shortName;
 
-	/**
-	 * Add a single file extension to the internal list of typical file extensions for this format.
-	 * @param ext file extension
-	 */
-	public void addFileExtension(String ext)
-	{
-		if (ext == null || ext.length() < 1)
-		{
-			return;
-		}
-		if (fileExtensions == null)
-		{
-			fileExtensions = new ArrayList<String>();
-		}
-		fileExtensions.add(ext);
-	}
+    /**
+     * Add a single file extension to the internal list of typical file extensions for this format.
+     * @param ext file extension
+     */
+    public void addFileExtension(String ext) {
+        if (ext == null || ext.length() < 1) {
+            return;
+        }
+        if (fileExtensions == null) {
+            fileExtensions = new ArrayList<String>();
+        }
+        fileExtensions.add(ext);
+    }
 
-	/**
-	 * Add all file extensions to the internal list of typical file extensions for this format.
-	 * @param ext a comma-separated list of typical file extensions
-	 */
-	public void addFileExtensions(String ext)
-	{
-		if (ext == null)
-		{
-			return;
-		}
-		if (ext.indexOf(',') == -1)
-		{
-			addFileExtension(ext);
-			return;
-		}
-		String[] extensions = ext.split(",");
-		for (int i = 0; i < extensions.length; i++)
-		{
-			addFileExtension(extensions[i]);
-		}
-	}
+    /**
+     * Add all file extensions to the internal list of typical file extensions for this format.
+     * @param ext a comma-separated list of typical file extensions
+     */
+    public void addFileExtensions(String ext) {
+        if (ext == null) {
+            return;
+        }
+        if (ext.indexOf(',') == -1) {
+            addFileExtension(ext);
+            return;
+        }
+        String[] extensions = ext.split(",");
+        for (int i = 0; i < extensions.length; i++) {
+            addFileExtension(extensions[i]);
+        }
+    }
 
-	/**
-	 * Add a single MIME type to the internal list of MIME types for this format.
-	 * @param mimeType the MIME type to be added
-	 */
-	public void addMimeType(String mimeType)
-	{
-		if (mimeType == null || mimeType.length() < 1)
-		{
-			return;
-		}
-		if (mimeTypes == null)
-		{
-			mimeTypes = new ArrayList<String>();
-		}
-		mimeTypes.add(mimeType);
-	}
+    /**
+     * Add a single MIME type to the internal list of MIME types for this format.
+     * @param mimeType the MIME type to be added
+     */
+    public void addMimeType(String mimeType) {
+        if (mimeType == null || mimeType.length() < 1) {
+            return;
+        }
+        if (mimeTypes == null) {
+            mimeTypes = new ArrayList<String>();
+        }
+        mimeTypes.add(mimeType);
+    }
 
-	/**
-	 * Add a list of MIME types to the internal list of MIME types for this format.
-	 * @param mimeType a comma-separated list of MIME types to be added
-	 */
-	public void addMimeTypes(String mimeType)
-	{
-		if (mimeType == null)
-		{
-			return;
-		}
-		if (mimeType.indexOf(',') == -1)
-		{
-			addMimeType(mimeType);
-			return;
-		}
-		String[] types = mimeType.split(",");
-		for (int i = 0; i < types.length; i++)
-		{
-			addMimeType(types[i]);
-		}
-	}
+    /**
+     * Add a list of MIME types to the internal list of MIME types for this format.
+     * @param mimeType a comma-separated list of MIME types to be added
+     */
+    public void addMimeTypes(String mimeType) {
+        if (mimeType == null) {
+            return;
+        }
+        if (mimeType.indexOf(',') == -1) {
+            addMimeType(mimeType);
+            return;
+        }
+        String[] types = mimeType.split(",");
+        for (int i = 0; i < types.length; i++) {
+            addMimeType(types[i]);
+        }
+    }
 
-	public int compareTo(FormatDescription desc)
-	{
-		//FormatDescription desc = (FormatDescription)obj;
-		int relation = getGroup().compareTo(desc.getGroup());
-		if (relation != 0)
-		{
-			return relation;
-		}
-		return getLongName().compareTo(desc.getLongName());
-	}
+    public int compareTo(FormatDescription desc) {
+        // FormatDescription desc = (FormatDescription)obj;
+        int relation = getGroup().compareTo(desc.getGroup());
+        if (relation != 0) {
+            return relation;
+        }
+        return getLongName().compareTo(desc.getLongName());
+    }
 
-	public List<String> getFileExtensions()
-	{
-		return fileExtensions;
-	}
+    public List<String> getFileExtensions() {
+        return fileExtensions;
+    }
 
-	public String getGroup()
-	{
-		return group;
-	}
+    public String getGroup() {
+        return group;
+    }
 
-	public String getLongName()
-	{
-		return longName;
-	}
+    public String getLongName() {
+        return longName;
+    }
 
-	public byte[] getMagicBytes()
-	{
-		return magicBytes;
-	}
+    public byte[] getMagicBytes() {
+        return magicBytes;
+    }
 
-	public String getMimeType()
-	{
-		return getMimeType(0);
-	}
+    public String getMimeType() {
+        return getMimeType(0);
+    }
 
-	public String getMimeType(int index)
-	{
-		if (mimeTypes != null && index >= 0 && index < mimeTypes.size())
-		{
-			return (String)mimeTypes.get(index);
-		}
-		else
-		{
-			return null;
-		}
-	}
+    public String getMimeType(int index) {
+        if (mimeTypes != null && index >= 0 && index < mimeTypes.size()) {
+            return (String) mimeTypes.get(index);
+        } else {
+            return null;
+        }
+    }
 
-	public List<String> getMimeTypes()
-	{
-		return mimeTypes;
-	}
+    public List<String> getMimeTypes() {
+        return mimeTypes;
+    }
 
-	public Integer getMinimumSize()
-	{
-		return minimumSize;
-	}
+    public Integer getMinimumSize() {
+        return minimumSize;
+    }
 
-	public Integer getOffset()
-	{
-		return offset;
-	}
+    public Integer getOffset() {
+        return offset;
+    }
 
-	public String getShortName()
-	{
-		return shortName;
-	}
+    public String getShortName() {
+        return shortName;
+    }
 
-	public boolean matches(byte[] data)
-	{
-		if (magicBytes == null || offset == null)
-		{
-			return false;
-		}
-		int index1 = 0;
-		int index2 = offset.intValue();
-		if (index2 + magicBytes.length > data.length)
-		{
-			return false;
-		}
-		int num = magicBytes.length;
-		do
-		{
-			if (magicBytes[index1++] != data[index2++])
-			{
-				return false;
-			}
-			num--;
-		}
-		while (num > 0);
-		return true;
-	}
+    public boolean matches(byte[] data) {
+        if (magicBytes == null || offset == null) {
+            return false;
+        }
+        int index1 = 0;
+        int index2 = offset.intValue();
+        if (index2 + magicBytes.length > data.length) {
+            return false;
+        }
+        int num = magicBytes.length;
+        do {
+            if (magicBytes[index1++] != data[index2++]) {
+                return false;
+            }
+            num--;
+        } while (num > 0);
+        return true;
+    }
 
-	public void setGroup(String newValue)
-	{
-		group = newValue;
-	}
+    public void setGroup(String newValue) {
+        group = newValue;
+    }
 
-	public void setLongName(String newValue)
-	{
-		longName = newValue;
-	}
+    public void setLongName(String newValue) {
+        longName = newValue;
+    }
 
-	public void setMagicBytes(byte[] newValue)
-	{
-		magicBytes = newValue;
-	}
+    public void setMagicBytes(byte[] newValue) {
+        magicBytes = newValue;
+    }
 
-	public void setMagicBytes(String newValue)
-	{
-		if (newValue == null || newValue.length() < 1)
-		{
-			magicBytes = null;
-			return;
-		}
-		if (newValue.length() > 2 &&
-		    newValue.charAt(0) == '"' &&
-		    newValue.charAt(newValue.length() - 1) == '"')
-		{
-			newValue = newValue.substring(1, newValue.length() - 1);
-			try
-			{
-				magicBytes = newValue.getBytes("iso-8859-1");
-			}
-			catch (UnsupportedEncodingException uee)
-			{
-				magicBytes = null;
-			}
-			return;
-		}
-		if ((newValue.length() % 2) == 0)
-		{
-			newValue = newValue.toLowerCase();
-			byte[] data = new byte[newValue.length() / 2];
-			int byteValue = 0;
-			for (int i = 0; i < newValue.length(); i++)
-			{
-				char c = newValue.charAt(i);
-				int number;
-				if (c >= '0' && c <= '9')
-				{
-					number = c - '0';
-				}
-				else
-				if (c >= 'a' && c <= 'f')
-				{
-					number = 10 + c - 'a';
-				}
-				else
-				{
-					return;
-				}
-				if ((i % 2) == 0)
-				{
-					byteValue = number * 16;
-				}
-				else
-				{
-					byteValue += number;
-					data[i / 2] = (byte)byteValue;
-				}
-			}
-			magicBytes = data;
-		}
-	}
+    public void setMagicBytes(String newValue) {
+        if (newValue == null || newValue.length() < 1) {
+            magicBytes = null;
+            return;
+        }
+        if (newValue.length() > 2 && newValue.charAt(0) == '"' && newValue.charAt(newValue.length() - 1) == '"') {
+            newValue = newValue.substring(1, newValue.length() - 1);
+            try {
+                magicBytes = newValue.getBytes("iso-8859-1");
+            } catch (UnsupportedEncodingException uee) {
+                magicBytes = null;
+            }
+            return;
+        }
+        if ((newValue.length() % 2) == 0) {
+            newValue = newValue.toLowerCase();
+            byte[] data = new byte[newValue.length() / 2];
+            int byteValue = 0;
+            for (int i = 0; i < newValue.length(); i++) {
+                char c = newValue.charAt(i);
+                int number;
+                if (c >= '0' && c <= '9') {
+                    number = c - '0';
+                } else if (c >= 'a' && c <= 'f') {
+                    number = 10 + c - 'a';
+                } else {
+                    return;
+                }
+                if ((i % 2) == 0) {
+                    byteValue = number * 16;
+                } else {
+                    byteValue += number;
+                    data[i / 2] = (byte) byteValue;
+                }
+            }
+            magicBytes = data;
+        }
+    }
 
-	public void setMinimumSize(Integer newValue)
-	{
-		minimumSize = newValue;
-	}
+    public void setMinimumSize(Integer newValue) {
+        minimumSize = newValue;
+    }
 
-	public void setOffset(Integer newValue)
-	{
-		offset = newValue;
-	}
+    public void setOffset(Integer newValue) {
+        offset = newValue;
+    }
 
-	public void setShortName(String newValue)
-	{
-		shortName = newValue;
-	}
+    public void setShortName(String newValue) {
+        shortName = newValue;
+    }
 
-	public String toString()
-	{
-		final String PRIMARY_SEPARATOR = "\t";
-		final String SECONDARY_SEPARATOR = ",";
-		StringBuffer sb = new StringBuffer(80);
-		sb.append(getGroup());
-		sb.append(PRIMARY_SEPARATOR);
-		sb.append(getShortName());
-		sb.append(PRIMARY_SEPARATOR);
-		sb.append(getLongName());
-		sb.append(PRIMARY_SEPARATOR);
-		if (getMimeTypes() != null)
-		{
-			Iterator<String> iter = getMimeTypes().iterator();
-			while (iter.hasNext())
-			{
-				sb.append(iter.next());
-				sb.append(SECONDARY_SEPARATOR);
-			}
-		}
-		else
-		{
-			sb.append(PRIMARY_SEPARATOR);
-		}
-		sb.append(PRIMARY_SEPARATOR);
-		if (getFileExtensions() != null)
-		{
-			Iterator<String> iter = getFileExtensions().iterator();
-			while (iter.hasNext())
-			{
-				sb.append(iter.next());
-				sb.append(SECONDARY_SEPARATOR);
-			}
-		}
-		else
-		{
-			sb.append(PRIMARY_SEPARATOR);
-		}
-		sb.append(getOffset());
-		sb.append(PRIMARY_SEPARATOR);
-		sb.append(PRIMARY_SEPARATOR);
-		return sb.toString();
-	}
+    public String toString() {
+        final String PRIMARY_SEPARATOR = "\t";
+        final String SECONDARY_SEPARATOR = ",";
+        StringBuffer sb = new StringBuffer(80);
+        sb.append(getGroup());
+        sb.append(PRIMARY_SEPARATOR);
+        sb.append(getShortName());
+        sb.append(PRIMARY_SEPARATOR);
+        sb.append(getLongName());
+        sb.append(PRIMARY_SEPARATOR);
+        if (getMimeTypes() != null) {
+            Iterator<String> iter = getMimeTypes().iterator();
+            while (iter.hasNext()) {
+                sb.append(iter.next());
+                sb.append(SECONDARY_SEPARATOR);
+            }
+        } else {
+            sb.append(PRIMARY_SEPARATOR);
+        }
+        sb.append(PRIMARY_SEPARATOR);
+        if (getFileExtensions() != null) {
+            Iterator<String> iter = getFileExtensions().iterator();
+            while (iter.hasNext()) {
+                sb.append(iter.next());
+                sb.append(SECONDARY_SEPARATOR);
+            }
+        } else {
+            sb.append(PRIMARY_SEPARATOR);
+        }
+        sb.append(getOffset());
+        sb.append(PRIMARY_SEPARATOR);
+        sb.append(PRIMARY_SEPARATOR);
+        return sb.toString();
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/ffident/FormatDescriptionReader.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/ffident/FormatDescriptionReader.java
@@ -18,42 +18,34 @@ import java.io.Reader;
  * Read {@link edu.harvard.hul.ois.fits.tools.ffident.FormatDescription} objects from a semicolon-separated text file.
  * @author Marco Schmidt
  */
-public class FormatDescriptionReader
-{
-	private BufferedReader in;
+public class FormatDescriptionReader {
+    private BufferedReader in;
 
-	public FormatDescriptionReader(Reader reader)
-	{
-		in = new BufferedReader(reader);
-	}
+    public FormatDescriptionReader(Reader reader) {
+        in = new BufferedReader(reader);
+    }
 
-	public FormatDescription read() throws IOException
-	{
-		String line;
-		do
-		{
-			line = in.readLine();
-			if (line == null)
-			{
-				return null;
-			}
-		}
-		while (line.length() < 1 || line.charAt(0) == '#');
-		String[] items = line.split(";");
-		if (items == null || items.length < 8)
-		{
-			throw new IOException("Could not interpret line: " +
-				line);
-		}
-		FormatDescription desc = new FormatDescription();
-		desc.setGroup(items[0]);
-		desc.setShortName(items[1]);
-		desc.setLongName(items[2]);
-		desc.addMimeTypes(items[3]);
-		desc.addFileExtensions(items[4]);
-		desc.setOffset(Integer.parseInt(items[5]));
-		desc.setMagicBytes(items[6]);
-		desc.setMinimumSize(Integer.parseInt(items[7]));
-		return desc;
-	}
+    public FormatDescription read() throws IOException {
+        String line;
+        do {
+            line = in.readLine();
+            if (line == null) {
+                return null;
+            }
+        } while (line.length() < 1 || line.charAt(0) == '#');
+        String[] items = line.split(";");
+        if (items == null || items.length < 8) {
+            throw new IOException("Could not interpret line: " + line);
+        }
+        FormatDescription desc = new FormatDescription();
+        desc.setGroup(items[0]);
+        desc.setShortName(items[1]);
+        desc.setLongName(items[2]);
+        desc.addMimeTypes(items[3]);
+        desc.addFileExtensions(items[4]);
+        desc.setOffset(Integer.parseInt(items[5]));
+        desc.setMagicBytes(items[6]);
+        desc.setMinimumSize(Integer.parseInt(items[7]));
+        return desc;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/ffident/FormatIdentification.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/ffident/FormatIdentification.java
@@ -18,7 +18,6 @@ import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,90 +28,89 @@ import org.slf4j.LoggerFactory;
  * @author Marco Schmidt, Modified for use by FITS by Spencer McEwen
  */
 public class FormatIdentification {
-	private static List<FormatDescription> descriptions;
-	private static int minBufferSize;
-	private static final Logger logger = LoggerFactory.getLogger(FormatIdentification.class);
+    private static List<FormatDescription> descriptions;
+    private static int minBufferSize;
+    private static final Logger logger = LoggerFactory.getLogger(FormatIdentification.class);
 
-	public FormatIdentification(String configFile) throws FileNotFoundException {
-		init(configFile);
-	}
+    public FormatIdentification(String configFile) throws FileNotFoundException {
+        init(configFile);
+    }
 
-	public FormatDescription identify(byte[] data) {
-		if (data == null || data.length < 1) {
-			return null;
-		}
-		Iterator<FormatDescription> iter = descriptions.iterator();
-		while (iter.hasNext()) {
-			FormatDescription desc = (FormatDescription) iter.next();
-			if (desc.matches(data)) {
-				return desc;
-			}
-		}
-		return null;
-	}
+    public FormatDescription identify(byte[] data) {
+        if (data == null || data.length < 1) {
+            return null;
+        }
+        Iterator<FormatDescription> iter = descriptions.iterator();
+        while (iter.hasNext()) {
+            FormatDescription desc = (FormatDescription) iter.next();
+            if (desc.matches(data)) {
+                return desc;
+            }
+        }
+        return null;
+    }
 
-	public FormatDescription identify(File file) {
-		if (!file.isFile()) {
-			return null;
-		}
-		long size = file.length();
-		int numBytes;
-		if (size > minBufferSize) {
-			numBytes = minBufferSize;
-		} else {
-			numBytes = (int) size;
-		}
-		byte[] data = new byte[numBytes];
-		RandomAccessFile in = null;
-		try {
-			in = new RandomAccessFile(file, "r");
-			in.readFully(data);
-			in.close();
-		} catch (IOException ioe) {
-			return null;
-		} finally {
-			try {
-				if (in != null) {
-					in.close();
-				}
-			} catch (IOException ioe) {
-				//
-			}
-		}
-		return identify(data);
-	}
+    public FormatDescription identify(File file) {
+        if (!file.isFile()) {
+            return null;
+        }
+        long size = file.length();
+        int numBytes;
+        if (size > minBufferSize) {
+            numBytes = minBufferSize;
+        } else {
+            numBytes = (int) size;
+        }
+        byte[] data = new byte[numBytes];
+        RandomAccessFile in = null;
+        try {
+            in = new RandomAccessFile(file, "r");
+            in.readFully(data);
+            in.close();
+        } catch (IOException ioe) {
+            return null;
+        } finally {
+            try {
+                if (in != null) {
+                    in.close();
+                }
+            } catch (IOException ioe) {
+                //
+            }
+        }
+        return identify(data);
+    }
 
-	private static void init(String configFile) throws FileNotFoundException {
-		descriptions = new ArrayList<FormatDescription>();
-		minBufferSize = 1;
+    private static void init(String configFile) throws FileNotFoundException {
+        descriptions = new ArrayList<FormatDescription>();
+        minBufferSize = 1;
 
-		FileReader fr = new FileReader(configFile);
+        FileReader fr = new FileReader(configFile);
 
-		try {
-			FormatDescriptionReader in = new FormatDescriptionReader(fr);
+        try {
+            FormatDescriptionReader in = new FormatDescriptionReader(fr);
 
-			FormatDescription desc;
-			while ((desc = in.read()) != null) {
-				byte[] magic = desc.getMagicBytes();
-				Integer offset = desc.getOffset();
-				if (magic != null && offset != null
-						&& offset.intValue() + magic.length > minBufferSize) {
-					minBufferSize = offset.intValue() + magic.length;
-				}
-				descriptions.add(desc);
-			}
+            FormatDescription desc;
+            while ((desc = in.read()) != null) {
+                byte[] magic = desc.getMagicBytes();
+                Integer offset = desc.getOffset();
+                if (magic != null && offset != null && offset.intValue() + magic.length > minBufferSize) {
+                    minBufferSize = offset.intValue() + magic.length;
+                }
+                descriptions.add(desc);
+            }
 
-		} catch (IOException e) {
-			logger.error("Problem reading file: " + configFile, e);
-		} finally {
-			try {
-				if (fr != null) {
-					fr.close();
-				}
-			} catch (IOException e) {
-				// nothing to do if exception other than log
-				logger.info("Problem closing FileReader for file: " + configFile, e);
-			}
-		}
-	}
+        } catch (IOException e) {
+            logger.error("Problem reading file: " + configFile, e);
+        } finally {
+            try {
+                if (fr != null) {
+                    fr.close();
+                }
+            } catch (IOException e) {
+                // nothing to do if exception other than log
+                logger.info("Problem closing FileReader for file: " + configFile, e);
+            }
+        }
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/fileutility/FileUtility.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/fileutility/FileUtility.java
@@ -8,18 +8,7 @@
 // See the License for the specific language governing permission and limitations under the License.
 //
 
-
 package edu.harvard.hul.ois.fits.tools.fileutility;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.jdom2.Document;
-import org.jdom2.Element;
 
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.exceptions.FitsToolCLIException;
@@ -28,242 +17,245 @@ import edu.harvard.hul.ois.fits.tools.ToolBase;
 import edu.harvard.hul.ois.fits.tools.ToolInfo;
 import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import edu.harvard.hul.ois.fits.tools.utils.CommandLine;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jdom2.Document;
+import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class FileUtility extends ToolBase {
 
-	private boolean osIsWindows = false;
-	private boolean osHasTool = false;
-	private List<String> WIN_COMMAND = new ArrayList<String>(Arrays.asList(Fits.FITS_TOOLS_DIR+"file_utility_windows/bin/file.exe"));
-	private List<String> UNIX_COMMAND = new ArrayList<String>(Arrays.asList("file"));
-	private List<String> FILE_TEST_COMMAND = new ArrayList<String>(Arrays.asList("which", "file"));
-	private final static String WIN_FILE_DATE = "6/7/2008";
-	private boolean enabled = true;
+    private boolean osIsWindows = false;
+    private boolean osHasTool = false;
+    private List<String> WIN_COMMAND =
+            new ArrayList<String>(Arrays.asList(Fits.FITS_TOOLS_DIR + "file_utility_windows/bin/file.exe"));
+    private List<String> UNIX_COMMAND = new ArrayList<String>(Arrays.asList("file"));
+    private List<String> FILE_TEST_COMMAND = new ArrayList<String>(Arrays.asList("which", "file"));
+    private static final String WIN_FILE_DATE = "6/7/2008";
+    private boolean enabled = true;
     private Fits fits;
 
-	private static final Logger logger = LoggerFactory.getLogger(FileUtility.class);
+    private static final Logger logger = LoggerFactory.getLogger(FileUtility.class);
 
-    private final static String xslt = Fits.FITS_XML_DIR+"fileutility/fileutility_to_fits.xslt";
+    private static final String xslt = Fits.FITS_XML_DIR + "fileutility/fileutility_to_fits.xslt";
 
-	public FileUtility(Fits fits) throws FitsToolException{
-		super();
-		this.fits = fits;
-        logger.debug ("Initializing FileUtility");
-		String osName = System.getProperty("os.name");
-		info = new ToolInfo();
-		String versionOutput = null;
-		List<String> infoCommand = new ArrayList<String>();
-		info.setName("file utility");
-		if (osName.startsWith("Windows")) {
-			//use provided Windows File Utility
-			osIsWindows = true;
-			info.setDate(WIN_FILE_DATE);
-			infoCommand.addAll(WIN_COMMAND);
-	        logger.debug("FileUtility will use Windows environment");
+    public FileUtility(Fits fits) throws FitsToolException {
+        super();
+        this.fits = fits;
+        logger.debug("Initializing FileUtility");
+        String osName = System.getProperty("os.name");
+        info = new ToolInfo();
+        String versionOutput = null;
+        List<String> infoCommand = new ArrayList<String>();
+        info.setName("file utility");
+        if (osName.startsWith("Windows")) {
+            // use provided Windows File Utility
+            osIsWindows = true;
+            info.setDate(WIN_FILE_DATE);
+            infoCommand.addAll(WIN_COMMAND);
+            logger.debug("FileUtility will use Windows environment");
 
-		}
-		else if (testOSForCommand()){
-			osHasTool = true;
-			//use file command in operating system
-			infoCommand.addAll(UNIX_COMMAND);
+        } else if (testOSForCommand()) {
+            osHasTool = true;
+            // use file command in operating system
+            infoCommand.addAll(UNIX_COMMAND);
             logger.debug("FileUtility will use system command");
-		}
-
-		else {
-			//Tool cannot be used on this system
-		    logger.error("File Utility cannot be used on this system");
-			throw new FitsToolException("File Utility cannot be used on this system");
-		}
-		infoCommand.add("-v");
-		versionOutput = CommandLine.exec(infoCommand,null);
-		String[] lines = versionOutput.split("\n");
-		String firstLine = lines[0];
-		String[] nameVersion = firstLine.split("-");
-		info.setVersion(nameVersion[nameVersion.length-1].trim());
-		info.setNote(lines[1]);
-
-	}
-
-	public ToolOutput extractInfo(File file) throws FitsToolException {
-	    logger.debug("FileUtility.extractInfo starting");
-		long startTime = System.currentTimeMillis();
-
-		List<String> execCommand = new ArrayList<String>();
-		if (osIsWindows) {
-			//use provided Windows File Utility
-			execCommand.addAll(WIN_COMMAND);
-		} else {
-			//use file command in operating system
-			execCommand.addAll(UNIX_COMMAND);
-		}
-		execCommand.add("-b"); // omit file name in output
-		if(info.getVersion().startsWith("5")) {
-			execCommand.add("-e"); // exclude specified test
-			execCommand.add("cdf"); //  details of Compound Document Files
-		}
-		execCommand.add(file.getPath());
-
-		String execOut = CommandLine.exec(execCommand,null);
-		if(execOut != null && execOut.length() > 0) {
-			execOut = execOut.trim();
-		}
-		else {
-			execOut = "";
-		}
-
-		execCommand.add(1, "--mime"); // options must come before file path
-		String execMimeOut = CommandLine.exec(execCommand,null);
-		if(execMimeOut != null && execMimeOut.length() > 0) {
-			execMimeOut = execMimeOut.trim();
-		}
-		else {
-			execMimeOut = "";
-		}
-
-		String format = null;
-		String mime = null;
-		String charset = null;
-		List<String> linebreaks = new ArrayList<String>();
-
-		//if mime indicates plain text (except if RTF files)
-		if(execMimeOut.startsWith("text/plain") && execMimeOut.contains("charset=") && !execOut.contains("Rich Text Format")) {
-			//mime = "text/plain";
-			mime = execMimeOut.substring(0,execMimeOut.indexOf("; charset="));
-			charset = execMimeOut.substring(execMimeOut.indexOf("=")+1);
-			charset = charset.toUpperCase();
-			/*if(execOut.contains("ASCII text") ||
-					execOut.contains("Unicode text, UTF-32") ||
-					execOut.contains("UTF-8 Unicode") ||
-					execOut.contains("UTF-16 Unicode") ||
-					execOut.contains("Non-ISO extended-ASCII text") ||
-					execOut.contains("ISO-8859")) {
-				format = "Plain text";
-			}*/
-			format = "Plain text";
-
-			Pattern p = Pattern.compile("(.*) with (.*) line terminators");
-			Matcher m = p.matcher(execOut);
-			if(m.matches()) {
-				String endings = m.group(2);
-				String[] breaks = endings.split(",");
-				for(String b : breaks) {
-					if(b.equals("CRLF")) {
-						b = "CR/LF";
-					}
-					linebreaks.add(b);
-				}
-			}
-		}
-		else if (execOut.contains("Rich Text Format") && execMimeOut.contains("charset=")) {
-			format = "Rich Text Format (RTF)";
-			mime = execMimeOut.substring(0,execMimeOut.indexOf("; charset="));
-		}
-		else if(execMimeOut.contains("charset=")) {
-			format = execOut;
-			mime = execMimeOut.substring(0,execMimeOut.indexOf("; charset="));
-		}
-		//else use output for format
-		else {
-			format = execOut;
-			mime = execMimeOut;
-		}
-
-		Document rawOut = createXml(mime,format,charset,linebreaks,execOut+"\n"+execMimeOut);
-		Document fitsXml = transform(xslt,rawOut);
-
-		output = new ToolOutput(this,fitsXml,rawOut, fits);
-
-		duration = System.currentTimeMillis()-startTime;
-		runStatus = RunStatus.SUCCESSFUL;
-        logger.debug("FileUtility.extractInfo finished");
-		return output;
-	}
-
-	public boolean testOSForCommand() throws FitsToolCLIException {
-		String output = CommandLine.exec(FILE_TEST_COMMAND,null);
-		if(output == null || output.length() == 0) {
-			return false;
-		}
-		else {
-			return true;
-		}
-	}
-	private Document createXml(String mime_s, String format_s, String charset_s, List<String> linebreaks, String rawOutput_s) throws FitsToolException {
-		//xml root
-		Element root = new Element("fileUtilityOutput");
-		//rawoutput
-		Element rawOutput = new Element("rawOutput");
-		rawOutput.setText(stripNonValidXMLCharacters(rawOutput_s));
-		root.addContent(rawOutput);
-		//mimetype
-		Element mime = new Element("mimetype");
-		mime.setText(mime_s);
-		root.addContent(mime);
-		//format
-		Element format = new Element("format");
-		format.setText(stripNonValidXMLCharacters(format_s));
-		root.addContent(format);
-		//charset
-		if(charset_s != null) {
-			Element charset = new Element("charset");
-			charset.setText(charset_s);
-			root.addContent(charset);
-		}
-		if(linebreaks.size() > 0) {
-			for(String l : linebreaks) {
-				Element linebreak = new Element("linebreak");
-				linebreak.setText(l);
-				root.addContent(linebreak);
-			}
-		}
-		return new Document(root);
-
+        } else {
+            // Tool cannot be used on this system
+            logger.error("File Utility cannot be used on this system");
+            throw new FitsToolException("File Utility cannot be used on this system");
+        }
+        infoCommand.add("-v");
+        versionOutput = CommandLine.exec(infoCommand, null);
+        String[] lines = versionOutput.split("\n");
+        String firstLine = lines[0];
+        String[] nameVersion = firstLine.split("-");
+        info.setVersion(nameVersion[nameVersion.length - 1].trim());
+        info.setNote(lines[1]);
     }
-	/*
-	public boolean isIdentityKnown(FileIdentity identity) {
-		//identity and mimetype must not be null or empty strings for an identity to be "known"
-		if(identity == null
-				|| identity.getMime() == null
-				|| identity.getMime().length() == 0
-				|| identity.getFormat() == null
-				|| identity.getFormat().length() == 0) {
-			return false;
-		}
-		String format = identity.getFormat();
-		String mime = identity.getMime();
-		if(format.equals("data") || format.equals("Unknown Binary") || mime.equals("application/octet-stream")) {
-			return false;
-		}
-		else {
-			return true;
-		}
-	}
-*/
 
-	public boolean isEnabled() {
-		return enabled;
-	}
+    public ToolOutput extractInfo(File file) throws FitsToolException {
+        logger.debug("FileUtility.extractInfo starting");
+        long startTime = System.currentTimeMillis();
 
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
+        List<String> execCommand = new ArrayList<String>();
+        if (osIsWindows) {
+            // use provided Windows File Utility
+            execCommand.addAll(WIN_COMMAND);
+        } else {
+            // use file command in operating system
+            execCommand.addAll(UNIX_COMMAND);
+        }
+        execCommand.add("-b"); // omit file name in output
+        if (info.getVersion().startsWith("5")) {
+            execCommand.add("-e"); // exclude specified test
+            execCommand.add("cdf"); //  details of Compound Document Files
+        }
+        execCommand.add(file.getPath());
 
-	 public String stripNonValidXMLCharacters(String in) {
-	        StringBuffer out = new StringBuffer(); // Used to hold the output.
-	        char current; // Used to reference the current character.
+        String execOut = CommandLine.exec(execCommand, null);
+        if (execOut != null && execOut.length() > 0) {
+            execOut = execOut.trim();
+        } else {
+            execOut = "";
+        }
 
-	        if (in == null || ("".equals(in))) return ""; // vacancy test.
-	        for (int i = 0; i < in.length(); i++) {
-	            current = in.charAt(i); // NOTE: No IndexOutOfBoundsException caught here; it should not happen.
-	            if ((current == 0x9) ||
-	                (current == 0xA) ||
-	                (current == 0xD) ||
-	                ((current >= 0x20) && (current <= 0xD7FF)) ||
-	                ((current >= 0xE000) && (current <= 0xFFFD)) ||
-	                ((current >= 0x10000) && (current <= 0x10FFFF)))
-	                out.append(current);
-	        }
-	        return out.toString();
-	    }
+        execCommand.add(1, "--mime"); // options must come before file path
+        String execMimeOut = CommandLine.exec(execCommand, null);
+        if (execMimeOut != null && execMimeOut.length() > 0) {
+            execMimeOut = execMimeOut.trim();
+        } else {
+            execMimeOut = "";
+        }
+
+        String format = null;
+        String mime = null;
+        String charset = null;
+        List<String> linebreaks = new ArrayList<String>();
+
+        // if mime indicates plain text (except if RTF files)
+        if (execMimeOut.startsWith("text/plain")
+                && execMimeOut.contains("charset=")
+                && !execOut.contains("Rich Text Format")) {
+            // mime = "text/plain";
+            mime = execMimeOut.substring(0, execMimeOut.indexOf("; charset="));
+            charset = execMimeOut.substring(execMimeOut.indexOf("=") + 1);
+            charset = charset.toUpperCase();
+            /*if(execOut.contains("ASCII text") ||
+            		execOut.contains("Unicode text, UTF-32") ||
+            		execOut.contains("UTF-8 Unicode") ||
+            		execOut.contains("UTF-16 Unicode") ||
+            		execOut.contains("Non-ISO extended-ASCII text") ||
+            		execOut.contains("ISO-8859")) {
+            	format = "Plain text";
+            }*/
+            format = "Plain text";
+
+            Pattern p = Pattern.compile("(.*) with (.*) line terminators");
+            Matcher m = p.matcher(execOut);
+            if (m.matches()) {
+                String endings = m.group(2);
+                String[] breaks = endings.split(",");
+                for (String b : breaks) {
+                    if (b.equals("CRLF")) {
+                        b = "CR/LF";
+                    }
+                    linebreaks.add(b);
+                }
+            }
+        } else if (execOut.contains("Rich Text Format") && execMimeOut.contains("charset=")) {
+            format = "Rich Text Format (RTF)";
+            mime = execMimeOut.substring(0, execMimeOut.indexOf("; charset="));
+        } else if (execMimeOut.contains("charset=")) {
+            format = execOut;
+            mime = execMimeOut.substring(0, execMimeOut.indexOf("; charset="));
+        }
+        // else use output for format
+        else {
+            format = execOut;
+            mime = execMimeOut;
+        }
+
+        Document rawOut = createXml(mime, format, charset, linebreaks, execOut + "\n" + execMimeOut);
+        Document fitsXml = transform(xslt, rawOut);
+
+        output = new ToolOutput(this, fitsXml, rawOut, fits);
+
+        duration = System.currentTimeMillis() - startTime;
+        runStatus = RunStatus.SUCCESSFUL;
+        logger.debug("FileUtility.extractInfo finished");
+        return output;
+    }
+
+    public boolean testOSForCommand() throws FitsToolCLIException {
+        String output = CommandLine.exec(FILE_TEST_COMMAND, null);
+        if (output == null || output.length() == 0) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private Document createXml(
+            String mime_s, String format_s, String charset_s, List<String> linebreaks, String rawOutput_s)
+            throws FitsToolException {
+        // xml root
+        Element root = new Element("fileUtilityOutput");
+        // rawoutput
+        Element rawOutput = new Element("rawOutput");
+        rawOutput.setText(stripNonValidXMLCharacters(rawOutput_s));
+        root.addContent(rawOutput);
+        // mimetype
+        Element mime = new Element("mimetype");
+        mime.setText(mime_s);
+        root.addContent(mime);
+        // format
+        Element format = new Element("format");
+        format.setText(stripNonValidXMLCharacters(format_s));
+        root.addContent(format);
+        // charset
+        if (charset_s != null) {
+            Element charset = new Element("charset");
+            charset.setText(charset_s);
+            root.addContent(charset);
+        }
+        if (linebreaks.size() > 0) {
+            for (String l : linebreaks) {
+                Element linebreak = new Element("linebreak");
+                linebreak.setText(l);
+                root.addContent(linebreak);
+            }
+        }
+        return new Document(root);
+    }
+    /*
+    	public boolean isIdentityKnown(FileIdentity identity) {
+    		//identity and mimetype must not be null or empty strings for an identity to be "known"
+    		if(identity == null
+    				|| identity.getMime() == null
+    				|| identity.getMime().length() == 0
+    				|| identity.getFormat() == null
+    				|| identity.getFormat().length() == 0) {
+    			return false;
+    		}
+    		String format = identity.getFormat();
+    		String mime = identity.getMime();
+    		if(format.equals("data") || format.equals("Unknown Binary") || mime.equals("application/octet-stream")) {
+    			return false;
+    		}
+    		else {
+    			return true;
+    		}
+    	}
+    */
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
+
+    public String stripNonValidXMLCharacters(String in) {
+        StringBuffer out = new StringBuffer(); // Used to hold the output.
+        char current; // Used to reference the current character.
+
+        if (in == null || ("".equals(in))) return ""; // vacancy test.
+        for (int i = 0; i < in.length(); i++) {
+            current = in.charAt(i); // NOTE: No IndexOutOfBoundsException caught here; it should not happen.
+            if ((current == 0x9)
+                    || (current == 0xA)
+                    || (current == 0xD)
+                    || ((current >= 0x20) && (current <= 0xD7FF))
+                    || ((current >= 0xE000) && (current <= 0xFFFD))
+                    || ((current >= 0x10000) && (current <= 0x10FFFF))) out.append(current);
+        }
+        return out.toString();
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/AudioMethods.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/AudioMethods.java
@@ -8,40 +8,39 @@
 // See the License for the specific language governing permission and limitations under the License.
 //
 
-
 package edu.harvard.hul.ois.fits.tools.mediainfo;
 
 public enum AudioMethods {
-	delay ("delay"),
-	numSamples ("numSamples"),
-	bitRate ("bitRate"),
-	codecId ("codecId"),
-	codeFamily ("codecFamily"),
-	duration ("duration"),
-	trackSize ("trackSize"),
-	samplingRate ("samplingRate"),
-	channels ("channels"),
-	soundField ("soundField"),
-	byteOrder ("byteOrder");
+    delay("delay"),
+    numSamples("numSamples"),
+    bitRate("bitRate"),
+    codecId("codecId"),
+    codeFamily("codecFamily"),
+    duration("duration"),
+    trackSize("trackSize"),
+    samplingRate("samplingRate"),
+    channels("channels"),
+    soundField("soundField"),
+    byteOrder("byteOrder");
 
-	private String name;
+    private String name;
 
-	AudioMethods(String name) {
+    AudioMethods(String name) {
         this.name = name;
     }
 
-    public String getName () {
+    public String getName() {
         return name;
     }
 
-    static public AudioMethods lookup(String name) {
-    	AudioMethods retMethod = null;
-    	for(AudioMethods method : AudioMethods.values()) {
-    		if (method.getName().equals(name)) {
-    			retMethod = method;
-    			break;
-    		}
-    	}
-    	return retMethod;
+    public static AudioMethods lookup(String name) {
+        AudioMethods retMethod = null;
+        for (AudioMethods method : AudioMethods.values()) {
+            if (method.getName().equals(name)) {
+                retMethod = method;
+                break;
+            }
+        }
+        return retMethod;
     }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/ChannelPositionWrapper.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/ChannelPositionWrapper.java
@@ -8,27 +8,38 @@
 // See the License for the specific language governing permission and limitations under the License.
 //
 
-
 package edu.harvard.hul.ois.fits.tools.mediainfo;
 
 public class ChannelPositionWrapper {
 
-	private String name;
-	private int xPos;
-	private int yPos;
+    private String name;
+    private int xPos;
+    private int yPos;
 
-	public ChannelPositionWrapper(String name, int xPos, int yPos) {
-		this.name=name;
-		this.xPos=xPos;
-		this.yPos=yPos;
-	}
+    public ChannelPositionWrapper(String name, int xPos, int yPos) {
+        this.name = name;
+        this.xPos = xPos;
+        this.yPos = yPos;
+    }
 
-	public String getName() {return name;}
-	public int getXpos() {return xPos;}
-	public int getYpos() {return yPos;}
+    public String getName() {
+        return name;
+    }
 
-	//void setName(String name) {this.name=name;}
-	public void setXpos(int xPos) {this.xPos=xPos;}
-	public void setYpos(int yPos) {this.yPos=yPos;}
+    public int getXpos() {
+        return xPos;
+    }
 
+    public int getYpos() {
+        return yPos;
+    }
+
+    // void setName(String name) {this.name=name;}
+    public void setXpos(int xPos) {
+        this.xPos = xPos;
+    }
+
+    public void setYpos(int yPos) {
+        this.yPos = yPos;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/ElementsToNormalize.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/ElementsToNormalize.java
@@ -8,38 +8,36 @@
 // See the License for the specific language governing permission and limitations under the License.
 //
 
-
 package edu.harvard.hul.ois.fits.tools.mediainfo;
 
 public enum ElementsToNormalize {
-	height ("height", " pixels"),
-	width ("width", " pixels");
+    height("height", " pixels"),
+    width("width", " pixels");
 
-	private String name;
-	private String unitsToAdd;
+    private String name;
+    private String unitsToAdd;
 
-	ElementsToNormalize(String name, String unitsToAdd) {
+    ElementsToNormalize(String name, String unitsToAdd) {
         this.unitsToAdd = unitsToAdd;
         this.name = name;
     }
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 
     public String getUnits() {
         return unitsToAdd;
     }
 
-    static public ElementsToNormalize lookup(String name) {
-    	ElementsToNormalize retMethod = null;
-    	for(ElementsToNormalize method : ElementsToNormalize.values()) {
-    		if (method.getName().equals(name)) {
-    			retMethod = method;
-    			break;
-    		}
-    	}
-    	return retMethod;
+    public static ElementsToNormalize lookup(String name) {
+        ElementsToNormalize retMethod = null;
+        for (ElementsToNormalize method : ElementsToNormalize.values()) {
+            if (method.getName().equals(name)) {
+                retMethod = method;
+                break;
+            }
+        }
+        return retMethod;
     }
-
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfo.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfo.java
@@ -10,260 +10,257 @@
 
 package edu.harvard.hul.ois.fits.tools.mediainfo;
 
-import java.io.File;
-import java.io.StringReader;
-import java.util.Map;
-
-import org.jdom2.Document;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
 import edu.harvard.hul.ois.fits.tools.ToolBase;
 import edu.harvard.hul.ois.fits.tools.ToolInfo;
 import edu.harvard.hul.ois.fits.tools.ToolOutput;
+import java.io.File;
+import java.io.StringReader;
+import java.util.Map;
+import org.jdom2.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**  The glue class for invoking the MediaInfo native library under FITS.
  */
 public class MediaInfo extends ToolBase {
 
-	private final static String TOOL_NAME = "MediaInfo";
-	private boolean enabled = true;
+    private static final String TOOL_NAME = "MediaInfo";
+    private boolean enabled = true;
     private Fits fits;
 
-    private final static String mediaInfoFitsConfig = Fits.FITS_XML_DIR+"mediainfo"+File.separator;
-    private final static String xsltTransform = "mediainfo_video_to_fits.xslt";
-    private final static String WINDOWS_NATIVE_LIB_PATH = "tools" + File.separator + "mediainfo" + File.separator + "windows" + File.separator + "64";
-    private final static String OSX_NATIVE_LIB_PATH = "tools" + File.separator + "mediainfo" + File.separator + "mac";
-    private final static String LINUX_NATIVE_LIB_PATH = "tools" + File.separator + "mediainfo" + File.separator + "linux";
+    private static final String mediaInfoFitsConfig = Fits.FITS_XML_DIR + "mediainfo" + File.separator;
+    private static final String xsltTransform = "mediainfo_video_to_fits.xslt";
+    private static final String WINDOWS_NATIVE_LIB_PATH =
+            "tools" + File.separator + "mediainfo" + File.separator + "windows" + File.separator + "64";
+    private static final String OSX_NATIVE_LIB_PATH = "tools" + File.separator + "mediainfo" + File.separator + "mac";
+    private static final String LINUX_NATIVE_LIB_PATH =
+            "tools" + File.separator + "mediainfo" + File.separator + "linux";
 
-	private static final Logger logger = LoggerFactory.getLogger(MediaInfo.class);
+    private static final Logger logger = LoggerFactory.getLogger(MediaInfo.class);
     private static MediaInfoNativeWrapper mi = null;
 
     /**
      * Instantiate this class.
      * Since this class is instantiated via Java Reflection, any exception
      * in this constructor will actually result in a InstantiationException, nto a FitsToolException.
-     * 
+     *
      * @param fits
      * @throws FitsToolException
      */
-	public MediaInfo(Fits fits) throws FitsToolException {
-		super();
-		this.fits = fits;
-		info = new ToolInfo();
-		info.setName(TOOL_NAME);
+    public MediaInfo(Fits fits) throws FitsToolException {
+        super();
+        this.fits = fits;
+        info = new ToolInfo();
+        info.setName(TOOL_NAME);
 
-		String fitsHome = Fits.FITS_HOME; // this will always have a trailing slash if not empty
-		String nativeLibPath = "";
+        String fitsHome = Fits.FITS_HOME; // this will always have a trailing slash if not empty
+        String nativeLibPath = "";
 
-		// Set the JNA library path based upon the OS
-		OsCheck.OSType ostype=OsCheck.getOperatingSystemType();
-		switch (ostype) {
-		    case Windows:
-		    	// default setting
-		    	if(fitsHome.equals(".")) {
-		    		fitsHome = System.getProperty("user.dir");
-		    	}
-		    	// Assume both a 64-bit operating system AND Java version, so default to 64-bit DLL location.
-		    	// 32 bit is not supported so pointing to 64-bit DLL will likely result in an error.
-		    	nativeLibPath = fitsHome + WINDOWS_NATIVE_LIB_PATH;
-		    	break;
-		    case MacOS:
-	    		nativeLibPath = fitsHome + OSX_NATIVE_LIB_PATH;
-	    		break;
-		    case Linux:
-		    	nativeLibPath = fitsHome + LINUX_NATIVE_LIB_PATH;
-		    	break;
-		    case Other:
-		    	logger.warn("Unsupported native support in MediaInfo for this OS");
-		    	break;
-		}
+        // Set the JNA library path based upon the OS
+        OsCheck.OSType ostype = OsCheck.getOperatingSystemType();
+        switch (ostype) {
+            case Windows:
+                // default setting
+                if (fitsHome.equals(".")) {
+                    fitsHome = System.getProperty("user.dir");
+                }
+                // Assume both a 64-bit operating system AND Java version, so default to 64-bit DLL location.
+                // 32 bit is not supported so pointing to 64-bit DLL will likely result in an error.
+                nativeLibPath = fitsHome + WINDOWS_NATIVE_LIB_PATH;
+                break;
+            case MacOS:
+                nativeLibPath = fitsHome + OSX_NATIVE_LIB_PATH;
+                break;
+            case Linux:
+                nativeLibPath = fitsHome + LINUX_NATIVE_LIB_PATH;
+                break;
+            case Other:
+                logger.warn("Unsupported native support in MediaInfo for this OS");
+                break;
+        }
 
-		try {
-			System.setProperty("jna.library.path", nativeLibPath);
-		    String versionOutput = MediaInfoNativeWrapper.Option_Static("Info_Version");
-		    // Strip "MediaInfoLib - v" from the version
-		    info.setVersion(versionOutput.replace("MediaInfoLib - v",""));
+        try {
+            System.setProperty("jna.library.path", nativeLibPath);
+            String versionOutput = MediaInfoNativeWrapper.Option_Static("Info_Version");
+            // Strip "MediaInfoLib - v" from the version
+            info.setVersion(versionOutput.replace("MediaInfoLib - v", ""));
 
-		    // Initialize the native library 
-		    mi = new MediaInfoNativeWrapper();
+            // Initialize the native library
+            mi = new MediaInfoNativeWrapper();
 
-		} catch (Throwable e){
-			String jvmModel =  System.getProperty("sun.arch.data.model");
-			logger.error("Error loading native library for this operating system for tool: " + TOOL_NAME +
-					". ostype=[" + ostype + "] -- jvmModel=[" + jvmModel + "] -- nativeLibPath=[" + nativeLibPath + "]" +
-					(nativeLibPath.length() == 0 ? "" : " -- No native MediaInfo library for this OS"), e);
-			throw new FitsToolException();
-		}
+        } catch (Throwable e) {
+            String jvmModel = System.getProperty("sun.arch.data.model");
+            logger.error(
+                    "Error loading native library for this operating system for tool: " + TOOL_NAME + ". ostype=["
+                            + ostype + "] -- jvmModel=[" + jvmModel + "] -- nativeLibPath=[" + nativeLibPath + "]"
+                            + (nativeLibPath.length() == 0 ? "" : " -- No native MediaInfo library for this OS"),
+                    e);
+            throw new FitsToolException();
+        }
+    }
 
-	}
+    @Override
+    public ToolOutput extractInfo(File file) throws FitsToolException {
 
-	@Override
-	public ToolOutput extractInfo(File file) throws FitsToolException {
+        logger.debug("MediaInfo.extractInfo starting on " + file.getName());
+        long startTime = System.currentTimeMillis();
 
-	   logger.debug("MediaInfo.extractInfo starting on " + file.getName());
-	   long startTime = System.currentTimeMillis();
+        // TODO: should we initialize the library via a static block?
+        // Initialize the library
+        // MediaInfoViaJNA mi = new MediaInfoViaJNA();
 
-		// TODO: should we initialize the library via a static block?
-	    // Initialize the library
-	    // MediaInfoViaJNA mi = new MediaInfoViaJNA();
+        // Open the file with mediainfo native library
+        try {
+            if (!(mi.Open(file.getCanonicalPath()) > 0)) {
+                throw new FitsToolException("Error opening " + file.getName());
+            }
+        } catch (Exception e) {
+            throw new FitsToolException("Error opening " + file.getName(), e);
+        }
 
-	    // Open the file with mediainfo native library
-		try {
-		    if (!(mi.Open(file.getCanonicalPath())>0)) {
-		    	throw new FitsToolException("Error opening " + file.getName());
-			}
-	    } catch (Exception e) {
-		    throw new FitsToolException("Error opening " + file.getName() ,e);
-	    }
+        // --------------------------------------------------------------------
+        // OUTPUT Options for the Native MediaInfo Library are:
+        // 		(From MediaInfo_Inform.cpp)
+        //
+        // NOTE: Default is Text - when no options set
+        //
+        // "EBUCore"
+        // "EBUCore_1.5"
+        //
+        // "MPEG-7"
+        //
+        // "PBCore"
+        // "PBCore_1.2"
+        // "PBCore2"
+        // "PBCore_2.0"
+        //
+        // NOTE: "reVTMD is disabled due to its non-free licensing
+        //
+        // XML
+        // HTML
+        // CSV
+        //
+        // Separate details are available via the API on various data types/tracks
+        //
+        //	     "General"
+        //	     "Video"
+        //	     "Audio"
+        //	     "Text"
+        //	     "Chapters"
+        //	     "Image"
+        //	     "Menu"
+        // --------------------------------------------------------------------
+        //
+        // No format, so output is pure text
+        // String textOutput = mi.Inform();
+        // System.out.println("\nTEXT:\n" + textOutput);
+        //
+        // Set the option:
+        // Complete details
+        // mi.Option("Complete", "1");
+        //
+        //// Complete = false, use a subset
+        // mi.Option("Complete", "");
 
-	    // --------------------------------------------------------------------
-	    // OUTPUT Options for the Native MediaInfo Library are:
-	    // 		(From MediaInfo_Inform.cpp)
-	    //
-		// NOTE: Default is Text - when no options set
-		//
-	    // "EBUCore"
-	    // "EBUCore_1.5"
-	    //
-	    // "MPEG-7"
-	    //
-	    // "PBCore"
-	    // "PBCore_1.2"
-	    // "PBCore2"
-	    // "PBCore_2.0"
-	    //
-	    // NOTE: "reVTMD is disabled due to its non-free licensing
-	    //
-	    // XML
-	    // HTML
-	    // CSV
-	    //
-	    // Separate details are available via the API on various data types/tracks
-	    //
-	    //	     "General"
-	    //	     "Video"
-	    //	     "Audio"
-	    //	     "Text"
-	    //	     "Chapters"
-	    //	     "Image"
-	    //	     "Menu"
-	    // --------------------------------------------------------------------
-		//
-		// No format, so output is pure text
-		// String textOutput = mi.Inform();
-		// System.out.println("\nTEXT:\n" + textOutput);
-		//
-	    // Set the option:
-	    // Complete details
-	    // mi.Option("Complete", "1");
-	    //
-	    //// Complete = false, use a subset
-	    //mi.Option("Complete", "");
+        // Get MediaInfoLib Output as standard RAW XML
+        mi.Option("Complete", "1");
+        mi.Option("Output", "OLDXML");
+        String execOutRaw = mi.Inform();
 
-	    // Get MediaInfoLib Output as standard RAW XML
-	    mi.Option("Complete", "1");
-	    mi.Option("Output", "OLDXML");
-	    String execOutRaw = mi.Inform();
+        // DEBUG
+        // System.out.println("\nMediaInfo RAW output:\n" + execOutRaw + "\n\n");
 
-	    // DEBUG
-	    // System.out.println("\nMediaInfo RAW output:\n" + execOutRaw + "\n\n");
+        // Get MediaInfoLib Output as standard XML
+        mi.Option("Complete", "");
+        mi.Option("Output", "OLDXML");
+        String execOut = mi.Inform();
 
-	    // Get MediaInfoLib Output as standard XML
-	    mi.Option("Complete", "");
-	    mi.Option("Output", "OLDXML");
-	    String execOut = mi.Inform();
+        //// Get MediaInfoLib Output as EBUCore 1.5
+        // mi.Option("Output", "EBUCore_1.5");
+        // String ebuOut = mi.Inform();;
 
-	    //// Get MediaInfoLib Output as EBUCore 1.5
-	    //mi.Option("Output", "EBUCore_1.5");
-	    //String ebuOut = mi.Inform();;
+        // DEBUG
+        // System.out.println("\nMediaInfo output:\n" + execOut + "\n\n");
 
-	    // DEBUG
-	    // System.out.println("\nMediaInfo output:\n" + execOut + "\n\n");
+        // --------------------------------------------------------------------
+        // Retrieve additional information for audio/video tracks not contained
+        // in the general XML
+        // --------------------------------------------------------------------
+        MediaInfoUtil mutil = new MediaInfoUtil(mi);
 
-	    // --------------------------------------------------------------------
-	    // Retrieve additional information for audio/video tracks not contained
-	    // in the general XML
-	    // --------------------------------------------------------------------
-	    MediaInfoUtil mutil = new MediaInfoUtil(mi);
+        // Maps to hold data that are obtained via explicit MediaInfo API call.
+        // These values are either not exposed in the XML returned by the Inform()
+        // method call, or if the granularity of the value is not correct, such as
+        // bitRate not returning the value as milliseconds, but rather as Mpbs
+        Map<String, String> generalValuesDataMap = mutil.loadGeneralDataMap();
+        Map<String, Map<String, String>> videoTrackValuesMap = mutil.loadVideoDataMap(generalValuesDataMap);
+        Map<String, Map<String, String>> audioTrackValuesMap = mutil.loadAudioDataMap();
 
-	    // Maps to hold data that are obtained via explicit MediaInfo API call.
-	    // These values are either not exposed in the XML returned by the Inform()
-	    // method call, or if the granularity of the value is not correct, such as
-	    // bitRate not returning the value as milliseconds, but rather as Mpbs
-	    Map<String, String> generalValuesDataMap = mutil.loadGeneralDataMap();
-	    Map<String, Map<String, String>> videoTrackValuesMap =
-	    		mutil.loadVideoDataMap (generalValuesDataMap);
-	    Map<String, Map<String, String>> audioTrackValuesMap =
-	    		mutil.loadAudioDataMap ();
+        mi.Close();
 
-	    mi.Close();
+        // ====================================================================
+        // Create a Document out of the generated XML text
+        // And transform via XSLT
+        // ====================================================================
+        Document outputMetaDoc = createXml(execOut);
+        Document rawOut = createXml(execOutRaw);
 
-		// ====================================================================
-	    // Create a Document out of the generated XML text
-	    // And transform via XSLT
-		// ====================================================================
-		Document outputMetaDoc = createXml(execOut);
-		Document rawOut = createXml(execOutRaw);
+        Document fitsXml = transform(mediaInfoFitsConfig + xsltTransform, outputMetaDoc);
 
-		Document fitsXml = transform(mediaInfoFitsConfig+xsltTransform,outputMetaDoc);
+        //		//
+        //		// DEBUG - write xml to file
+        //		//
+        //		try {
+        //			XMLOutputter xmlOutput = new XMLOutputter();
+        //
+        //			// display nice nice
+        //			xmlOutput.setFormat(Format.getPrettyFormat());
+        //			xmlOutput.output(fitsXml, new FileWriter("fitsxml_so_far.xml"));
+        //		} catch (IOException e) {
+        //			e.printStackTrace();
+        //		}
 
-//		//
-//		// DEBUG - write xml to file
-//		//
-//		try {
-//			XMLOutputter xmlOutput = new XMLOutputter();
-//
-//			// display nice nice
-//			xmlOutput.setFormat(Format.getPrettyFormat());
-//			xmlOutput.output(fitsXml, new FileWriter("fitsxml_so_far.xml"));
-//		} catch (IOException e) {
-//			e.printStackTrace();
-//		}
+        // Revise the XML to include element data that was not returned either
+        // via the MediaInfo XML or require revision for granularity
+        mutil.reviseXmlData(fitsXml, videoTrackValuesMap, audioTrackValuesMap, generalValuesDataMap);
 
-		// Revise the XML to include element data that was not returned either
-		// via the MediaInfo XML or require revision for granularity
-		mutil.reviseXmlData (fitsXml, videoTrackValuesMap, audioTrackValuesMap,
-				generalValuesDataMap);
+        mutil.removeEmptyElements(fitsXml);
 
-		mutil.removeEmptyElements(fitsXml);
+        // DEBUG
+        // String finalXml = new XMLOutputter(Format.getPrettyFormat()).outputString(fitsXml);
+        // System.out.println("\nFINAL XML:\n" + finalXml);
 
-		// DEBUG
-		// String finalXml = new XMLOutputter(Format.getPrettyFormat()).outputString(fitsXml);
-		// System.out.println("\nFINAL XML:\n" + finalXml);
+        output = new ToolOutput(this, fitsXml, rawOut, fits);
 
-		output = new ToolOutput(this,fitsXml,rawOut, fits);
+        // DEBUG
+        // String fitsOutputString = new XMLOutputter(Format.getPrettyFormat()).outputString(output.getFitsXml());
 
-		// DEBUG
-		// String fitsOutputString = new XMLOutputter(Format.getPrettyFormat()).outputString(output.getFitsXml());
-
-		duration = System.currentTimeMillis()-startTime;
-		runStatus = RunStatus.SUCCESSFUL;
+        duration = System.currentTimeMillis() - startTime;
+        runStatus = RunStatus.SUCCESSFUL;
         logger.debug("MediaInfo.extractInfo finished on " + file.getName());
 
-		return output;
-	}
+        return output;
+    }
 
-	private Document createXml(String out) throws FitsToolException {
+    private Document createXml(String out) throws FitsToolException {
         Document doc = null;
-		try {
-			doc = saxBuilder.build(new StringReader(out));
-		} catch (Exception e) {
-			throw new FitsToolException("Error parsing Mediainfo XML Output",e);
-		}
+        try {
+            doc = saxBuilder.build(new StringReader(out));
+        } catch (Exception e) {
+            throw new FitsToolException("Error parsing Mediainfo XML Output", e);
+        }
         return doc;
     }
 
-	@Override
-	public boolean isEnabled() {
-		return enabled;
-	}
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
 
-	@Override
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
-
+    @Override
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoNativeWrapper.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoNativeWrapper.java
@@ -1,15 +1,15 @@
 /*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
-*
-*  Use of this source code is governed by a BSD-style license that can
-*  be found in the License.html file in the root of the source tree.
-*/
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
 
-//Note: the original stuff was well packaged with Java style,
-//but I (the main developer) prefer to keep an easiest for me
-//way to have all sources and example in the same place
-//Removed stuff:
-//"package net.sourceforge.mediainfo;"
-//directory was /net/sourceforge/mediainfo
+// Note: the original stuff was well packaged with Java style,
+// but I (the main developer) prefer to keep an easiest for me
+// way to have all sources and example in the same place
+// Removed stuff:
+// "package net.sourceforge.mediainfo;"
+// directory was /net/sourceforge/mediainfo
 
 // The original file was modified as follows for use in the File Information Tool Set (FITS) project:
 //
@@ -22,18 +22,18 @@
 
 // License text from the MediaInfo license.html file and https://mediaarea.net/en/License
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS 
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
-// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 // EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package edu.harvard.hul.ois.fits.tools.mediainfo;
 
 import static java.util.Collections.singletonMap;
-
-import java.lang.reflect.Method;
 
 import com.sun.jna.FunctionMapper;
 import com.sun.jna.Library;
@@ -41,414 +41,407 @@ import com.sun.jna.Native;
 import com.sun.jna.NativeLibrary;
 import com.sun.jna.Pointer;
 import com.sun.jna.WString;
+import java.lang.reflect.Method;
 
-class MediaInfoNativeWrapper
-{
-   static String LibraryPath="mediainfo";
-   static
-   {
-       // libmediainfo for linux depends on libzen
-       try
-       {
-           // We need to load dependencies first, because we know where our native libs are (e.g. Java Web Start Cache).
-           // If we do not, the system will look for dependencies, but only in the library path.
-           String os=System.getProperty("os.name");
-           if (os!=null && !os.toLowerCase().startsWith("windows") && !os.toLowerCase().startsWith("mac"))
-           {
-               final ClassLoader loader=MediaInfoNativeWrapper.class.getClassLoader();
-               final String LocalPath;
-               if (loader!=null)
-               {
-                   LocalPath=loader.getResource(MediaInfoNativeWrapper.class.getName().replace('.', '/')+ ".class").getPath().replace("MediaInfoNativeWrapper.class", "");
-                   try
-                   {
-                       NativeLibrary.getInstance(LocalPath+"libzen.so.0"); // Local path
-                   }
-                   catch (LinkageError e)
-                   {
-                       NativeLibrary.getInstance("zen"); // Default path
-                   }
-               }
-               else
-               {
-                   LocalPath="";
-                   NativeLibrary.getInstance("zen"); // Default path
-               }
-               if (LocalPath.length()>0)
-               {
-                   try
-                   {
-                       NativeLibrary.getInstance(LocalPath+"libmediainfo.so.0"); // Local path
-                       LibraryPath=LocalPath+"libmediainfo.so.0";
-                   }
-                   catch (LinkageError e)
-                   {
-                       NativeLibrary.getInstance("mediainfo");
-                   }
-               }
-           }
-       }
-       catch (LinkageError  e)
-       {
-           //Logger.getLogger(MediaInfo.class.getName()).warning("Failed to preload libzen");
-       }
-   }
+class MediaInfoNativeWrapper {
+    static String LibraryPath = "mediainfo";
 
-   //Internal stuff
-   interface MediaInfoDLL_Internal extends Library
-   {
+    static {
+        // libmediainfo for linux depends on libzen
+        try {
+            // We need to load dependencies first, because we know where our native libs are (e.g. Java Web Start
+            // Cache).
+            // If we do not, the system will look for dependencies, but only in the library path.
+            String os = System.getProperty("os.name");
+            if (os != null
+                    && !os.toLowerCase().startsWith("windows")
+                    && !os.toLowerCase().startsWith("mac")) {
+                final ClassLoader loader = MediaInfoNativeWrapper.class.getClassLoader();
+                final String LocalPath;
+                if (loader != null) {
+                    LocalPath = loader.getResource(
+                                    MediaInfoNativeWrapper.class.getName().replace('.', '/') + ".class")
+                            .getPath()
+                            .replace("MediaInfoNativeWrapper.class", "");
+                    try {
+                        NativeLibrary.getInstance(LocalPath + "libzen.so.0"); // Local path
+                    } catch (LinkageError e) {
+                        NativeLibrary.getInstance("zen"); // Default path
+                    }
+                } else {
+                    LocalPath = "";
+                    NativeLibrary.getInstance("zen"); // Default path
+                }
+                if (LocalPath.length() > 0) {
+                    try {
+                        NativeLibrary.getInstance(LocalPath + "libmediainfo.so.0"); // Local path
+                        LibraryPath = LocalPath + "libmediainfo.so.0";
+                    } catch (LinkageError e) {
+                        NativeLibrary.getInstance("mediainfo");
+                    }
+                }
+            }
+        } catch (LinkageError e) {
+            // Logger.getLogger(MediaInfo.class.getName()).warning("Failed to preload libzen");
+        }
+    }
 
-       MediaInfoDLL_Internal INSTANCE = Native.load(LibraryPath, MediaInfoDLL_Internal.class, singletonMap(OPTION_FUNCTION_MAPPER, new FunctionMapper() {
-               @Override
-               public String getFunctionName(NativeLibrary lib, Method method) {
-                   return "MediaInfo_" + method.getName();
-               }
-           }
-       ));
+    // Internal stuff
+    interface MediaInfoDLL_Internal extends Library {
 
+        MediaInfoDLL_Internal INSTANCE = Native.load(
+                LibraryPath, MediaInfoDLL_Internal.class, singletonMap(OPTION_FUNCTION_MAPPER, new FunctionMapper() {
+                    @Override
+                    public String getFunctionName(NativeLibrary lib, Method method) {
+                        return "MediaInfo_" + method.getName();
+                    }
+                }));
 
-       //Constructor/Destructor
-       Pointer New();
-       void Delete(Pointer Handle);
+        // Constructor/Destructor
+        Pointer New();
 
-       //File
-       int Open(Pointer Handle, WString file);
-       int Open_Buffer_Init(Pointer handle, long length, long offset);
-       int Open_Buffer_Continue(Pointer handle, byte[] buffer, int size);
-       long Open_Buffer_Continue_GoTo_Get(Pointer handle);
-       int Open_Buffer_Finalize(Pointer handle);
-       void Close(Pointer Handle);
+        void Delete(Pointer Handle);
 
-       //Infos
-       WString Inform(Pointer Handle, int Reserved);
-       WString Get(Pointer Handle, int StreamKind, int StreamNumber, WString parameter, int infoKind, int searchKind);
-       WString GetI(Pointer Handle, int StreamKind, int StreamNumber, int parameterIndex, int infoKind);
-       int     Count_Get(Pointer Handle, int StreamKind, int StreamNumber);
+        // File
+        int Open(Pointer Handle, WString file);
 
-       //Options
-       WString Option(Pointer Handle, WString option, WString value);
-   }
-   private Pointer Handle;
+        int Open_Buffer_Init(Pointer handle, long length, long offset);
 
-   public enum StreamKind {
-       General,
-       Video,
-       Audio,
-       Text,
-       Other,
-       Image,
-       Menu;
-   }
+        int Open_Buffer_Continue(Pointer handle, byte[] buffer, int size);
 
-   //Enums
-   public enum InfoKind {
-       /**
-        * Unique name of parameter.
-        */
-       Name,
+        long Open_Buffer_Continue_GoTo_Get(Pointer handle);
 
-       /**
-        * Value of parameter.
-        */
-       Text,
+        int Open_Buffer_Finalize(Pointer handle);
 
-       /**
-        * Unique name of measure unit of parameter.
-        */
-       Measure,
+        void Close(Pointer Handle);
 
-       Options,
+        // Infos
+        WString Inform(Pointer Handle, int Reserved);
 
-       /**
-        * Translated name of parameter.
-        */
-       Name_Text,
+        WString Get(Pointer Handle, int StreamKind, int StreamNumber, WString parameter, int infoKind, int searchKind);
 
-       /**
-        * Translated name of measure unit.
-        */
-       Measure_Text,
+        WString GetI(Pointer Handle, int StreamKind, int StreamNumber, int parameterIndex, int infoKind);
 
-       /**
-        * More information about the parameter.
-        */
-       Info,
+        int Count_Get(Pointer Handle, int StreamKind, int StreamNumber);
 
-       /**
-        * How this parameter is supported, could be N (No), B (Beta), R (Read only), W
-        * (Read/Write).
-        */
-       HowTo,
+        // Options
+        WString Option(Pointer Handle, WString option, WString value);
+    }
 
-       /**
-        * Domain of this piece of information.
-        */
-       Domain;
-   }
+    private Pointer Handle;
 
-   public enum Status {
-       None        (0x00),
-       Accepted    (0x01),
-       Filled      (0x02),
-       Updated     (0x04),
-       Finalized   (0x08);
-       
-       private int value;
-       private Status(int value) {this.value = value;}
-       public  int getValue(int value) {return value;}
-   }
+    public enum StreamKind {
+        General,
+        Video,
+        Audio,
+        Text,
+        Other,
+        Image,
+        Menu;
+    }
 
-   //Constructor/Destructor
-   public MediaInfoNativeWrapper()
-   {
-       Handle = MediaInfoDLL_Internal.INSTANCE.New();
-   }
+    // Enums
+    public enum InfoKind {
+        /**
+         * Unique name of parameter.
+         */
+        Name,
 
-    public void dispose()
-   {
-       if (Handle == null)
-           throw new IllegalStateException();
+        /**
+         * Value of parameter.
+         */
+        Text,
 
-       MediaInfoDLL_Internal.INSTANCE.Delete(Handle);
-       Handle = null;
-   }
+        /**
+         * Unique name of measure unit of parameter.
+         */
+        Measure,
 
-   @Override
-   protected void finalize() throws Throwable
-   {
-       if (Handle != null)
-           dispose();
-   }
+        Options,
 
-   //File
-   /**
-    * Open a file and collect information about it (technical information and tags).
-    *
-    * @param file full name of the file to open
-    * @return 1 if file was opened, 0 if file was not not opened
-    */
-   public int Open(String File_Name)
-   {
-       return MediaInfoDLL_Internal.INSTANCE.Open(Handle, new WString(File_Name));
-   }
+        /**
+         * Translated name of parameter.
+         */
+        Name_Text,
 
-	public int Open_Buffer_Init(long length, long offset)
-   {
-       return MediaInfoDLL_Internal.INSTANCE.Open_Buffer_Init(Handle, length, offset);
-   }
+        /**
+         * Translated name of measure unit.
+         */
+        Measure_Text,
 
-	/**
-	 *  Open a stream and collect information about it (technical information and tags) (By buffer, Continue)
+        /**
+         * More information about the parameter.
+         */
+        Info,
 
-	 * @param buffer pointer to the stream
-	 * @param size Count of bytes to read
-	 * @return a bitfield 
-				bit 0: Is Accepted (format is known) 
-				bit 1: Is Filled (main data is collected) 
-				bit 2: Is Updated (some data have beed updated, example: duration for a real time MPEG-TS stream) 
-				bit 3: Is Finalized (No more data is needed, will not use further data) 
-				bit 4-15: Reserved 
-				bit 16-31: User defined
-	 */
-	public int Open_Buffer_Continue(byte[] buffer, int size)
-   {
-       return MediaInfoDLL_Internal.INSTANCE.Open_Buffer_Continue(Handle, buffer, size);
-   }
+        /**
+         * How this parameter is supported, could be N (No), B (Beta), R (Read only), W
+         * (Read/Write).
+         */
+        HowTo,
 
-	public long Open_Buffer_Continue_GoTo_Get()
-   {
-       return MediaInfoDLL_Internal.INSTANCE.Open_Buffer_Continue_GoTo_Get(Handle);
-   }
+        /**
+         * Domain of this piece of information.
+         */
+        Domain;
+    }
 
-	public int Open_Buffer_Finalize()
-   {
-       return MediaInfoDLL_Internal.INSTANCE.Open_Buffer_Finalize(Handle);
-   }
+    public enum Status {
+        None(0x00),
+        Accepted(0x01),
+        Filled(0x02),
+        Updated(0x04),
+        Finalized(0x08);
 
-   /**
-    * Close a file opened before with Open().
-    *
-    */
-   public void Close()
-   {
-       MediaInfoDLL_Internal.INSTANCE.Close(Handle);
-   }
+        private int value;
 
-   //Information
-   /**
-    * Get all details about a file.
-    *
-    * @return All details about a file in one string
-    */
-   public String Inform()
-   {
-       return MediaInfoDLL_Internal.INSTANCE.Inform(Handle, 0).toString();
-   }
+        private Status(int value) {
+            this.value = value;
+        }
 
-   /**
-    * Get a piece of information about a file (parameter is a string).
-    *
-    * @param StreamKind Kind of Stream (general, video, audio...)
-    * @param StreamNumber Stream number in Kind of Stream (first, second...)
-    * @param parameter Parameter you are looking for in the Stream (Codec, width, bitrate...),
-    *            in string format ("Codec", "Width"...)
-    * @return a string about information you search, an empty string if there is a problem
-    */
-   public String Get(StreamKind StreamKind, int StreamNumber, String parameter)
-   {
-       return Get(StreamKind, StreamNumber, parameter, InfoKind.Text, InfoKind.Name);
-   }
+        public int getValue(int value) {
+            return value;
+        }
+    }
 
+    // Constructor/Destructor
+    public MediaInfoNativeWrapper() {
+        Handle = MediaInfoDLL_Internal.INSTANCE.New();
+    }
 
-   /**
-    * Get a piece of information about a file (parameter is a string).
-    *
-    * @param StreamKind Kind of Stream (general, video, audio...)
-    * @param StreamNumber Stream number in Kind of Stream (first, second...)
-    * @param parameter Parameter you are looking for in the Stream (Codec, width, bitrate...),
-    *            in string format ("Codec", "Width"...)
-    * @param infoKind Kind of information you want about the parameter (the text, the measure,
-    *            the help...)
-    * @param searchKind Where to look for the parameter
-    */
-   public String Get(StreamKind StreamKind, int StreamNumber, String parameter, InfoKind infoKind)
-   {
-       return Get(StreamKind, StreamNumber, parameter, infoKind, InfoKind.Name);
-   }
+    public void dispose() {
+        if (Handle == null) throw new IllegalStateException();
 
+        MediaInfoDLL_Internal.INSTANCE.Delete(Handle);
+        Handle = null;
+    }
 
-   /**
-    * Get a piece of information about a file (parameter is a string).
-    *
-    * @param StreamKind Kind of Stream (general, video, audio...)
-    * @param StreamNumber Stream number in Kind of Stream (first, second...)
-    * @param parameter Parameter you are looking for in the Stream (Codec, width, bitrate...),
-    *            in string format ("Codec", "Width"...)
-    * @param infoKind Kind of information you want about the parameter (the text, the measure,
-    *            the help...)
-    * @param searchKind Where to look for the parameter
-    * @return a string about information you search, an empty string if there is a problem
-    */
-   public String Get(StreamKind StreamKind, int StreamNumber, String parameter, InfoKind infoKind, InfoKind searchKind)
-   {
-       return MediaInfoDLL_Internal.INSTANCE.Get(Handle, StreamKind.ordinal(), StreamNumber, new WString(parameter), infoKind.ordinal(), searchKind.ordinal()).toString();
-   }
+    @Override
+    protected void finalize() throws Throwable {
+        if (Handle != null) dispose();
+    }
 
+    // File
+    /**
+     * Open a file and collect information about it (technical information and tags).
+     *
+     * @param file full name of the file to open
+     * @return 1 if file was opened, 0 if file was not not opened
+     */
+    public int Open(String File_Name) {
+        return MediaInfoDLL_Internal.INSTANCE.Open(Handle, new WString(File_Name));
+    }
 
-   /**
-    * Get a piece of information about a file (parameter is an integer).
-    *
+    public int Open_Buffer_Init(long length, long offset) {
+        return MediaInfoDLL_Internal.INSTANCE.Open_Buffer_Init(Handle, length, offset);
+    }
 
-    * @param StreamKind Kind of Stream (general, video, audio...)
-    * @param StreamNumber Stream number in Kind of Stream (first, second...)
-    * @param parameter Parameter you are looking for in the Stream (Codec, width, bitrate...),
-    *            in integer format (first parameter, second parameter...)
-    * @return a string about information you search, an empty string if there is a problem
-    */
-   public String get(StreamKind StreamKind, int StreamNumber, int parameterIndex)
-   {
-       return Get(StreamKind, StreamNumber, parameterIndex, InfoKind.Text);
-   }
+    /**
+     *  Open a stream and collect information about it (technical information and tags) (By buffer, Continue)
+     *
+     * @param buffer pointer to the stream
+     * @param size Count of bytes to read
+     * @return a bitfield
+     * bit 0: Is Accepted (format is known)
+     * bit 1: Is Filled (main data is collected)
+     * bit 2: Is Updated (some data have beed updated, example: duration for a real time MPEG-TS stream)
+     * bit 3: Is Finalized (No more data is needed, will not use further data)
+     * bit 4-15: Reserved
+     * bit 16-31: User defined
+     */
+    public int Open_Buffer_Continue(byte[] buffer, int size) {
+        return MediaInfoDLL_Internal.INSTANCE.Open_Buffer_Continue(Handle, buffer, size);
+    }
 
+    public long Open_Buffer_Continue_GoTo_Get() {
+        return MediaInfoDLL_Internal.INSTANCE.Open_Buffer_Continue_GoTo_Get(Handle);
+    }
 
-   /**
-    * Get a piece of information about a file (parameter is an integer).
-    *
+    public int Open_Buffer_Finalize() {
+        return MediaInfoDLL_Internal.INSTANCE.Open_Buffer_Finalize(Handle);
+    }
 
-    * @param StreamKind Kind of Stream (general, video, audio...)
-    * @param StreamNumber Stream number in Kind of Stream (first, second...)
-    * @param parameter Parameter you are looking for in the Stream (Codec, width, bitrate...),
-    *            in integer format (first parameter, second parameter...)
-    * @param infoKind Kind of information you want about the parameter (the text, the measure,
-    *            the help...)
-    * @return a string about information you search, an empty string if there is a problem
-    */
-   public String Get(StreamKind StreamKind, int StreamNumber, int parameterIndex, InfoKind infoKind)
-   {
-       return MediaInfoDLL_Internal.INSTANCE.GetI(Handle, StreamKind.ordinal(), StreamNumber, parameterIndex, infoKind.ordinal()).toString();
-   }
+    /**
+     * Close a file opened before with Open().
+     *
+     */
+    public void Close() {
+        MediaInfoDLL_Internal.INSTANCE.Close(Handle);
+    }
 
-   /**
-    * Count of Streams of a Stream kind (StreamNumber not filled), or count of piece of
-    * information in this Stream.
-    *
+    // Information
+    /**
+     * Get all details about a file.
+     *
+     * @return All details about a file in one string
+     */
+    public String Inform() {
+        return MediaInfoDLL_Internal.INSTANCE.Inform(Handle, 0).toString();
+    }
 
-    * @param StreamKind Kind of Stream (general, video, audio...)
-    * @return number of Streams of the given Stream kind
-    */
-   public int Count_Get(StreamKind StreamKind)
-   {
-       //We should use NativeLong for -1, but it fails on 64-bit
-       //int Count_Get(Pointer Handle, int StreamKind, NativeLong StreamNumber);
-       //return MediaInfoDLL_Internal.INSTANCE.Count_Get(Handle, StreamKind.ordinal(), -1);
-       //so we use slower Get() with a character string
-       String StreamCount = Get(StreamKind, 0, "StreamCount");
-       if (StreamCount == null || StreamCount.length() == 0)
-           return 0;
-       return Integer.parseInt(StreamCount);
-   }
+    /**
+     * Get a piece of information about a file (parameter is a string).
+     *
+     * @param StreamKind Kind of Stream (general, video, audio...)
+     * @param StreamNumber Stream number in Kind of Stream (first, second...)
+     * @param parameter Parameter you are looking for in the Stream (Codec, width, bitrate...),
+     *            in string format ("Codec", "Width"...)
+     * @return a string about information you search, an empty string if there is a problem
+     */
+    public String Get(StreamKind StreamKind, int StreamNumber, String parameter) {
+        return Get(StreamKind, StreamNumber, parameter, InfoKind.Text, InfoKind.Name);
+    }
 
+    /**
+     * Get a piece of information about a file (parameter is a string).
+     *
+     * @param StreamKind Kind of Stream (general, video, audio...)
+     * @param StreamNumber Stream number in Kind of Stream (first, second...)
+     * @param parameter Parameter you are looking for in the Stream (Codec, width, bitrate...),
+     *            in string format ("Codec", "Width"...)
+     * @param infoKind Kind of information you want about the parameter (the text, the measure,
+     *            the help...)
+     * @param searchKind Where to look for the parameter
+     */
+    public String Get(StreamKind StreamKind, int StreamNumber, String parameter, InfoKind infoKind) {
+        return Get(StreamKind, StreamNumber, parameter, infoKind, InfoKind.Name);
+    }
 
-   /**
-    * Count of Streams of a Stream kind (StreamNumber not filled), or count of piece of
-    * information in this Stream.
-    *
-    * @param StreamKind Kind of Stream (general, video, audio...)
-    * @param StreamNumber Stream number in this kind of Stream (first, second...)
-    * @return number of Streams of the given Stream kind
-    */
-   public int Count_Get(StreamKind StreamKind, int StreamNumber)
-   {
-       return MediaInfoDLL_Internal.INSTANCE.Count_Get(Handle, StreamKind.ordinal(), StreamNumber);
-   }
+    /**
+     * Get a piece of information about a file (parameter is a string).
+     *
+     * @param StreamKind Kind of Stream (general, video, audio...)
+     * @param StreamNumber Stream number in Kind of Stream (first, second...)
+     * @param parameter Parameter you are looking for in the Stream (Codec, width, bitrate...),
+     *            in string format ("Codec", "Width"...)
+     * @param infoKind Kind of information you want about the parameter (the text, the measure,
+     *            the help...)
+     * @param searchKind Where to look for the parameter
+     * @return a string about information you search, an empty string if there is a problem
+     */
+    public String Get(
+            StreamKind StreamKind, int StreamNumber, String parameter, InfoKind infoKind, InfoKind searchKind) {
+        return MediaInfoDLL_Internal.INSTANCE
+                .Get(
+                        Handle,
+                        StreamKind.ordinal(),
+                        StreamNumber,
+                        new WString(parameter),
+                        infoKind.ordinal(),
+                        searchKind.ordinal())
+                .toString();
+    }
 
+    /**
+     * Get a piece of information about a file (parameter is an integer).
+     *
+     *
+     * @param StreamKind Kind of Stream (general, video, audio...)
+     * @param StreamNumber Stream number in Kind of Stream (first, second...)
+     * @param parameter Parameter you are looking for in the Stream (Codec, width, bitrate...),
+     *            in integer format (first parameter, second parameter...)
+     * @return a string about information you search, an empty string if there is a problem
+     */
+    public String get(StreamKind StreamKind, int StreamNumber, int parameterIndex) {
+        return Get(StreamKind, StreamNumber, parameterIndex, InfoKind.Text);
+    }
 
+    /**
+     * Get a piece of information about a file (parameter is an integer).
+     *
+     *
+     * @param StreamKind Kind of Stream (general, video, audio...)
+     * @param StreamNumber Stream number in Kind of Stream (first, second...)
+     * @param parameter Parameter you are looking for in the Stream (Codec, width, bitrate...),
+     *            in integer format (first parameter, second parameter...)
+     * @param infoKind Kind of information you want about the parameter (the text, the measure,
+     *            the help...)
+     * @return a string about information you search, an empty string if there is a problem
+     */
+    public String Get(StreamKind StreamKind, int StreamNumber, int parameterIndex, InfoKind infoKind) {
+        return MediaInfoDLL_Internal.INSTANCE
+                .GetI(Handle, StreamKind.ordinal(), StreamNumber, parameterIndex, infoKind.ordinal())
+                .toString();
+    }
 
-   //Options
-   /**
-    * Configure or get information about MediaInfo.
-    *
-    * @param Option The name of option
-    * @return Depends on the option: by default "" (nothing) means No, other means Yes
-    */
-   public String Option(String Option)
-   {
-       return MediaInfoDLL_Internal.INSTANCE.Option(Handle, new WString(Option), new WString("")).toString();
-   }
+    /**
+     * Count of Streams of a Stream kind (StreamNumber not filled), or count of piece of
+     * information in this Stream.
+     *
+     *
+     * @param StreamKind Kind of Stream (general, video, audio...)
+     * @return number of Streams of the given Stream kind
+     */
+    public int Count_Get(StreamKind StreamKind) {
+        // We should use NativeLong for -1, but it fails on 64-bit
+        // int Count_Get(Pointer Handle, int StreamKind, NativeLong StreamNumber);
+        // return MediaInfoDLL_Internal.INSTANCE.Count_Get(Handle, StreamKind.ordinal(), -1);
+        // so we use slower Get() with a character string
+        String StreamCount = Get(StreamKind, 0, "StreamCount");
+        if (StreamCount == null || StreamCount.length() == 0) return 0;
+        return Integer.parseInt(StreamCount);
+    }
 
-   /**
-    * Configure or get information about MediaInfo.
-    *
-    * @param Option The name of option
-    * @param Value The value of option
-    * @return Depends on the option: by default "" (nothing) means No, other means Yes
-    */
-   public String Option(String Option, String Value)
-   {
-       return MediaInfoDLL_Internal.INSTANCE.Option(Handle, new WString(Option), new WString(Value)).toString();
-   }
+    /**
+     * Count of Streams of a Stream kind (StreamNumber not filled), or count of piece of
+     * information in this Stream.
+     *
+     * @param StreamKind Kind of Stream (general, video, audio...)
+     * @param StreamNumber Stream number in this kind of Stream (first, second...)
+     * @return number of Streams of the given Stream kind
+     */
+    public int Count_Get(StreamKind StreamKind, int StreamNumber) {
+        return MediaInfoDLL_Internal.INSTANCE.Count_Get(Handle, StreamKind.ordinal(), StreamNumber);
+    }
 
-   /**
-    * Configure or get information about MediaInfo (Static version).
-    *
-    * @param Option The name of option
-    * @return Depends on the option: by default "" (nothing) means No, other means Yes
-    */
-   public static String Option_Static(String Option)
-   {
-       return MediaInfoDLL_Internal.INSTANCE.Option(MediaInfoDLL_Internal.INSTANCE.New(), new WString(Option), new WString("")).toString();
-   }
+    // Options
+    /**
+     * Configure or get information about MediaInfo.
+     *
+     * @param Option The name of option
+     * @return Depends on the option: by default "" (nothing) means No, other means Yes
+     */
+    public String Option(String Option) {
+        return MediaInfoDLL_Internal.INSTANCE
+                .Option(Handle, new WString(Option), new WString(""))
+                .toString();
+    }
 
-   /**
-    * Configure or get information about MediaInfo(Static version).
-    *
-    * @param Option The name of option
-    * @param Value The value of option
-    * @return Depends on the option: by default "" (nothing) means No, other means Yes
-    */
-   public static String Option_Static(String Option, String Value)
-   {
-       return MediaInfoDLL_Internal.INSTANCE.Option(MediaInfoDLL_Internal.INSTANCE.New(), new WString(Option), new WString(Value)).toString();
-   }
+    /**
+     * Configure or get information about MediaInfo.
+     *
+     * @param Option The name of option
+     * @param Value The value of option
+     * @return Depends on the option: by default "" (nothing) means No, other means Yes
+     */
+    public String Option(String Option, String Value) {
+        return MediaInfoDLL_Internal.INSTANCE
+                .Option(Handle, new WString(Option), new WString(Value))
+                .toString();
+    }
+
+    /**
+     * Configure or get information about MediaInfo (Static version).
+     *
+     * @param Option The name of option
+     * @return Depends on the option: by default "" (nothing) means No, other means Yes
+     */
+    public static String Option_Static(String Option) {
+        return MediaInfoDLL_Internal.INSTANCE
+                .Option(MediaInfoDLL_Internal.INSTANCE.New(), new WString(Option), new WString(""))
+                .toString();
+    }
+
+    /**
+     * Configure or get information about MediaInfo(Static version).
+     *
+     * @param Option The name of option
+     * @param Value The value of option
+     * @return Depends on the option: by default "" (nothing) means No, other means Yes
+     */
+    public static String Option_Static(String Option, String Value) {
+        return MediaInfoDLL_Internal.INSTANCE
+                .Option(MediaInfoDLL_Internal.INSTANCE.New(), new WString(Option), new WString(Value))
+                .toString();
+    }
 }
-

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoUtil.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoUtil.java
@@ -10,12 +10,14 @@
 
 package edu.harvard.hul.ois.fits.tools.mediainfo;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import edu.harvard.hul.ois.fits.tools.utils.XmlUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.commons.lang.StringUtils;
 import org.jdom2.Attribute;
 import org.jdom2.Content;
@@ -29,10 +31,6 @@ import org.jdom2.xpath.XPathFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
-import edu.harvard.hul.ois.fits.tools.utils.XmlUtils;
-
 /**
  * This is a helper class for the MediaInfo tool class. The main purpose of
  * this class is post process and revise XML data where necessary when either
@@ -45,859 +43,813 @@ public class MediaInfoUtil {
     private XPathFactory xFactory = XPathFactory.instance();
     private Namespace fitsNamespace = Namespace.getNamespace("x", Fits.XML_NAMESPACE);
 
-	public static final String CODEC_FAMILY_AVID_DNXHD = "Avid DNxHD";
-	public static final String CODEC_FAMILY_JPG2000 = "JPEG 2000";
-	public static final String CODEC_FAMILY_DV = "DV";
-	public static final String CODEC_FAMILY_UNCOMPRESSED = "Uncompressed";
-	public static final String CODEC_FAMILY_H_264 = "H.264";
-	public static final String CODEC_FAMILY_PRORES = "Apple ProRes";
-
-	public static final String QUICKTIME_MIMETYPE = "video/quicktime";
-	public static final String QUICKTIME_FORMAT = "Quicktime";
-	public static final String MPEG4_FORMAT = "MPEG-4";
-
-	@SuppressWarnings("serial")
-	private static final Map<String, String> CODEC_4CC_TO_FAMILY = Collections.unmodifiableMap(
-		    new HashMap<String, String>() {{
-                put("mjp2", CODEC_FAMILY_JPG2000);
-
-                put("r210", CODEC_FAMILY_UNCOMPRESSED);
-
-                put("v210", CODEC_FAMILY_UNCOMPRESSED);
-                put("v216", CODEC_FAMILY_UNCOMPRESSED);
-                put("2vuy", CODEC_FAMILY_UNCOMPRESSED);
-                put("yuv2", CODEC_FAMILY_UNCOMPRESSED);
-                put("v308", CODEC_FAMILY_UNCOMPRESSED);
-                put("v408", CODEC_FAMILY_UNCOMPRESSED);
-                put("v410", CODEC_FAMILY_UNCOMPRESSED);
-                put("R10g", CODEC_FAMILY_UNCOMPRESSED);
-                put("2Vuy", CODEC_FAMILY_UNCOMPRESSED);
-
-                put("dv1p", CODEC_FAMILY_DV);
-                put("dv1n", CODEC_FAMILY_DV);
-                put("dv5n", CODEC_FAMILY_DV);
-                put("dv5p", CODEC_FAMILY_DV);
-                put("dvc", CODEC_FAMILY_DV);
-                put("dvcp", CODEC_FAMILY_DV);
-                put("dvh2", CODEC_FAMILY_DV);
-                put("dvh3", CODEC_FAMILY_DV);
-                put("dvh5", CODEC_FAMILY_DV);
-                put("dvh6", CODEC_FAMILY_DV);
-                put("dvhp", CODEC_FAMILY_DV);
-                put("dvhq", CODEC_FAMILY_DV);
-                put("dvp", CODEC_FAMILY_DV);
-                put("dvpp", CODEC_FAMILY_DV);
-
-                put("mp2v", "MPEG-2");
-                put("m2v1", "MPEG-2");                
-
-                put("avc1", CODEC_FAMILY_H_264);
-                put("h264", CODEC_FAMILY_H_264);
-                put("v264", CODEC_FAMILY_H_264);
-                put("x264", CODEC_FAMILY_H_264);
-
-                put("AVdn", CODEC_FAMILY_AVID_DNXHD);
-
-                put("ap4h", CODEC_FAMILY_PRORES);
-                put("ap4x", CODEC_FAMILY_PRORES);
-                put("apch", CODEC_FAMILY_PRORES);
-                put("apcn", CODEC_FAMILY_PRORES);
-                put("apco", CODEC_FAMILY_PRORES);
-                put("apcs", CODEC_FAMILY_PRORES);
-		    }});
-
-	@SuppressWarnings("serial")
-	private static final Map<String, String> CODEC_MXF_TO_FAMILY = Collections.unmodifiableMap(
-		    new HashMap<String, String>() {{
-                put("0D010301020C0100-040102020301017F", CODEC_FAMILY_JPG2000);
-                put("0D010301020C0100-0401020203010000", CODEC_FAMILY_JPG2000);
-                put("0D010301020C0100-0401020203010100", CODEC_FAMILY_JPG2000);
-                put("0D010301020C0100-0401020203010101", CODEC_FAMILY_JPG2000);
-                put("0D010301020C0100-0401020203010103", CODEC_FAMILY_JPG2000);
-                put("0D010301020C0100-0401020203010104", CODEC_FAMILY_JPG2000);
-
-                put("0D01030102110100-0401020271010000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-0401020271030000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-0401020271040000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-0401020271070000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-0401020271080000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-0401020271090000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-0401020271100000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-0401020271110000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-0401020271120000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-0401020271130000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-0401020271160000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-0401020271180000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-0401020271190000",CODEC_FAMILY_AVID_DNXHD);
-                put("0D01030102110100-04010202711A0000",CODEC_FAMILY_AVID_DNXHD);
-
-		    }});
-
-	private final static String TOOL_NAME = "MediaInfo";
-	private static final Logger logger = LoggerFactory.getLogger(MediaInfoUtil.class);
-	private static MediaInfoNativeWrapper mi = null;
-
-	protected MediaInfoUtil(MediaInfoNativeWrapper mi) {
-		MediaInfoUtil.mi = mi;
-	}
-
-	protected  Map<String, String> loadGeneralDataMap () {
-	    Map<String, String> generalValuesDataMap = new HashMap<String, String>();
-
-	    generalValuesDataMap.put("dateModified", getMediaInfoString(
-	    		"File_Modified_Date", MediaInfoNativeWrapper.StreamKind.General));
-
-	    generalValuesDataMap.put("generalBitRate", getMediaInfoString(
-	    		"BitRate", MediaInfoNativeWrapper.StreamKind.General));
-
-	    generalValuesDataMap.put("timeCodeStart", getMediaInfoString(
-	    		"TimeCode_FirstFrame", MediaInfoNativeWrapper.StreamKind.Other));
-
-	    generalValuesDataMap.put("generalDuration", getMediaInfoString(
-	    		"Duration", MediaInfoNativeWrapper.StreamKind.General));
-
-	    generalValuesDataMap.put("generalFileSize", getMediaInfoString(
-	    		"FileSize", MediaInfoNativeWrapper.StreamKind.General));
-
-//	    //
-//	    // TODO: bitRate_Maximum never seems to appear in MediaInfo
-//	    // in the general section
-//	    //
-//	    //String generalBitRateMax = getMediaInfoString(
-//	    //		"BitRate_Maximum", MediaInfoNativeWrapper.StreamKind.General);
-//
-//	    // Empty ???
-//	    String dateCreated = getMediaInfoString(
-//	    		"File_Created_Date", MediaInfoNativeWrapper.StreamKind.General);
-//				//"Created_Date", MediaInfoNativeWrapper.StreamKind.General);
-//
-//	    String dateEncoded = getMediaInfoString(
-//	    		"Encoded_Date", MediaInfoNativeWrapper.StreamKind.General);
-//
-//	    // Empty ???
-//	    String encodedLibraryVersion = getMediaInfoString(
-//	    		//"File_Encoded_Library_Version", MediaInfoNativeWrapper.StreamKind.General);
-//				"Encoded_Library_Version",MediaInfoNativeWrapper.StreamKind.General);
-
-	    return generalValuesDataMap;
-	}
-
-	/**
-	 * Helper method to add values to the map within the trackValuesMap
-	 *
-	 * @param trackValuesMap  The map to be updated
-	 * @param id  The key to trackValuesMap
-	 * @param key The key to the map contained within trackValuesMap
-	 * @param value The value to set in the map contained within trackValuesMap
-	 */
-	protected void addDataToMap(Map<String, Map<String, String>> trackValuesMap,
-			String id, String key, String value) {
-	    if (!StringUtils.isEmpty(value)) {
-	    	if(trackValuesMap.get(id) == null)
-	    		trackValuesMap.put(id, new HashMap<String, String>());
-		    trackValuesMap.get(id).put(key, value);
-	    }
-	}
-
-	protected Map<String, Map<String, String>> loadVideoDataMap (Map<String, String> generalValuesDataMap) {
-
-	    Map<String, Map<String, String>> videoTrackValuesMap =
-	    	    new HashMap<String, Map<String, String>>();
-
-	    int numVideoTracks = mi.Count_Get(MediaInfoNativeWrapper.StreamKind.Video);
-	    for (int ndx = 0; ndx < numVideoTracks; ndx++) {
-
-		    String id = getMediaInfoString(ndx, "ID",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-
-		    if(StringUtils.isEmpty(id)) {
-		    	// If we only have one video track, we can retrieve data with
-		    	// the index 0
-		    	if(numVideoTracks == 1)
-		    		id = "0";
-		    	else {
-			    	// TODO: Throw error and/or log?
-			    	logger.error("Error retrieving the ID of the video track from MediaInfo: " + ndx);
-			    	continue;
-		    	}
-		    }
-
-		    String duration = getMediaInfoString(ndx, "Duration",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap (videoTrackValuesMap, id, "duration", duration);
-
-		    String videoDelay = getMediaInfoString(ndx, "Delay",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap (videoTrackValuesMap, id, "delay", videoDelay);
-
-		    String frameCount = getMediaInfoString(ndx, "FrameCount",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap (videoTrackValuesMap, id, "frameCount", frameCount);
-
-		    String bitRate = getMediaInfoString(ndx, "BitRate",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap(videoTrackValuesMap, id, "bitRate", bitRate);
-
-		    //
-		    // TODO: bitRate_Maximum never seems to appear in MediaInfo
-		    // in the video section
-		    //
-		    // bitRateMax and bitRateMode, are both used to update
-		    // bitRate, when bitRateMode is variable (VBR)
-		    //
-		    String bitRateMax = getMediaInfoString(ndx, "BitRate_Maximum",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap(videoTrackValuesMap, id, "bitRateMax", bitRateMax);
-
-		    String bitRateMode = getMediaInfoString(ndx, "BitRate_Mode",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap(videoTrackValuesMap, id, "bitRateMode", bitRateMode);
-
-		    // ----------------------------------------------------------------
-
-		    String trackSize = getMediaInfoString(ndx, "StreamSize",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap(videoTrackValuesMap, id, "trackSize", trackSize);
-
-		    //
-		    // TODO: frameRate_Maximum never seems to appear in MediaInfo
-		    // in the video section
-		    //
-		    // frameRateMax and frameRateMode, are both used to update
-		    // frameRate, when frameRateMode is variable (VFR)
-		    //
-		    String frameRateMax = getMediaInfoString(ndx, "FrameRate_Maximum",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap(videoTrackValuesMap, id, "frameRateMax", frameRateMax);
-
-		    String frameRateMode = getMediaInfoString(ndx, "FrameRate_Mode",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap(videoTrackValuesMap, id, "frameRateMode", frameRateMode);
-
-		    String frameRate = getMediaInfoString(ndx, "FrameRate",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap(videoTrackValuesMap, id, "frameRate", frameRate);
-
-		    // ----------------------------------------------------------------
-		    String scanningOrder = getMediaInfoString(ndx, "ScanOrder",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap (videoTrackValuesMap, id, "scanningOrder", scanningOrder);
-
-		    // Additional Codec stuff:
-		    String codecId = getMediaInfoString(ndx, "CodecID",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap (videoTrackValuesMap, id, "codecId", codecId);
-
-		    String codecCC = getMediaInfoString(ndx, "Codec/CC",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    if(codecCC != null) {
-		    	codecCC = codecCC.trim();
-		    }		    
-		    addDataToMap (videoTrackValuesMap, id, "codecCC", codecCC);
-
-		    String codecName = getMediaInfoString(ndx, "Codec",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap (videoTrackValuesMap, id, "codecName", codecName);
-
-		    String codecVersion = getMediaInfoString(ndx, "Codec_Profile",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap (videoTrackValuesMap, id, "codecVersion", codecVersion);
-
-		    // By design - if the 4CC code is not one expected, then don't
-		    // generate a Code Family.
-		    // NOTE for all but MXF, codecCC is used for the 4CC code.
-		    // for MXF, we use the codecId.
-		    // String codecFamily = getMediaInfoString(ndx, "Codec/Family",
-		    //		MediaInfoNativeWrapper.StreamKind.Video);
-		    String codecFamily = CODEC_4CC_TO_FAMILY.get(codecId);
-		    // Now try for MXF files, if we haven't gotten a Codec Family
-		    if(codecFamily == null) {
-		    	codecFamily = CODEC_MXF_TO_FAMILY.get(codecId);
-		    }
-		    // If we got a Codec Family, set it in the map
-		    if(codecFamily != null) {
-		    	addDataToMap (videoTrackValuesMap, id, "codecFamily", codecFamily);
-		    }
-
-		    String codecInfo = getMediaInfoString(ndx, "Codec/Info",
-		    		MediaInfoNativeWrapper.StreamKind.Video);
-		    addDataToMap (videoTrackValuesMap, id, "codecInfo", codecInfo);
-
-		    // NOTE:
-		    // formatProfile goes in the FITS XML general section, but
-		    // sometimes is missing from the MediaInfo general section and
-		    // present in video section.
-		    generalValuesDataMap.put("generalFormatProfileFromVideo",
-		    		getMediaInfoString(ndx, "Format_Profile",
-		    		MediaInfoNativeWrapper.StreamKind.Video));
-	    }
-		return videoTrackValuesMap;
-	}
-
-	protected Map<String, Map<String, String>> loadAudioDataMap () {
-
-		Map<String, Map<String, String>> audioTrackValuesMap =
-	    	    new HashMap<String, Map<String, String>>();
-
-	    int numAudioTracks = mi.Count_Get(MediaInfoNativeWrapper.StreamKind.Audio);
-	    for (int ndx = 0; ndx < numAudioTracks; ndx++) {
-
-		    String id = getMediaInfoString(ndx, "ID",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-
-		    if(StringUtils.isEmpty(id)) {
-		    	// If we only have one audio track, we can retrieve data with
-		    	// the index 0
-		    	if(numAudioTracks == 1)
-		    		id = "0";
-		    	else {
-			    	// TODO: Throw error and/or log?
-			    	logger.error("Error retrieving the ID of the audio track from MediaInfo: " + ndx);
-			    	continue;
-		    	}
-		    }
-
-		    String audioDelay = getMediaInfoString(ndx, "Delay",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-		    addDataToMap (audioTrackValuesMap, id, "delay", audioDelay);
-
-		    String audioSamplesCount = getMediaInfoString(ndx, "SamplingCount",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-		    addDataToMap (audioTrackValuesMap, id, "numSamples", audioSamplesCount);
-
-		    String bitRate = getMediaInfoString(ndx, "BitRate",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-		    addDataToMap(audioTrackValuesMap, id, "bitRate", bitRate);
-
-		    //
-		    // TODO: bitRate_Maximum never seems to appear in MediaInfo
-		    // in the video section
-		    //
-		    // bitRateMax and bitRateMode, are both used to update
-		    // bitRate, when bitRateMode is variable (VBR)
-		    //
-		    String bitRateMax = getMediaInfoString(ndx, "BitRate_Maximum",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-		    addDataToMap(audioTrackValuesMap, id, "bitRateMax", bitRateMax);
-
-		    String bitRateMode = getMediaInfoString(ndx, "BitRate_Mode",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-		    addDataToMap(audioTrackValuesMap, id, "bitRateMode", bitRateMode);
-
-		    // ----------------------------------------------------------------
-
-		    String duration = getMediaInfoString(ndx, "Duration",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);;
-		    addDataToMap (audioTrackValuesMap, id, "duration", duration);
-
-		    String trackSize = getMediaInfoString(ndx, "StreamSize",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-		    addDataToMap(audioTrackValuesMap, id, "trackSize", trackSize);
-
-		    String samplingRate = getMediaInfoString(ndx, "SamplingRate",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-		    addDataToMap(audioTrackValuesMap, id, "samplingRate", samplingRate);
-
-		    String channels = getMediaInfoString(ndx, "Channels",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-		    addDataToMap(audioTrackValuesMap, id, "channels", channels);
-
-		    String channelPositions = getMediaInfoString(ndx, "ChannelPositions",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-		    addDataToMap(audioTrackValuesMap, id, "soundField", channelPositions);
-
-		    String byteOrder = getMediaInfoString(ndx, "Format_Settings_Endianness",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-		    addDataToMap(audioTrackValuesMap, id, "byteOrder", byteOrder);
-
-		    // Additional Codec stuff:
-		    String codecId = getMediaInfoString(ndx, "CodecID",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-		    addDataToMap(audioTrackValuesMap, id, "codecId", codecId);
-
-		    String codecFamily = getMediaInfoString(ndx, "Codec/Family",
-		    		MediaInfoNativeWrapper.StreamKind.Audio);
-		    addDataToMap(audioTrackValuesMap, id, "codecFamily", codecFamily);
-
-		    //String codecInfo = getMediaInfoString(ndx, "Codec/Info",
-		    //		MediaInfoNativeWrapper.StreamKind.Audio);
-		    //addDataToMap(audioTrackValuesMap, id, "codecInfo", codecInfo);
-	    }
-
-	    return audioTrackValuesMap;
-
-	}
-
-	/**
-	 * Revises the XML to include element data that was not returned either via
-	 * the MediaInfo XML or require revision for granularity using various data
-	 * maps
-	 *
-	 * @param fitsXml
-	 * @param videoTrackValuesMap
-	 * @param audioTrackValuesMap
-	 * @param generalValuesDataMap
-	 * @throws FitsToolException
-	 */
-	protected void reviseXmlData (Document fitsXml, Map<String, Map<String, String>> videoTrackValuesMap,
-			Map<String, Map<String, String>> audioTrackValuesMap,  Map<String, String> generalValuesDataMap )
-					throws FitsToolException {
-
-		try {
-			reviseIdentification(fitsXml);
+    public static final String CODEC_FAMILY_AVID_DNXHD = "Avid DNxHD";
+    public static final String CODEC_FAMILY_JPG2000 = "JPEG 2000";
+    public static final String CODEC_FAMILY_DV = "DV";
+    public static final String CODEC_FAMILY_UNCOMPRESSED = "Uncompressed";
+    public static final String CODEC_FAMILY_H_264 = "H.264";
+    public static final String CODEC_FAMILY_PRORES = "Apple ProRes";
+
+    public static final String QUICKTIME_MIMETYPE = "video/quicktime";
+    public static final String QUICKTIME_FORMAT = "Quicktime";
+    public static final String MPEG4_FORMAT = "MPEG-4";
+
+    @SuppressWarnings("serial")
+    private static final Map<String, String> CODEC_4CC_TO_FAMILY =
+            Collections.unmodifiableMap(new HashMap<String, String>() {
+                {
+                    put("mjp2", CODEC_FAMILY_JPG2000);
+
+                    put("r210", CODEC_FAMILY_UNCOMPRESSED);
+
+                    put("v210", CODEC_FAMILY_UNCOMPRESSED);
+                    put("v216", CODEC_FAMILY_UNCOMPRESSED);
+                    put("2vuy", CODEC_FAMILY_UNCOMPRESSED);
+                    put("yuv2", CODEC_FAMILY_UNCOMPRESSED);
+                    put("v308", CODEC_FAMILY_UNCOMPRESSED);
+                    put("v408", CODEC_FAMILY_UNCOMPRESSED);
+                    put("v410", CODEC_FAMILY_UNCOMPRESSED);
+                    put("R10g", CODEC_FAMILY_UNCOMPRESSED);
+                    put("2Vuy", CODEC_FAMILY_UNCOMPRESSED);
+
+                    put("dv1p", CODEC_FAMILY_DV);
+                    put("dv1n", CODEC_FAMILY_DV);
+                    put("dv5n", CODEC_FAMILY_DV);
+                    put("dv5p", CODEC_FAMILY_DV);
+                    put("dvc", CODEC_FAMILY_DV);
+                    put("dvcp", CODEC_FAMILY_DV);
+                    put("dvh2", CODEC_FAMILY_DV);
+                    put("dvh3", CODEC_FAMILY_DV);
+                    put("dvh5", CODEC_FAMILY_DV);
+                    put("dvh6", CODEC_FAMILY_DV);
+                    put("dvhp", CODEC_FAMILY_DV);
+                    put("dvhq", CODEC_FAMILY_DV);
+                    put("dvp", CODEC_FAMILY_DV);
+                    put("dvpp", CODEC_FAMILY_DV);
+
+                    put("mp2v", "MPEG-2");
+                    put("m2v1", "MPEG-2");
+
+                    put("avc1", CODEC_FAMILY_H_264);
+                    put("h264", CODEC_FAMILY_H_264);
+                    put("v264", CODEC_FAMILY_H_264);
+                    put("x264", CODEC_FAMILY_H_264);
+
+                    put("AVdn", CODEC_FAMILY_AVID_DNXHD);
+
+                    put("ap4h", CODEC_FAMILY_PRORES);
+                    put("ap4x", CODEC_FAMILY_PRORES);
+                    put("apch", CODEC_FAMILY_PRORES);
+                    put("apcn", CODEC_FAMILY_PRORES);
+                    put("apco", CODEC_FAMILY_PRORES);
+                    put("apcs", CODEC_FAMILY_PRORES);
+                }
+            });
+
+    @SuppressWarnings("serial")
+    private static final Map<String, String> CODEC_MXF_TO_FAMILY =
+            Collections.unmodifiableMap(new HashMap<String, String>() {
+                {
+                    put("0D010301020C0100-040102020301017F", CODEC_FAMILY_JPG2000);
+                    put("0D010301020C0100-0401020203010000", CODEC_FAMILY_JPG2000);
+                    put("0D010301020C0100-0401020203010100", CODEC_FAMILY_JPG2000);
+                    put("0D010301020C0100-0401020203010101", CODEC_FAMILY_JPG2000);
+                    put("0D010301020C0100-0401020203010103", CODEC_FAMILY_JPG2000);
+                    put("0D010301020C0100-0401020203010104", CODEC_FAMILY_JPG2000);
+
+                    put("0D01030102110100-0401020271010000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-0401020271030000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-0401020271040000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-0401020271070000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-0401020271080000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-0401020271090000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-0401020271100000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-0401020271110000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-0401020271120000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-0401020271130000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-0401020271160000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-0401020271180000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-0401020271190000", CODEC_FAMILY_AVID_DNXHD);
+                    put("0D01030102110100-04010202711A0000", CODEC_FAMILY_AVID_DNXHD);
+                }
+            });
+
+    private static final String TOOL_NAME = "MediaInfo";
+    private static final Logger logger = LoggerFactory.getLogger(MediaInfoUtil.class);
+    private static MediaInfoNativeWrapper mi = null;
+
+    protected MediaInfoUtil(MediaInfoNativeWrapper mi) {
+        MediaInfoUtil.mi = mi;
+    }
+
+    protected Map<String, String> loadGeneralDataMap() {
+        Map<String, String> generalValuesDataMap = new HashMap<String, String>();
+
+        generalValuesDataMap.put(
+                "dateModified", getMediaInfoString("File_Modified_Date", MediaInfoNativeWrapper.StreamKind.General));
+
+        generalValuesDataMap.put(
+                "generalBitRate", getMediaInfoString("BitRate", MediaInfoNativeWrapper.StreamKind.General));
+
+        generalValuesDataMap.put(
+                "timeCodeStart", getMediaInfoString("TimeCode_FirstFrame", MediaInfoNativeWrapper.StreamKind.Other));
+
+        generalValuesDataMap.put(
+                "generalDuration", getMediaInfoString("Duration", MediaInfoNativeWrapper.StreamKind.General));
+
+        generalValuesDataMap.put(
+                "generalFileSize", getMediaInfoString("FileSize", MediaInfoNativeWrapper.StreamKind.General));
+
+        //	    //
+        //	    // TODO: bitRate_Maximum never seems to appear in MediaInfo
+        //	    // in the general section
+        //	    //
+        //	    //String generalBitRateMax = getMediaInfoString(
+        //	    //		"BitRate_Maximum", MediaInfoNativeWrapper.StreamKind.General);
+        //
+        //	    // Empty ???
+        //	    String dateCreated = getMediaInfoString(
+        //	    		"File_Created_Date", MediaInfoNativeWrapper.StreamKind.General);
+        //				//"Created_Date", MediaInfoNativeWrapper.StreamKind.General);
+        //
+        //	    String dateEncoded = getMediaInfoString(
+        //	    		"Encoded_Date", MediaInfoNativeWrapper.StreamKind.General);
+        //
+        //	    // Empty ???
+        //	    String encodedLibraryVersion = getMediaInfoString(
+        //	    		//"File_Encoded_Library_Version", MediaInfoNativeWrapper.StreamKind.General);
+        //				"Encoded_Library_Version",MediaInfoNativeWrapper.StreamKind.General);
+
+        return generalValuesDataMap;
+    }
+
+    /**
+     * Helper method to add values to the map within the trackValuesMap
+     *
+     * @param trackValuesMap  The map to be updated
+     * @param id  The key to trackValuesMap
+     * @param key The key to the map contained within trackValuesMap
+     * @param value The value to set in the map contained within trackValuesMap
+     */
+    protected void addDataToMap(Map<String, Map<String, String>> trackValuesMap, String id, String key, String value) {
+        if (!StringUtils.isEmpty(value)) {
+            if (trackValuesMap.get(id) == null) trackValuesMap.put(id, new HashMap<String, String>());
+            trackValuesMap.get(id).put(key, value);
+        }
+    }
+
+    protected Map<String, Map<String, String>> loadVideoDataMap(Map<String, String> generalValuesDataMap) {
+
+        Map<String, Map<String, String>> videoTrackValuesMap = new HashMap<String, Map<String, String>>();
+
+        int numVideoTracks = mi.Count_Get(MediaInfoNativeWrapper.StreamKind.Video);
+        for (int ndx = 0; ndx < numVideoTracks; ndx++) {
+
+            String id = getMediaInfoString(ndx, "ID", MediaInfoNativeWrapper.StreamKind.Video);
+
+            if (StringUtils.isEmpty(id)) {
+                // If we only have one video track, we can retrieve data with
+                // the index 0
+                if (numVideoTracks == 1) id = "0";
+                else {
+                    // TODO: Throw error and/or log?
+                    logger.error("Error retrieving the ID of the video track from MediaInfo: " + ndx);
+                    continue;
+                }
+            }
+
+            String duration = getMediaInfoString(ndx, "Duration", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "duration", duration);
+
+            String videoDelay = getMediaInfoString(ndx, "Delay", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "delay", videoDelay);
+
+            String frameCount = getMediaInfoString(ndx, "FrameCount", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "frameCount", frameCount);
+
+            String bitRate = getMediaInfoString(ndx, "BitRate", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "bitRate", bitRate);
+
+            //
+            // TODO: bitRate_Maximum never seems to appear in MediaInfo
+            // in the video section
+            //
+            // bitRateMax and bitRateMode, are both used to update
+            // bitRate, when bitRateMode is variable (VBR)
+            //
+            String bitRateMax = getMediaInfoString(ndx, "BitRate_Maximum", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "bitRateMax", bitRateMax);
+
+            String bitRateMode = getMediaInfoString(ndx, "BitRate_Mode", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "bitRateMode", bitRateMode);
+
+            // ----------------------------------------------------------------
+
+            String trackSize = getMediaInfoString(ndx, "StreamSize", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "trackSize", trackSize);
+
+            //
+            // TODO: frameRate_Maximum never seems to appear in MediaInfo
+            // in the video section
+            //
+            // frameRateMax and frameRateMode, are both used to update
+            // frameRate, when frameRateMode is variable (VFR)
+            //
+            String frameRateMax = getMediaInfoString(ndx, "FrameRate_Maximum", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "frameRateMax", frameRateMax);
+
+            String frameRateMode = getMediaInfoString(ndx, "FrameRate_Mode", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "frameRateMode", frameRateMode);
+
+            String frameRate = getMediaInfoString(ndx, "FrameRate", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "frameRate", frameRate);
+
+            // ----------------------------------------------------------------
+            String scanningOrder = getMediaInfoString(ndx, "ScanOrder", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "scanningOrder", scanningOrder);
+
+            // Additional Codec stuff:
+            String codecId = getMediaInfoString(ndx, "CodecID", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "codecId", codecId);
+
+            String codecCC = getMediaInfoString(ndx, "Codec/CC", MediaInfoNativeWrapper.StreamKind.Video);
+            if (codecCC != null) {
+                codecCC = codecCC.trim();
+            }
+            addDataToMap(videoTrackValuesMap, id, "codecCC", codecCC);
+
+            String codecName = getMediaInfoString(ndx, "Codec", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "codecName", codecName);
+
+            String codecVersion = getMediaInfoString(ndx, "Codec_Profile", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "codecVersion", codecVersion);
+
+            // By design - if the 4CC code is not one expected, then don't
+            // generate a Code Family.
+            // NOTE for all but MXF, codecCC is used for the 4CC code.
+            // for MXF, we use the codecId.
+            // String codecFamily = getMediaInfoString(ndx, "Codec/Family",
+            //		MediaInfoNativeWrapper.StreamKind.Video);
+            String codecFamily = CODEC_4CC_TO_FAMILY.get(codecId);
+            // Now try for MXF files, if we haven't gotten a Codec Family
+            if (codecFamily == null) {
+                codecFamily = CODEC_MXF_TO_FAMILY.get(codecId);
+            }
+            // If we got a Codec Family, set it in the map
+            if (codecFamily != null) {
+                addDataToMap(videoTrackValuesMap, id, "codecFamily", codecFamily);
+            }
+
+            String codecInfo = getMediaInfoString(ndx, "Codec/Info", MediaInfoNativeWrapper.StreamKind.Video);
+            addDataToMap(videoTrackValuesMap, id, "codecInfo", codecInfo);
+
+            // NOTE:
+            // formatProfile goes in the FITS XML general section, but
+            // sometimes is missing from the MediaInfo general section and
+            // present in video section.
+            generalValuesDataMap.put(
+                    "generalFormatProfileFromVideo",
+                    getMediaInfoString(ndx, "Format_Profile", MediaInfoNativeWrapper.StreamKind.Video));
+        }
+        return videoTrackValuesMap;
+    }
+
+    protected Map<String, Map<String, String>> loadAudioDataMap() {
+
+        Map<String, Map<String, String>> audioTrackValuesMap = new HashMap<String, Map<String, String>>();
+
+        int numAudioTracks = mi.Count_Get(MediaInfoNativeWrapper.StreamKind.Audio);
+        for (int ndx = 0; ndx < numAudioTracks; ndx++) {
+
+            String id = getMediaInfoString(ndx, "ID", MediaInfoNativeWrapper.StreamKind.Audio);
+
+            if (StringUtils.isEmpty(id)) {
+                // If we only have one audio track, we can retrieve data with
+                // the index 0
+                if (numAudioTracks == 1) id = "0";
+                else {
+                    // TODO: Throw error and/or log?
+                    logger.error("Error retrieving the ID of the audio track from MediaInfo: " + ndx);
+                    continue;
+                }
+            }
+
+            String audioDelay = getMediaInfoString(ndx, "Delay", MediaInfoNativeWrapper.StreamKind.Audio);
+            addDataToMap(audioTrackValuesMap, id, "delay", audioDelay);
+
+            String audioSamplesCount =
+                    getMediaInfoString(ndx, "SamplingCount", MediaInfoNativeWrapper.StreamKind.Audio);
+            addDataToMap(audioTrackValuesMap, id, "numSamples", audioSamplesCount);
+
+            String bitRate = getMediaInfoString(ndx, "BitRate", MediaInfoNativeWrapper.StreamKind.Audio);
+            addDataToMap(audioTrackValuesMap, id, "bitRate", bitRate);
+
+            //
+            // TODO: bitRate_Maximum never seems to appear in MediaInfo
+            // in the video section
+            //
+            // bitRateMax and bitRateMode, are both used to update
+            // bitRate, when bitRateMode is variable (VBR)
+            //
+            String bitRateMax = getMediaInfoString(ndx, "BitRate_Maximum", MediaInfoNativeWrapper.StreamKind.Audio);
+            addDataToMap(audioTrackValuesMap, id, "bitRateMax", bitRateMax);
+
+            String bitRateMode = getMediaInfoString(ndx, "BitRate_Mode", MediaInfoNativeWrapper.StreamKind.Audio);
+            addDataToMap(audioTrackValuesMap, id, "bitRateMode", bitRateMode);
+
+            // ----------------------------------------------------------------
+
+            String duration = getMediaInfoString(ndx, "Duration", MediaInfoNativeWrapper.StreamKind.Audio);
+            ;
+            addDataToMap(audioTrackValuesMap, id, "duration", duration);
+
+            String trackSize = getMediaInfoString(ndx, "StreamSize", MediaInfoNativeWrapper.StreamKind.Audio);
+            addDataToMap(audioTrackValuesMap, id, "trackSize", trackSize);
+
+            String samplingRate = getMediaInfoString(ndx, "SamplingRate", MediaInfoNativeWrapper.StreamKind.Audio);
+            addDataToMap(audioTrackValuesMap, id, "samplingRate", samplingRate);
+
+            String channels = getMediaInfoString(ndx, "Channels", MediaInfoNativeWrapper.StreamKind.Audio);
+            addDataToMap(audioTrackValuesMap, id, "channels", channels);
+
+            String channelPositions =
+                    getMediaInfoString(ndx, "ChannelPositions", MediaInfoNativeWrapper.StreamKind.Audio);
+            addDataToMap(audioTrackValuesMap, id, "soundField", channelPositions);
+
+            String byteOrder =
+                    getMediaInfoString(ndx, "Format_Settings_Endianness", MediaInfoNativeWrapper.StreamKind.Audio);
+            addDataToMap(audioTrackValuesMap, id, "byteOrder", byteOrder);
+
+            // Additional Codec stuff:
+            String codecId = getMediaInfoString(ndx, "CodecID", MediaInfoNativeWrapper.StreamKind.Audio);
+            addDataToMap(audioTrackValuesMap, id, "codecId", codecId);
+
+            String codecFamily = getMediaInfoString(ndx, "Codec/Family", MediaInfoNativeWrapper.StreamKind.Audio);
+            addDataToMap(audioTrackValuesMap, id, "codecFamily", codecFamily);
+
+            // String codecInfo = getMediaInfoString(ndx, "Codec/Info",
+            //		MediaInfoNativeWrapper.StreamKind.Audio);
+            // addDataToMap(audioTrackValuesMap, id, "codecInfo", codecInfo);
+        }
+
+        return audioTrackValuesMap;
+    }
+
+    /**
+     * Revises the XML to include element data that was not returned either via
+     * the MediaInfo XML or require revision for granularity using various data
+     * maps
+     *
+     * @param fitsXml
+     * @param videoTrackValuesMap
+     * @param audioTrackValuesMap
+     * @param generalValuesDataMap
+     * @throws FitsToolException
+     */
+    protected void reviseXmlData(
+            Document fitsXml,
+            Map<String, Map<String, String>> videoTrackValuesMap,
+            Map<String, Map<String, String>> audioTrackValuesMap,
+            Map<String, String> generalValuesDataMap)
+            throws FitsToolException {
+
+        try {
+            reviseIdentification(fitsXml);
 
             // NOTE: We need to add a namespace to xpath, because JDom XPath
             // does not support default namespaces. It requires you to add a
             // fake namespace to the XPath instance.
-	        XPathExpression<Element> expr = xFactory.compile("//x:fits/x:metadata/x:video", Filters.element(), null, fitsNamespace);
-		    Element videoElement = expr.evaluateFirst(fitsXml);
-		    List<Content>elementList = videoElement.getContent();
+            XPathExpression<Element> expr =
+                    xFactory.compile("//x:fits/x:metadata/x:video", Filters.element(), null, fitsNamespace);
+            Element videoElement = expr.evaluateFirst(fitsXml);
+            List<Content> elementList = videoElement.getContent();
 
-		    // --------------------------------------------
-		    // We need to normalize the format for files with MIME Type of
-		    // "video/quicktime" to Format of "Quicktime" in some cases
-		    String mimeType = null;
-		    String format = null;
-		    for (Content content : elementList) {
-		        Element element = (Element)content;
-		    	if(element.getName().equals("mimeType")) {
-					mimeType = element.getText();
-		    	}
-		    	else if(element.getName().equals("format")) {
-					format = element.getText();
-		    	}
-		    }
-	    	if(mimeType != null && format != null) {
-			    if(mimeType.equals(QUICKTIME_MIMETYPE) && format.equals(MPEG4_FORMAT)) {
-			    	generalValuesDataMap.put("format", QUICKTIME_FORMAT);
-			    }
-	    	}
-		    // --------------------------------------------
+            // --------------------------------------------
+            // We need to normalize the format for files with MIME Type of
+            // "video/quicktime" to Format of "Quicktime" in some cases
+            String mimeType = null;
+            String format = null;
+            for (Content content : elementList) {
+                Element element = (Element) content;
+                if (element.getName().equals("mimeType")) {
+                    mimeType = element.getText();
+                } else if (element.getName().equals("format")) {
+                    format = element.getText();
+                }
+            }
+            if (mimeType != null && format != null) {
+                if (mimeType.equals(QUICKTIME_MIMETYPE) && format.equals(MPEG4_FORMAT)) {
+                    generalValuesDataMap.put("format", QUICKTIME_FORMAT);
+                }
+            }
+            // --------------------------------------------
 
-		    for (Content content : elementList) {
+            for (Content content : elementList) {
 
-		        Element element = (Element)content;
-		    	// First revise the general data right off the video element
-		    	reviseGeneralSection(element,  generalValuesDataMap);
+                Element element = (Element) content;
+                // First revise the general data right off the video element
+                reviseGeneralSection(element, generalValuesDataMap);
 
-		    	// Tracks
-		    	if(element.getName().equals("track")) {
-		    		String id = element.getAttributeValue("id");
+                // Tracks
+                if (element.getName().equals("track")) {
+                    String id = element.getAttributeValue("id");
 
-		    		// In some cases, the track ID returned by MediaInfo in the
-		    		// XML used for XSLT transformation is not fully numerical,
-		    		// and does NOT match the ID returned by calling the
-		    		// MediaInfo API, so we need to strip off the additional
-		    		// information contained in the ID that the XSLT transformation
-		    		//
-		    		// For example, if the track ID is 1666406348 (0x635357CC)
-		    		// or even 189 (0xBD)-128 (0x80)
-		    		// we need to remove all of the text between, and including
-		    		// the parenthesis to match what is returned by MediaInfo
-		    		// and set the ID to the 1st value
-		    		if(!XmlUtils.isNumeric(id)) {
-		    			id = convertIdToMediaInfoFormat(id);
-		    			element.setAttribute("id", id);
-		    		}
+                    // In some cases, the track ID returned by MediaInfo in the
+                    // XML used for XSLT transformation is not fully numerical,
+                    // and does NOT match the ID returned by calling the
+                    // MediaInfo API, so we need to strip off the additional
+                    // information contained in the ID that the XSLT transformation
+                    //
+                    // For example, if the track ID is 1666406348 (0x635357CC)
+                    // or even 189 (0xBD)-128 (0x80)
+                    // we need to remove all of the text between, and including
+                    // the parenthesis to match what is returned by MediaInfo
+                    // and set the ID to the 1st value
+                    if (!XmlUtils.isNumeric(id)) {
+                        id = convertIdToMediaInfoFormat(id);
+                        element.setAttribute("id", id);
+                    }
 
-			    	// HACK: In some cases a track ID is not given, in those cases, use the index
-		    		if (StringUtils.isEmpty(id)) {
-			    		id = "0";
-		    			element.setAttribute("id", id);
-		    		}
+                    // HACK: In some cases a track ID is not given, in those cases, use the index
+                    if (StringUtils.isEmpty(id)) {
+                        id = "0";
+                        element.setAttribute("id", id);
+                    }
 
-		    		// video track data
-		    		if (videoTrackValuesMap.containsKey(id)) {
-		    			reviseVideoSection(element, id, videoTrackValuesMap);
-		    		}
-		    		// audio track data
-		    		if (audioTrackValuesMap.containsKey(id)) {
-		    			reviseAudioSection(element, id, audioTrackValuesMap);
-		    		}
+                    // video track data
+                    if (videoTrackValuesMap.containsKey(id)) {
+                        reviseVideoSection(element, id, videoTrackValuesMap);
+                    }
+                    // audio track data
+                    if (audioTrackValuesMap.containsKey(id)) {
+                        reviseAudioSection(element, id, audioTrackValuesMap);
+                    }
+                } // "track"
+            } // for (Element element : elementList) {
 
-		    	} // "track"
+        } catch (JDOMException e) {
+            throw new FitsToolException("Error revising xml node values " + TOOL_NAME);
+        }
+    }
 
-		    }  // for (Element element : elementList) {
+    private String convertIdToMediaInfoFormat(String id) {
+        return id.replaceAll("\\s*\\([^\\)]*\\)\\s*", "");
+    }
 
+    /**
+     * Helper method to revise text in the identification element.
+     * @param fitsXml
+     * @throws JDOMException
+     */
+    private void reviseIdentification(Document fitsXml) throws JDOMException {
 
-		} catch(JDOMException e) {
-			throw new FitsToolException("Error revising xml node values " + TOOL_NAME);
-		}
+        //
+        // Get the format and formatProfile from the video track element
+        //
+        String videoFormat = "";
+        String videoFormatProfile = "";
 
-	}
+        // NOTE: We need to add a namespace	to xpath, because JDom XPath
+        // does not support default namespaces. It requires you to add a
+        // fake namespace to the XPath instance.
+        XPathExpression<Element> expr =
+                xFactory.compile("//x:fits/x:metadata/x:video", Filters.element(), null, fitsNamespace);
 
-	private String convertIdToMediaInfoFormat(String id) {
-		return id.replaceAll("\\s*\\([^\\)]*\\)\\s*", "");
-	}
+        Element videoElement = expr.evaluateFirst(fitsXml);
+        List<Content> elementList = videoElement.getContent();
+        for (Content content : elementList) {
+            Element element = (Element) content;
+            if (element.getName().equals("format")) {
+                videoFormat = element.getText();
+            } else if (element.getName().equals("formatProfile")) {
+                videoFormatProfile = element.getText();
+            }
+        }
 
-	/**
-	 * Helper method to revise text in the identification element.
-	 * @param fitsXml
-	 * @throws JDOMException
-	 */
-	private void reviseIdentification (Document fitsXml )
-					throws JDOMException {
-
-		//
-		// Get the format and formatProfile from the video track element
-		//
-		String videoFormat = "";
-		String videoFormatProfile = "";
-
-	    // NOTE: We need to add a namespace	to xpath, because JDom XPath
-	    // does not support default namespaces. It requires you to add a
-	    // fake namespace to the XPath instance.
-        XPathExpression<Element> expr = xFactory.compile("//x:fits/x:metadata/x:video", Filters.element(), null, fitsNamespace);
-
-	    Element videoElement = expr.evaluateFirst(fitsXml);
-	    List <Content>elementList = videoElement.getContent();
-	    for (Content content : elementList) {
-	        Element element = (Element)content;
-	    	if(element.getName().equals("format")) {
-	    		videoFormat = element.getText();
-	    	}
-	    	else if(element.getName().equals("formatProfile")) {
-	    		videoFormatProfile = element.getText();
-	    	}
-	    }
-
-		//
-		// Normalize the format and mimetype to "video/quicktime" and
-	    // Quicktime
-		//
+        //
+        // Normalize the format and mimetype to "video/quicktime" and
+        // Quicktime
+        //
         // NOTE: We need to add a namespace to xpath, because JDom XPath
         // does not support default namespaces. It requires you to add a
         // fake namespace to the XPath instance.
-        XPathExpression<Element> identityExpr = xFactory.compile("//x:fits/x:identification", Filters.element(), null, fitsNamespace);
-	    Element identityElement = identityExpr.evaluateFirst(fitsXml);
-	    List<Content>elementIdentityList = identityElement.getContent();
-	    for (Content content : elementIdentityList) {
+        XPathExpression<Element> identityExpr =
+                xFactory.compile("//x:fits/x:identification", Filters.element(), null, fitsNamespace);
+        Element identityElement = identityExpr.evaluateFirst(fitsXml);
+        List<Content> elementIdentityList = identityElement.getContent();
+        for (Content content : elementIdentityList) {
 
-	        Element elementIdentity = (Element)content;
-	    	Attribute formatAttrib = elementIdentity.getAttribute("format");
-	    	Attribute mimeAttrib = elementIdentity.getAttribute("mimetype");
+            Element elementIdentity = (Element) content;
+            Attribute formatAttrib = elementIdentity.getAttribute("format");
+            Attribute mimeAttrib = elementIdentity.getAttribute("mimetype");
 
-	    	// Only Reset the format and mimetype if they are the format and
-	    	// formatProfile from the video section are the required types
-	    	if(formatAttrib != null && mimeAttrib != null) {
-		    	if(videoFormat.toUpperCase().contains(MPEG4_FORMAT) && videoFormatProfile.toUpperCase().equals(QUICKTIME_FORMAT.toUpperCase())){
-		    		formatAttrib.setValue(QUICKTIME_FORMAT);
-		    		mimeAttrib.setValue(QUICKTIME_MIMETYPE);
-		    	}
-		    	else if(videoFormat.toUpperCase().contains(MPEG4_FORMAT) && mimeAttrib.getValue().equals(QUICKTIME_MIMETYPE)){
-		    		formatAttrib.setValue(QUICKTIME_FORMAT);
-		    	}
-	    		break;
-	    	}
-	    }
-
-	}
-
-	/**
-	 * Helper method to revise text in the element passed in. If the element
-	 * is found to have an associated value in the map, the current text of
-	 * the element is revised.
-	 *
-	 * @param element jdom element to be revised
-	 * @param generalValuesDataMap map holding video elements to revise
-	 */
-	private void reviseGeneralSection(Element element,
-			Map<String, String> generalValuesDataMap) {
-
-    	// General size
-    	if(element.getName().equals("size")) {
-    		String generalFileSize = generalValuesDataMap.get("generalFileSize");
-			if (!StringUtils.isEmpty(generalFileSize)) {
-				element.setText(generalFileSize);
-			}
-    	}
-
-    	// General Section dateModified
-    	else if(element.getName().equals("dateModified")) {
-    		String dateModified = generalValuesDataMap.get("dateModified");
-			if (!StringUtils.isEmpty(dateModified)) {
-				element.setText(dateModified);
-			}
-    	}
-    	// General Section timecodeStart
-    	else if(element.getName().equals("timecodeStart")) {
-    		String timeCodeStart = generalValuesDataMap.get("timeCodeStart");
-			if (!StringUtils.isEmpty(timeCodeStart)) {
-				element.setText(timeCodeStart);
-			}
-    	}
-    	// General Section bit rate
-    	else if(element.getName().equals("bitRate")) {
-    		String generalBitRate = generalValuesDataMap.get("generalBitRate");
-			if (!StringUtils.isEmpty(generalBitRate)) {
-				element.setText(generalBitRate);
-			}
-    	}
-
-    	// General Section duration
-    	else if(element.getName().equals("duration")) {
-    		String generalDuration = generalValuesDataMap.get("generalDuration");
-			if (!StringUtils.isEmpty(generalDuration)) {
-				element.setText(generalDuration);
-			}
-    	}
-
-    	// For now, the MD5 will be put in Ebucore manually AFTER FITS generates it.
-    	//// General Section  MD5
-    	//else if(element.getName().equals("filemd5")) {
-    	//	String generalMd5 = generalValuesDataMap.get("md5Hash");
-		//	if (!StringUtils.isEmpty(generalMd5)) {
-		//		element.setText(generalMd5);
-		//	}
-    	//}
-
-		// General Section formatProfile - If missing, use value from
-    	// video section, which was set above
-    	else if(element.getName().equals("formatProfile")) {
-			String formatProfileFromElement = element.getValue();
-			// if value for element is missing or empty, we need to update it
-			if(StringUtils.isEmpty(formatProfileFromElement)) {
-				String generalFormatProfileFromVideo = generalValuesDataMap.get("formatProfileFromElement");
-				if(generalFormatProfileFromVideo != null && generalFormatProfileFromVideo.length() > 0) {
-					element.setText(generalFormatProfileFromVideo);
-				}
-			}
-
-		}
-    	else if (element.getName().equals("format")) {
-    		String format = generalValuesDataMap.get("format");
-			if (!StringUtils.isEmpty(format)) {
-				element.setText(format);
-			}
-    	}
-
-	}
-
-	/**
-	 * Wrapper to the MediaInfo Get method to retrieve a MediaInfo String from
-	 * stream number 0, of info type text, using a named field.
-	 *
-	 * @param fieldName MediaInfo Field
-	 * @param streamType MediaInfoNativeWrapper.InfoKind
-	 * @return The data as a String
-	 */
-	private String getMediaInfoString(String fieldName,
-			MediaInfoNativeWrapper.StreamKind streamType) {
-		return getMediaInfoString(0, fieldName, streamType);
-	}
-
-	/**
-	 * Wrapper to the MediaInfo Get method to retrieve a MediaInfo String from
-	 * the stream number passed in, of info type text, using a named field.
-	 *
-	 * @param streamNumber MediaInfo stream number
-	 * @param fieldName MediaInfo Field
-	 * @param streamType MediaInfoNativeWrapper.InfoKind
-	 * @return The data as a String
-	 */
-	private String getMediaInfoString(int streamNumber, String fieldName,
-			MediaInfoNativeWrapper.StreamKind streamType) {
-		return mi.Get(streamType, streamNumber, fieldName,
-				MediaInfoNativeWrapper.InfoKind.Text,
-	    		MediaInfoNativeWrapper.InfoKind.Name);
-	}
-
-	private String convertToNormalizedData(String originalString, String labelToPreserve) {
-		return StringUtils.deleteWhitespace(originalString.replace(labelToPreserve, "")) + labelToPreserve;
-
-	}
-
-	/**
-	 * Helper method to revise text in the video track element passed in. The
-	 * id is used as a key to a map of values. If the element's name is found
-	 * in the map, the value in the map is used to replace the current text of
-	 * the element.
-	 *
-	 * @param element jdom element to be revised
-	 * @param id track key to the map value
-	 * @param videoTrackValuesMap map holding video elements to revise
-	 */
-    private void reviseVideoSection(Element element, String id,
-    		Map<String, Map<String, String>> videoTrackValuesMap) {
-
-    	// Remove any empty elements
-    	// Right now it is only scanning order
-    	List<Element> elementsToRemove = new ArrayList<Element>();
-
-    	List<Content>contents = element.getContent();
-    	for (Content content : contents) {
-    	    Element childElement = (Element)content;
-    		String name = childElement.getName();
-
-       		// If the element name is one which has to be normalized, do so.
-    		ElementsToNormalize elementToNomalize = ElementsToNormalize.lookup(name);
-    		if(elementToNomalize != null) {
-    			String value = childElement.getValue();
-    			if(!StringUtils.isEmpty(value)) {
-        			value = convertToNormalizedData(value, elementToNomalize.getUnits());
-    				// If we got here, then we need to update the element's text
-    				if(!StringUtils.isEmpty(value))
-    					childElement.setText(value);
-    			}
-    			continue;
-    		}
-    		// End normalize
-
-
-    		// If the "name" is not contained in the enum, continue
-    		VideoMethods videoValueEnum = VideoMethods.lookup(name);
-    		if(videoValueEnum == null)
-    			continue;
-
-    		String value = videoTrackValuesMap.get(id).get(videoValueEnum.getName());
-    		switch (videoValueEnum) {
-    		// bitRate
-    		// 1) correct format
-    		// 2) set to bitRateMax, if mode is variable
-    		case bitRate:
-    			// NOTE: If the bitRateMode is Variable (VBR), set it to the value for
-    			// BitRateMax
-    			String bitRateMode = videoTrackValuesMap.get(id).get("bitRateMode");
-    			if(!StringUtils.isEmpty(bitRateMode) && bitRateMode.equals("Variable")) {
-    				String bitRateMax = videoTrackValuesMap.get(id).get("bitRateMax");
-    				if(!StringUtils.isEmpty(bitRateMax)) {
-    					childElement.setText(bitRateMax);
-    					value = bitRateMax;
-    				}
-    			}
-    			break;
-    		case frameRate:
-    			// NOTE: If the bitRateMode is Variable (VFR), set it to the value for
-    			// BitRateMax
-    			String frameRateMode = videoTrackValuesMap.get(id).get("frameRateMode");
-    			if(!StringUtils.isEmpty(frameRateMode) && (frameRateMode.equals("Variable") || frameRateMode.equals("VFR"))) {
-    				String frameRateMax = videoTrackValuesMap.get(id).get("frameRateMax");
-    				if(!StringUtils.isEmpty(frameRateMax)) {
-    					childElement.setText(frameRateMax);
-    					value = frameRateMax;
-    				}
-    			}
-    			break;
-
-    		case scanningOrder:
-    			// TODO: Fix the below ...
-    			// It was noticed that might display BFF (Bottom Filed First),
-    			// instead of TFF (Top Field First) for interlaced videos
-    			// See:
-    			// https://mediaarea.net/en-us/MediaInfo/Support/FAQ
-    			// Section:
-    			// MediaInfo states video is Bottom Filed First when it is actually Top Field First
-        		if(!StringUtils.isEmpty(value))
-        			childElement.setText(value);
-        		else {	// Remove the child element if it is empty
-        			elementsToRemove.add(childElement);
-        		}
-    			break;
-    		default:
-    			break;
-
-    		}	// switch
-
-    		// If we got here, then we need to update the element's text
-    		if(!StringUtils.isEmpty(value))
-    			childElement.setText(value);
-
-    	} // childElement
-
-    	// Remove all elements marked as empty
-    	for (Element elementToRemove : elementsToRemove) {
-    		elementToRemove.getParent().removeContent(elementToRemove);
-    	}
+            // Only Reset the format and mimetype if they are the format and
+            // formatProfile from the video section are the required types
+            if (formatAttrib != null && mimeAttrib != null) {
+                if (videoFormat.toUpperCase().contains(MPEG4_FORMAT)
+                        && videoFormatProfile.toUpperCase().equals(QUICKTIME_FORMAT.toUpperCase())) {
+                    formatAttrib.setValue(QUICKTIME_FORMAT);
+                    mimeAttrib.setValue(QUICKTIME_MIMETYPE);
+                } else if (videoFormat.toUpperCase().contains(MPEG4_FORMAT)
+                        && mimeAttrib.getValue().equals(QUICKTIME_MIMETYPE)) {
+                    formatAttrib.setValue(QUICKTIME_FORMAT);
+                }
+                break;
+            }
+        }
     }
 
-	/**
-	 * Helper method to revise text in the audio track element passed in. The
-	 * id is used as a key to a map of values. If the element's name is found
-	 * in the map, the value in the map is used to replace the current text of
-	 * the element.
-	 *
-	 * @param element jdom element to be revised
-	 * @param id track key to the map value
-	 * @param  audioTrackValuesMap map holding audio elements to revise
-	 */
-    private void reviseAudioSection(Element element, String id,
-    		Map<String, Map<String, String>> audioTrackValuesMap) {
+    /**
+     * Helper method to revise text in the element passed in. If the element
+     * is found to have an associated value in the map, the current text of
+     * the element is revised.
+     *
+     * @param element jdom element to be revised
+     * @param generalValuesDataMap map holding video elements to revise
+     */
+    private void reviseGeneralSection(Element element, Map<String, String> generalValuesDataMap) {
 
-    	List<Content>contents = element.getContent();
-    	for (Content content : contents) {
-    	    Element childElement = (Element)content;
-    		String name = childElement.getName();
+        // General size
+        if (element.getName().equals("size")) {
+            String generalFileSize = generalValuesDataMap.get("generalFileSize");
+            if (!StringUtils.isEmpty(generalFileSize)) {
+                element.setText(generalFileSize);
+            }
+        }
 
-    		// If the "name" is not contained in the enum, continue
-    		AudioMethods audioValueEnum = AudioMethods.lookup(name);
-    		if(audioValueEnum == null)
-    			continue;
+        // General Section dateModified
+        else if (element.getName().equals("dateModified")) {
+            String dateModified = generalValuesDataMap.get("dateModified");
+            if (!StringUtils.isEmpty(dateModified)) {
+                element.setText(dateModified);
+            }
+        }
+        // General Section timecodeStart
+        else if (element.getName().equals("timecodeStart")) {
+            String timeCodeStart = generalValuesDataMap.get("timeCodeStart");
+            if (!StringUtils.isEmpty(timeCodeStart)) {
+                element.setText(timeCodeStart);
+            }
+        }
+        // General Section bit rate
+        else if (element.getName().equals("bitRate")) {
+            String generalBitRate = generalValuesDataMap.get("generalBitRate");
+            if (!StringUtils.isEmpty(generalBitRate)) {
+                element.setText(generalBitRate);
+            }
+        }
 
-    		String value = audioTrackValuesMap.get(id).get(audioValueEnum.getName());
-    		switch (audioValueEnum) {
-    		// bitRate
-    		// 1) correct format
-    		// 2) set to bitRateMax, if mode is variable
-    		case bitRate:
-    			// NOTE: If the bitRateMode is Variable (VBR), set it to the value for
-    			// BitRateMax
-    			String bitRateMode = audioTrackValuesMap.get(id).get("bitRateMode");
-    			if(!StringUtils.isEmpty(bitRateMode) && (bitRateMode.equals("Variable") || bitRateMode.equals("VBR"))) {
-    				String bitRateMax = audioTrackValuesMap.get(id).get("bitRateMax");
-    				if(!StringUtils.isEmpty(bitRateMax)) {
-    					childElement.setText(bitRateMax);
-    					value = bitRateMax;
-    				}
-    			}
-    			break;
-    		default:
-    			break;
+        // General Section duration
+        else if (element.getName().equals("duration")) {
+            String generalDuration = generalValuesDataMap.get("generalDuration");
+            if (!StringUtils.isEmpty(generalDuration)) {
+                element.setText(generalDuration);
+            }
+        }
 
-    		}	// switch
+        // For now, the MD5 will be put in Ebucore manually AFTER FITS generates it.
+        //// General Section  MD5
+        // else if(element.getName().equals("filemd5")) {
+        //	String generalMd5 = generalValuesDataMap.get("md5Hash");
+        //	if (!StringUtils.isEmpty(generalMd5)) {
+        //		element.setText(generalMd5);
+        //	}
+        // }
 
-    		// If we got here, then we need to update the element's text
-    		if(!StringUtils.isEmpty(value))
-    			childElement.setText(value);
+        // General Section formatProfile - If missing, use value from
+        // video section, which was set above
+        else if (element.getName().equals("formatProfile")) {
+            String formatProfileFromElement = element.getValue();
+            // if value for element is missing or empty, we need to update it
+            if (StringUtils.isEmpty(formatProfileFromElement)) {
+                String generalFormatProfileFromVideo = generalValuesDataMap.get("formatProfileFromElement");
+                if (generalFormatProfileFromVideo != null && generalFormatProfileFromVideo.length() > 0) {
+                    element.setText(generalFormatProfileFromVideo);
+                }
+            }
 
-    	} // childElement
+        } else if (element.getName().equals("format")) {
+            String format = generalValuesDataMap.get("format");
+            if (!StringUtils.isEmpty(format)) {
+                element.setText(format);
+            }
+        }
     }
 
-	protected void removeEmptyElements (Document fitsXml) throws FitsToolException {
+    /**
+     * Wrapper to the MediaInfo Get method to retrieve a MediaInfo String from
+     * stream number 0, of info type text, using a named field.
+     *
+     * @param fieldName MediaInfo Field
+     * @param streamType MediaInfoNativeWrapper.InfoKind
+     * @return The data as a String
+     */
+    private String getMediaInfoString(String fieldName, MediaInfoNativeWrapper.StreamKind streamType) {
+        return getMediaInfoString(0, fieldName, streamType);
+    }
 
-    	// Remove any empty elements
-    	// Right now it is only scanning order
-    	List<Element> elementsToRemove = new ArrayList<Element>();
+    /**
+     * Wrapper to the MediaInfo Get method to retrieve a MediaInfo String from
+     * the stream number passed in, of info type text, using a named field.
+     *
+     * @param streamNumber MediaInfo stream number
+     * @param fieldName MediaInfo Field
+     * @param streamType MediaInfoNativeWrapper.InfoKind
+     * @return The data as a String
+     */
+    private String getMediaInfoString(
+            int streamNumber, String fieldName, MediaInfoNativeWrapper.StreamKind streamType) {
+        return mi.Get(
+                streamType,
+                streamNumber,
+                fieldName,
+                MediaInfoNativeWrapper.InfoKind.Text,
+                MediaInfoNativeWrapper.InfoKind.Name);
+    }
 
-	    // NOTE: We need to add a namespace	to xpath, because JDom XPath
-	    // does not support default namespaces. It requires you to add a
-	    // fake namespace to the XPath instance.
-        XPathExpression<Element> expr = xFactory.compile("//x:fits/x:metadata/x:video", Filters.element(), null, fitsNamespace);
+    private String convertToNormalizedData(String originalString, String labelToPreserve) {
+        return StringUtils.deleteWhitespace(originalString.replace(labelToPreserve, "")) + labelToPreserve;
+    }
 
-	    Element videoElement = (Element)expr.evaluateFirst(fitsXml);
-	    List<Content>elementList = videoElement.getContent();
-	    for (Content content : elementList) {
+    /**
+     * Helper method to revise text in the video track element passed in. The
+     * id is used as a key to a map of values. If the element's name is found
+     * in the map, the value in the map is used to replace the current text of
+     * the element.
+     *
+     * @param element jdom element to be revised
+     * @param id track key to the map value
+     * @param videoTrackValuesMap map holding video elements to revise
+     */
+    private void reviseVideoSection(Element element, String id, Map<String, Map<String, String>> videoTrackValuesMap) {
 
-	        Element element = (Element)content;
-	    	// Tracks
-	    	if(element.getName().equals("track")) {
+        // Remove any empty elements
+        // Right now it is only scanning order
+        List<Element> elementsToRemove = new ArrayList<Element>();
 
-	        	List<Content>contents = element.getContent();
-	        	
-	        	for (Content subContent  : contents) {
-	        	    Element childElement = (Element)subContent;
-	        		String value = childElement.getText();
-	        		if(StringUtils.isEmpty(value)) {
-	        			elementsToRemove.add(childElement);
-	        		}
-	        	}
+        List<Content> contents = element.getContent();
+        for (Content content : contents) {
+            Element childElement = (Element) content;
+            String name = childElement.getName();
 
-	    	}
-	    }
+            // If the element name is one which has to be normalized, do so.
+            ElementsToNormalize elementToNomalize = ElementsToNormalize.lookup(name);
+            if (elementToNomalize != null) {
+                String value = childElement.getValue();
+                if (!StringUtils.isEmpty(value)) {
+                    value = convertToNormalizedData(value, elementToNomalize.getUnits());
+                    // If we got here, then we need to update the element's text
+                    if (!StringUtils.isEmpty(value)) childElement.setText(value);
+                }
+                continue;
+            }
+            // End normalize
 
-    	// Remove all elements marked as empty
-    	for (Element elementToRemove : elementsToRemove) {
-    		elementToRemove.getParent().removeContent(elementToRemove);
-    	}
-	}
+            // If the "name" is not contained in the enum, continue
+            VideoMethods videoValueEnum = VideoMethods.lookup(name);
+            if (videoValueEnum == null) continue;
 
+            String value = videoTrackValuesMap.get(id).get(videoValueEnum.getName());
+            switch (videoValueEnum) {
+                    // bitRate
+                    // 1) correct format
+                    // 2) set to bitRateMax, if mode is variable
+                case bitRate:
+                    // NOTE: If the bitRateMode is Variable (VBR), set it to the value for
+                    // BitRateMax
+                    String bitRateMode = videoTrackValuesMap.get(id).get("bitRateMode");
+                    if (!StringUtils.isEmpty(bitRateMode) && bitRateMode.equals("Variable")) {
+                        String bitRateMax = videoTrackValuesMap.get(id).get("bitRateMax");
+                        if (!StringUtils.isEmpty(bitRateMax)) {
+                            childElement.setText(bitRateMax);
+                            value = bitRateMax;
+                        }
+                    }
+                    break;
+                case frameRate:
+                    // NOTE: If the bitRateMode is Variable (VFR), set it to the value for
+                    // BitRateMax
+                    String frameRateMode = videoTrackValuesMap.get(id).get("frameRateMode");
+                    if (!StringUtils.isEmpty(frameRateMode)
+                            && (frameRateMode.equals("Variable") || frameRateMode.equals("VFR"))) {
+                        String frameRateMax = videoTrackValuesMap.get(id).get("frameRateMax");
+                        if (!StringUtils.isEmpty(frameRateMax)) {
+                            childElement.setText(frameRateMax);
+                            value = frameRateMax;
+                        }
+                    }
+                    break;
+
+                case scanningOrder:
+                    // TODO: Fix the below ...
+                    // It was noticed that might display BFF (Bottom Filed First),
+                    // instead of TFF (Top Field First) for interlaced videos
+                    // See:
+                    // https://mediaarea.net/en-us/MediaInfo/Support/FAQ
+                    // Section:
+                    // MediaInfo states video is Bottom Filed First when it is actually Top Field First
+                    if (!StringUtils.isEmpty(value)) childElement.setText(value);
+                    else { // Remove the child element if it is empty
+                        elementsToRemove.add(childElement);
+                    }
+                    break;
+                default:
+                    break;
+            } // switch
+
+            // If we got here, then we need to update the element's text
+            if (!StringUtils.isEmpty(value)) childElement.setText(value);
+        } // childElement
+
+        // Remove all elements marked as empty
+        for (Element elementToRemove : elementsToRemove) {
+            elementToRemove.getParent().removeContent(elementToRemove);
+        }
+    }
+
+    /**
+     * Helper method to revise text in the audio track element passed in. The
+     * id is used as a key to a map of values. If the element's name is found
+     * in the map, the value in the map is used to replace the current text of
+     * the element.
+     *
+     * @param element jdom element to be revised
+     * @param id track key to the map value
+     * @param  audioTrackValuesMap map holding audio elements to revise
+     */
+    private void reviseAudioSection(Element element, String id, Map<String, Map<String, String>> audioTrackValuesMap) {
+
+        List<Content> contents = element.getContent();
+        for (Content content : contents) {
+            Element childElement = (Element) content;
+            String name = childElement.getName();
+
+            // If the "name" is not contained in the enum, continue
+            AudioMethods audioValueEnum = AudioMethods.lookup(name);
+            if (audioValueEnum == null) continue;
+
+            String value = audioTrackValuesMap.get(id).get(audioValueEnum.getName());
+            switch (audioValueEnum) {
+                    // bitRate
+                    // 1) correct format
+                    // 2) set to bitRateMax, if mode is variable
+                case bitRate:
+                    // NOTE: If the bitRateMode is Variable (VBR), set it to the value for
+                    // BitRateMax
+                    String bitRateMode = audioTrackValuesMap.get(id).get("bitRateMode");
+                    if (!StringUtils.isEmpty(bitRateMode)
+                            && (bitRateMode.equals("Variable") || bitRateMode.equals("VBR"))) {
+                        String bitRateMax = audioTrackValuesMap.get(id).get("bitRateMax");
+                        if (!StringUtils.isEmpty(bitRateMax)) {
+                            childElement.setText(bitRateMax);
+                            value = bitRateMax;
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            } // switch
+
+            // If we got here, then we need to update the element's text
+            if (!StringUtils.isEmpty(value)) childElement.setText(value);
+        } // childElement
+    }
+
+    protected void removeEmptyElements(Document fitsXml) throws FitsToolException {
+
+        // Remove any empty elements
+        // Right now it is only scanning order
+        List<Element> elementsToRemove = new ArrayList<Element>();
+
+        // NOTE: We need to add a namespace	to xpath, because JDom XPath
+        // does not support default namespaces. It requires you to add a
+        // fake namespace to the XPath instance.
+        XPathExpression<Element> expr =
+                xFactory.compile("//x:fits/x:metadata/x:video", Filters.element(), null, fitsNamespace);
+
+        Element videoElement = (Element) expr.evaluateFirst(fitsXml);
+        List<Content> elementList = videoElement.getContent();
+        for (Content content : elementList) {
+
+            Element element = (Element) content;
+            // Tracks
+            if (element.getName().equals("track")) {
+
+                List<Content> contents = element.getContent();
+
+                for (Content subContent : contents) {
+                    Element childElement = (Element) subContent;
+                    String value = childElement.getText();
+                    if (StringUtils.isEmpty(value)) {
+                        elementsToRemove.add(childElement);
+                    }
+                }
+            }
+        }
+
+        // Remove all elements marked as empty
+        for (Element elementToRemove : elementsToRemove) {
+            elementToRemove.getParent().removeContent(elementToRemove);
+        }
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/OsCheck.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/OsCheck.java
@@ -23,35 +23,38 @@ import java.util.Locale;
 
 public final class OsCheck {
 
-  /**
-   * types of Operating Systems
-   */
-  public enum OSType {
-    Windows, MacOS, Linux, Other
-  };
+    /**
+     * types of Operating Systems
+     */
+    public enum OSType {
+        Windows,
+        MacOS,
+        Linux,
+        Other
+    };
 
-  // cached result of OS detection
-  protected static OSType detectedOS;
+    // cached result of OS detection
+    protected static OSType detectedOS;
 
-  /**
-   * detect the operating system from the os.name System property and cache
-   * the result
-   *
-   * @return - the operating system detected
-   */
-  public static OSType getOperatingSystemType() {
-    if (detectedOS == null) {
-      String OS = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
-      if ((OS.indexOf("mac") >= 0) || (OS.indexOf("darwin") >= 0)) {
-        detectedOS = OSType.MacOS;
-      } else if (OS.indexOf("win") >= 0) {
-        detectedOS = OSType.Windows;
-      } else if (OS.indexOf("linux") >= 0) {
-        detectedOS = OSType.Linux;
-      } else {
-        detectedOS = OSType.Other;
-      }
+    /**
+     * detect the operating system from the os.name System property and cache
+     * the result
+     *
+     * @return - the operating system detected
+     */
+    public static OSType getOperatingSystemType() {
+        if (detectedOS == null) {
+            String OS = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
+            if ((OS.indexOf("mac") >= 0) || (OS.indexOf("darwin") >= 0)) {
+                detectedOS = OSType.MacOS;
+            } else if (OS.indexOf("win") >= 0) {
+                detectedOS = OSType.Windows;
+            } else if (OS.indexOf("linux") >= 0) {
+                detectedOS = OSType.Linux;
+            } else {
+                detectedOS = OSType.Other;
+            }
+        }
+        return detectedOS;
     }
-    return detectedOS;
-  }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/VideoMethods.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/VideoMethods.java
@@ -11,38 +11,38 @@
 package edu.harvard.hul.ois.fits.tools.mediainfo;
 
 public enum VideoMethods {
-	delay ("delay"),
-	frameCount ("frameCount"),
-	bitRate ("bitRate"),
-	codecCC ("codecCC"),
-	codecId ("codecId"),
-	codecFamily ("codecFamily"),
-	codecName ("codecName"),
-	codecVersion ("codecVersion"),
-	codecInfo ("codecInfo"),
-	duration ("duration"),
-	trackSize ("trackSize"),
-	frameRate ("frameRate"),
-	scanningOrder ("scanningOrder");
+    delay("delay"),
+    frameCount("frameCount"),
+    bitRate("bitRate"),
+    codecCC("codecCC"),
+    codecId("codecId"),
+    codecFamily("codecFamily"),
+    codecName("codecName"),
+    codecVersion("codecVersion"),
+    codecInfo("codecInfo"),
+    duration("duration"),
+    trackSize("trackSize"),
+    frameRate("frameRate"),
+    scanningOrder("scanningOrder");
 
-	private String name;
+    private String name;
 
-	VideoMethods(String name) {
+    VideoMethods(String name) {
         this.name = name;
     }
 
-    public String getName () {
+    public String getName() {
         return name;
     }
 
-    static public VideoMethods lookup(String name) {
-    	VideoMethods retMethod = null;
-    	for(VideoMethods method : VideoMethods.values()) {
-    		if (method.getName().equals(name)) {
-    			retMethod = method;
-    			break;
-    		}
-    	}
-    	return retMethod;
+    public static VideoMethods lookup(String name) {
+        VideoMethods retMethod = null;
+        for (VideoMethods method : VideoMethods.values()) {
+            if (method.getName().equals(name)) {
+                retMethod = method;
+                break;
+            }
+        }
+        return retMethod;
     }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/nlnz/MetadataExtractor.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/nlnz/MetadataExtractor.java
@@ -10,11 +10,25 @@
 
 package edu.harvard.hul.ois.fits.tools.nlnz;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.exceptions.FitsException;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import edu.harvard.hul.ois.fits.tools.ToolBase;
+import edu.harvard.hul.ois.fits.tools.ToolInfo;
+import edu.harvard.hul.ois.fits.tools.ToolOutput;
+import edu.harvard.hul.ois.fits.tools.utils.XsltTransformMap;
+import edu.harvard.hul.ois.fits.util.DateTimeUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
-
+import nz.govt.natlib.AdapterFactory;
+import nz.govt.natlib.adapter.DataAdapter;
+import nz.govt.natlib.fx.ParserContext;
+import nz.govt.natlib.fx.ParserListener;
+import nz.govt.natlib.meta.config.Config;
+import nz.govt.natlib.meta.harvester.DTDXmlParserListener;
+import nz.govt.natlib.meta.log.LogManager;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -25,173 +39,157 @@ import org.jdom2.xpath.XPathFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.exceptions.FitsException;
-import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
-import edu.harvard.hul.ois.fits.tools.ToolBase;
-import edu.harvard.hul.ois.fits.tools.ToolInfo;
-import edu.harvard.hul.ois.fits.tools.ToolOutput;
-import edu.harvard.hul.ois.fits.tools.utils.XsltTransformMap;
-import edu.harvard.hul.ois.fits.util.DateTimeUtil;
-import nz.govt.natlib.AdapterFactory;
-import nz.govt.natlib.adapter.DataAdapter;
-import nz.govt.natlib.fx.ParserContext;
-import nz.govt.natlib.fx.ParserListener;
-import nz.govt.natlib.meta.config.Config;
-import nz.govt.natlib.meta.harvester.DTDXmlParserListener;
-import nz.govt.natlib.meta.log.LogManager;
-
 /**  The glue class for invoking the NLNZ Metadata Extractor under FITS.
  */
 public class MetadataExtractor extends ToolBase {
 
-    private final static String TOOL_NAME = "NLNZ Metadata Extractor";
-    private final static String TOOL_VERSION = "3.6GA";
-    private final static String TOOL_DATE = "06/05/2014";
+    private static final String TOOL_NAME = "NLNZ Metadata Extractor";
+    private static final String TOOL_VERSION = "3.6GA";
+    private static final String TOOL_DATE = "06/05/2014";
 
     private static String nlnzFitsConfig;
-	private boolean enabled = true;
+    private boolean enabled = true;
     private Fits fits;
 
-    private static Namespace fitsNS = Namespace.getNamespace("fits",Fits.XML_NAMESPACE);
+    private static Namespace fitsNS = Namespace.getNamespace("fits", Fits.XML_NAMESPACE);
     private XPathFactory xFactory = XPathFactory.instance();
 
-	private static final Logger logger = LoggerFactory.getLogger(MetadataExtractor.class);
+    private static final Logger logger = LoggerFactory.getLogger(MetadataExtractor.class);
 
     static {
-    	nlnzFitsConfig = Fits.FITS_XML_DIR+"nlnz"+File.separator+"fits"+File.separator;
-    	logger.debug("nlnzFitsConfig: " + nlnzFitsConfig);
+        nlnzFitsConfig = Fits.FITS_XML_DIR + "nlnz" + File.separator + "fits" + File.separator;
+        logger.debug("nlnzFitsConfig: " + nlnzFitsConfig);
     }
 
-	public MetadataExtractor(Fits fits) throws FitsException {
-		super();
-		this.fits = fits;
-        logger.debug ("Initializing MetadataExtractor");
-		info = new ToolInfo(TOOL_NAME,TOOL_VERSION,TOOL_DATE);
-		transformMap = XsltTransformMap.getMap(nlnzFitsConfig+"nlnz_xslt_map.xml");
+    public MetadataExtractor(Fits fits) throws FitsException {
+        super();
+        this.fits = fits;
+        logger.debug("Initializing MetadataExtractor");
+        info = new ToolInfo(TOOL_NAME, TOOL_VERSION, TOOL_DATE);
+        transformMap = XsltTransformMap.getMap(nlnzFitsConfig + "nlnz_xslt_map.xml");
 
-		// HACK: need to set custom ClassLoader in NLNZ Config class so that it can find class names on Class.forName() call.
-		ClassLoader cl = MetadataExtractor.class.getClassLoader();
-		Config.setClassLoader(cl); // customized Config class; NOT the one supplied by NLNZ
-		// Use custom logger so that NLNZ code doesn't log to System.out by default
-		// (see what happens in nz.govt.natlib.meta.log.LogManager source code)
-		LogManager.getInstance().addLog(new SLF4JLogger());
-	}
+        // HACK: need to set custom ClassLoader in NLNZ Config class so that it can find class names on Class.forName()
+        // call.
+        ClassLoader cl = MetadataExtractor.class.getClassLoader();
+        Config.setClassLoader(cl); // customized Config class; NOT the one supplied by NLNZ
+        // Use custom logger so that NLNZ code doesn't log to System.out by default
+        // (see what happens in nz.govt.natlib.meta.log.LogManager source code)
+        LogManager.getInstance().addLog(new SLF4JLogger());
+    }
 
-	public ToolOutput extractInfo(File file) throws FitsToolException {
+    public ToolOutput extractInfo(File file) throws FitsToolException {
         logger.debug("MetadataExtractor.extractInfo starting on " + file.getName());
-		long startTime = System.currentTimeMillis();
-		Document dom = null;
-		//Document rawDom = null;
+        long startTime = System.currentTimeMillis();
+        Document dom = null;
+        // Document rawDom = null;
 
-		// Make sure the Harvester System is initialized.
-		//Config.getInstance();
+        // Make sure the Harvester System is initialized.
+        // Config.getInstance();
 
-		String baseUrl = Fits.FITS_XML_DIR+"nlnz";
-		Config.getInstance().setXMLBaseURL(baseUrl);
+        String baseUrl = Fits.FITS_XML_DIR + "nlnz";
+        Config.getInstance().setXMLBaseURL(baseUrl);
 
-		// Get the appropriate adapter.
-		DataAdapter adapter = AdapterFactory.getInstance().getAdapter(file);
+        // Get the appropriate adapter.
+        DataAdapter adapter = AdapterFactory.getInstance().getAdapter(file);
 
-		//The adapter's DTD to use for output
-		String outDTD = adapter.getOutputType();
+        // The adapter's DTD to use for output
+        String outDTD = adapter.getOutputType();
 
-		//output stream to hold raw output from adapter
-		ByteArrayOutputStream adapterOutput = new ByteArrayOutputStream(2048);
+        // output stream to hold raw output from adapter
+        ByteArrayOutputStream adapterOutput = new ByteArrayOutputStream(2048);
 
-		//holder for the transformed adapter output
-		//ByteArrayOutputStream tAdapterOutput = new ByteArrayOutputStream(2048);
+        // holder for the transformed adapter output
+        // ByteArrayOutputStream tAdapterOutput = new ByteArrayOutputStream(2048);
 
-		// Set up the parser context and listener to hold the adapter output
-		ParserContext pContext = new ParserContext();
+        // Set up the parser context and listener to hold the adapter output
+        ParserContext pContext = new ParserContext();
 
-		ParserListener listener= new DTDXmlParserListener(adapterOutput, outDTD == null ? null
-				: Config.getInstance().getXMLBaseURL() + "/" + outDTD);
-		pContext.addListener(listener);
+        ParserListener listener = new DTDXmlParserListener(
+                adapterOutput, outDTD == null ? null : Config.getInstance().getXMLBaseURL() + "/" + outDTD);
+        pContext.addListener(listener);
 
-		// Attempt to harvest the metadata.
-		try {
-			// Extract the metadata.
-			adapter.adapt(file, pContext);
-			dom = saxBuilder.build(new StringReader(adapterOutput.toString()));
-		}
-		catch (JDOMException e) {
-            logger.error("Error parsing NLNZ Metadata Extractor XML output: " + e.getClass().getName());
-			throw new FitsToolException("Error parsing NLNZ Metadata Extractor XML output",e);
-		}
-		catch (Exception e) {
-			// harvesting metadata failed
-            logger.error("NLNZ Metadata Extractor error while harvesting file: " + e.getClass().getName());
-			throw new FitsToolException("NLNZ Metadata Extractor error while harvesting file "+file.getName(),e);
-		}
-		finally {
-			//done with the adapter output streams so close them
-			try {
-				adapterOutput.close();
-				//tAdapterOutput.close();
-			} catch (IOException e) {
-			    logger.error("Error closing NLNZ Metadata Extractor XML output stream: " + e.getClass().getName());
-				throw new FitsToolException("Error closing NLNZ Metadata Extractor XML output stream",e);
-			}
-		}
+        // Attempt to harvest the metadata.
+        try {
+            // Extract the metadata.
+            adapter.adapt(file, pContext);
+            dom = saxBuilder.build(new StringReader(adapterOutput.toString()));
+        } catch (JDOMException e) {
+            logger.error("Error parsing NLNZ Metadata Extractor XML output: "
+                    + e.getClass().getName());
+            throw new FitsToolException("Error parsing NLNZ Metadata Extractor XML output", e);
+        } catch (Exception e) {
+            // harvesting metadata failed
+            logger.error("NLNZ Metadata Extractor error while harvesting file: "
+                    + e.getClass().getName());
+            throw new FitsToolException("NLNZ Metadata Extractor error while harvesting file " + file.getName(), e);
+        } finally {
+            // done with the adapter output streams so close them
+            try {
+                adapterOutput.close();
+                // tAdapterOutput.close();
+            } catch (IOException e) {
+                logger.error("Error closing NLNZ Metadata Extractor XML output stream: "
+                        + e.getClass().getName());
+                throw new FitsToolException("Error closing NLNZ Metadata Extractor XML output stream", e);
+            }
+        }
 
-		//FileIdentity identity = null;
-		Document fitsXml = null;
-		if(dom != null) {
-			String format = dom.getRootElement().getName();
-			//String format = XmlUtils.getDomValue(dom,"Format");
-			if(format != null) {
-				String xsltTransform = (String)transformMap.get(format.toUpperCase());
-				if(xsltTransform != null) {
-					fitsXml = transform(nlnzFitsConfig+xsltTransform,dom);
-				}
-			}
-		}
+        // FileIdentity identity = null;
+        Document fitsXml = null;
+        if (dom != null) {
+            String format = dom.getRootElement().getName();
+            // String format = XmlUtils.getDomValue(dom,"Format");
+            if (format != null) {
+                String xsltTransform = (String) transformMap.get(format.toUpperCase());
+                if (xsltTransform != null) {
+                    fitsXml = transform(nlnzFitsConfig + xsltTransform, dom);
+                }
+            }
+        }
 
-		//XmlUtils.printToConsole(dom);
+        // XmlUtils.printToConsole(dom);
 
-		standardizeTimestamp("//fits:fileinfo/fits:created", fitsXml);
-		standardizeTimestamp("//fits:fileinfo/fits:lastmodified", fitsXml);
+        standardizeTimestamp("//fits:fileinfo/fits:created", fitsXml);
+        standardizeTimestamp("//fits:fileinfo/fits:lastmodified", fitsXml);
 
-		output = new ToolOutput(this,fitsXml,dom, fits);
-		duration = System.currentTimeMillis()-startTime;
+        output = new ToolOutput(this, fitsXml, dom, fits);
+        duration = System.currentTimeMillis() - startTime;
         logger.debug("MetadataExtractor.extractInfo finished on " + file.getName());
-		runStatus = RunStatus.SUCCESSFUL;
-		return output;
-	}
-	/*
-	public boolean isIdentityKnown(FileIdentity identity) {
-		if(identity == null
-				|| identity.getMime() == null
-				|| identity.getMime().length() == 0
-				|| identity.getFormat() == null
-				|| identity.getFormat().length() == 0) {
-			return false;
-		}
-		String format = identity.getFormat();
-		String mime = identity.getMime();
-		if(format == null || mime.equalsIgnoreCase("file/unknown")) {
-			return false;
-		}
-		else {
-			return true;
-		}
-	}*/
-
-	public boolean isEnabled() {
-		return enabled;
-	}
-
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
-
-	private void standardizeTimestamp(String path, Document document) {
-        XPathExpression<Element> expr = xFactory.compile(path, Filters.element(), null, fitsNS);
-    	Element element = (Element) expr.evaluateFirst(document);
-    	if (element != null) {
-    		element.setText(DateTimeUtil.standardize(element.getText()));
+        runStatus = RunStatus.SUCCESSFUL;
+        return output;
+    }
+    /*
+    public boolean isIdentityKnown(FileIdentity identity) {
+    	if(identity == null
+    			|| identity.getMime() == null
+    			|| identity.getMime().length() == 0
+    			|| identity.getFormat() == null
+    			|| identity.getFormat().length() == 0) {
+    		return false;
     	}
-	}
+    	String format = identity.getFormat();
+    	String mime = identity.getMime();
+    	if(format == null || mime.equalsIgnoreCase("file/unknown")) {
+    		return false;
+    	}
+    	else {
+    		return true;
+    	}
+    }*/
 
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
+
+    private void standardizeTimestamp(String path, Document document) {
+        XPathExpression<Element> expr = xFactory.compile(path, Filters.element(), null, fitsNS);
+        Element element = (Element) expr.evaluateFirst(document);
+        if (element != null) {
+            element.setText(DateTimeUtil.standardize(element.getText()));
+        }
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/nlnz/SLF4JLogger.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/nlnz/SLF4JLogger.java
@@ -11,7 +11,6 @@
 package edu.harvard.hul.ois.fits.tools.nlnz;
 
 import java.io.IOException;
-
 import nz.govt.natlib.meta.log.Log;
 import nz.govt.natlib.meta.log.LogLevel;
 import nz.govt.natlib.meta.log.LogMessage;
@@ -25,72 +24,72 @@ import org.slf4j.LoggerFactory;
  */
 public class SLF4JLogger implements Log {
 
-	/*
-	 * Copyright 2006 The National Library of New Zealand
-	 *
-	 * Licensed under the Apache License, Version 2.0 (the "License"); you may
-	 * not use this file except in compliance with the License. You may obtain a
-	 * copy of the License at
-	 *
-	 * http://www.apache.org/licenses/LICENSE-2.0
-	 *
-	 * Unless required by applicable law or agreed to in writing, software
-	 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-	 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-	 * License for the specific language governing permissions and limitations
-	 * under the License.
-	 */
-	private static final Logger logger = LoggerFactory.getLogger(SLF4JLogger.class);
+    /*
+     * Copyright 2006 The National Library of New Zealand
+     *
+     * Licensed under the Apache License, Version 2.0 (the "License"); you may
+     * not use this file except in compliance with the License. You may obtain a
+     * copy of the License at
+     *
+     * http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+     * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+     * License for the specific language governing permissions and limitations
+     * under the License.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(SLF4JLogger.class);
 
-	public SLF4JLogger() {
-		super();
-	}
+    public SLF4JLogger() {
+        super();
+    }
 
-	public void logMessage(LogMessage message) {
-		LogLevel logLevel = message.getLevel();
-		int level = logLevel.getLevel();
+    public void logMessage(LogMessage message) {
+        LogLevel logLevel = message.getLevel();
+        int level = logLevel.getLevel();
 
-		if (level == LogMessage.CRITICAL.getLevel() ) {
-			logger.error( formatMessage(message, false) );
-		} else if (level == LogMessage.ERROR.getLevel() ) {
-			logger.error( formatMessage(message, false) );
-		} else if (level == LogMessage.DEBUG.getLevel() ) {
-			logger.debug( formatMessage(message, false) );
-		} else if (level == LogMessage.INFO.getLevel() ) {
-			logger.info( formatMessage(message, false) );
-		} else if (level == LogMessage.WORTHLESS_CHATTER.getLevel() ) {
-			logger.trace( formatMessage(message, false) );
-		} else {
-			// unknown level -- show full content of LogMessage
-			// arbitrarily picking 'warn'
-			logger.warn( formatMessage(message, true) );
-		}
-	}
+        if (level == LogMessage.CRITICAL.getLevel()) {
+            logger.error(formatMessage(message, false));
+        } else if (level == LogMessage.ERROR.getLevel()) {
+            logger.error(formatMessage(message, false));
+        } else if (level == LogMessage.DEBUG.getLevel()) {
+            logger.debug(formatMessage(message, false));
+        } else if (level == LogMessage.INFO.getLevel()) {
+            logger.info(formatMessage(message, false));
+        } else if (level == LogMessage.WORTHLESS_CHATTER.getLevel()) {
+            logger.trace(formatMessage(message, false));
+        } else {
+            // unknown level -- show full content of LogMessage
+            // arbitrarily picking 'warn'
+            logger.warn(formatMessage(message, true));
+        }
+    }
 
-	public void suspendEvents(boolean suspend) {
-		// no-op
-	}
+    public void suspendEvents(boolean suspend) {
+        // no-op
+    }
 
-	public void close() throws IOException {
-		// no-op
-	}
+    public void close() throws IOException {
+        // no-op
+    }
 
-	// Somehow spit out all that might be in one of their log messages.
-	private String formatMessage(LogMessage msg, boolean verbose) {
-		StringBuilder sb = new StringBuilder("NLNZ Logging -- ");
-		if ( !verbose ) {
-			sb.append(msg.getMessage());
-		} else {
-			sb.append("Source: [");
-			sb.append(msg.getSource());
-			sb.append("], Message: [");
-			sb.append(msg.getMessage());
-			sb.append("], Commen:t [");
-			sb.append(msg.getComment());
-			sb.append("], Level: [");
-			sb.append(msg.getLevel());
-			sb.append("]");
-		}
-		return sb.toString();
-	}
+    // Somehow spit out all that might be in one of their log messages.
+    private String formatMessage(LogMessage msg, boolean verbose) {
+        StringBuilder sb = new StringBuilder("NLNZ Logging -- ");
+        if (!verbose) {
+            sb.append(msg.getMessage());
+        } else {
+            sb.append("Source: [");
+            sb.append(msg.getSource());
+            sb.append("], Message: [");
+            sb.append(msg.getMessage());
+            sb.append("], Commen:t [");
+            sb.append(msg.getComment());
+            sb.append("], Level: [");
+            sb.append(msg.getLevel());
+            sb.append("]");
+        }
+        return sb.toString();
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/oisfileinfo/ADLTool.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/oisfileinfo/ADLTool.java
@@ -10,21 +10,18 @@
 
 package edu.harvard.hul.ois.fits.tools.oisfileinfo;
 
-import java.io.File;
-import java.io.FileReader;
-import java.util.Scanner;
-
-import org.jdom2.Attribute;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.Namespace;
-
 import com.therockquarry.aes31.adl.ADL;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
 import edu.harvard.hul.ois.fits.tools.ToolBase;
 import edu.harvard.hul.ois.fits.tools.ToolOutput;
+import java.io.File;
+import java.io.FileReader;
+import java.util.Scanner;
+import org.jdom2.Attribute;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,135 +32,128 @@ import org.slf4j.LoggerFactory;
  */
 public class ADLTool extends ToolBase {
 
-	private boolean enabled = true;
-	private Fits fits;
-	private final static Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
-	private final static Namespace xsiNS = Namespace.getNamespace("xsi","http://www.w3.org/2001/XMLSchema-instance");
-	private static final Logger logger = LoggerFactory.getLogger(ADLTool.class);
+    private boolean enabled = true;
+    private Fits fits;
+    private static final Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
+    private static final Namespace xsiNS = Namespace.getNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+    private static final Logger logger = LoggerFactory.getLogger(ADLTool.class);
 
-	public ADLTool(Fits fits) throws FitsToolException {
-		super();
-		this.fits = fits;
-		info.setName("ADL Tool");
-		info.setVersion("0.1");
-		info.setDate("10/24/11");
-	}
+    public ADLTool(Fits fits) throws FitsToolException {
+        super();
+        this.fits = fits;
+        info.setName("ADL Tool");
+        info.setVersion("0.1");
+        info.setDate("10/24/11");
+    }
 
-	public ToolOutput extractInfo(File file) throws FitsToolException {
+    public ToolOutput extractInfo(File file) throws FitsToolException {
         logger.debug("ADLTool.extractInfo starting on " + file.getName());
-		long startTime = System.currentTimeMillis();
-		Document doc = createXml(file);
-		output = new ToolOutput(this,(Document)doc.clone(),doc, fits);
-		duration = System.currentTimeMillis()-startTime;
-		runStatus = RunStatus.SUCCESSFUL;
-		logger.debug("ADLTool.extractInfo finishing on " + file.getName());
-		return output;
-	}
+        long startTime = System.currentTimeMillis();
+        Document doc = createXml(file);
+        output = new ToolOutput(this, (Document) doc.clone(), doc, fits);
+        duration = System.currentTimeMillis() - startTime;
+        runStatus = RunStatus.SUCCESSFUL;
+        logger.debug("ADLTool.extractInfo finishing on " + file.getName());
+        return output;
+    }
 
-	private Document createXml(File file) throws FitsToolException {
+    private Document createXml(File file) throws FitsToolException {
 
-		Element root = new Element("fits",fitsNS);
-		root.setAttribute(new Attribute("schemaLocation",
-										"http://hul.harvard.edu/ois/xml/ns/fits/fits_output " + fits.getExternalOutputSchema(),
-										xsiNS));
+        Element root = new Element("fits", fitsNS);
+        root.setAttribute(new Attribute(
+                "schemaLocation",
+                "http://hul.harvard.edu/ois/xml/ns/fits/fits_output " + fits.getExternalOutputSchema(),
+                xsiNS));
 
-		if(file.getPath().toLowerCase().endsWith(".adl")) {
+        if (file.getPath().toLowerCase().endsWith(".adl")) {
 
-			String adlVersion = null;
-			String adlCreator = null;
-			String adlCreatorVersion = null;
+            String adlVersion = null;
+            String adlCreator = null;
+            String adlCreatorVersion = null;
 
-			try	{
-				//creating an ADL object should be enough to validate it as ADL
-				new ADL(file);
+            try {
+                // creating an ADL object should be enough to validate it as ADL
+                new ADL(file);
 
-				Scanner scanner = new Scanner(new FileReader(file));
-			    try {
-			      //first use a Scanner to get each line
-			      while ( scanner.hasNextLine() ){
-			    	  String line = scanner.nextLine();
-			    	  if(line.contains("(VER_ADL_VERSION)")) {
-			    		  adlVersion = getLineVal(line);
-			    	  }
-			    	  else if(line.contains("(VER_CREATOR)")) {
-			    		  adlCreator = getLineVal(line);
-			    	  }
-			    	  else if(line.contains("(VER_CRTR)")) {
-			    		  adlCreatorVersion = getLineVal(line);
-			    	  }
-			      }
-			    }
-			    finally {
-			      //ensure the underlying stream is always closed
-			      scanner.close();
-			    }
-			}
-			catch (Exception e)	{
-				throw new FitsToolException("Error parsing ADL file", e);
-			}
+                Scanner scanner = new Scanner(new FileReader(file));
+                try {
+                    // first use a Scanner to get each line
+                    while (scanner.hasNextLine()) {
+                        String line = scanner.nextLine();
+                        if (line.contains("(VER_ADL_VERSION)")) {
+                            adlVersion = getLineVal(line);
+                        } else if (line.contains("(VER_CREATOR)")) {
+                            adlCreator = getLineVal(line);
+                        } else if (line.contains("(VER_CRTR)")) {
+                            adlCreatorVersion = getLineVal(line);
+                        }
+                    }
+                } finally {
+                    // ensure the underlying stream is always closed
+                    scanner.close();
+                }
+            } catch (Exception e) {
+                throw new FitsToolException("Error parsing ADL file", e);
+            }
 
-			Element identification = new Element("identification",fitsNS);
-			Element identity = new Element("identity",fitsNS);
-			identity.setAttribute("format","Audio Decision List");
-			identity.setAttribute("mimetype","text/x-adl");
-			Element version = new Element("version",fitsNS);
-			version.addContent(adlVersion);
-			identity.addContent(version);
-			//add identity to identification section
-			identification.addContent(identity);
-			//add identification section to root
-			root.addContent(identification);
+            Element identification = new Element("identification", fitsNS);
+            Element identity = new Element("identity", fitsNS);
+            identity.setAttribute("format", "Audio Decision List");
+            identity.setAttribute("mimetype", "text/x-adl");
+            Element version = new Element("version", fitsNS);
+            version.addContent(adlVersion);
+            identity.addContent(version);
+            // add identity to identification section
+            identification.addContent(identity);
+            // add identification section to root
+            root.addContent(identification);
 
-			Element fileInfo = new Element("fileinfo",fitsNS);
-			Element metadata = new Element("metadata",fitsNS);
-			Element textMetadata = new Element("text",fitsNS);
+            Element fileInfo = new Element("fileinfo", fitsNS);
+            Element metadata = new Element("metadata", fitsNS);
+            Element textMetadata = new Element("text", fitsNS);
 
-			Element markupLanguage = new Element("markupLanguage",fitsNS);
-			markupLanguage.addContent("EDML");
-			textMetadata.addContent(markupLanguage);
+            Element markupLanguage = new Element("markupLanguage", fitsNS);
+            markupLanguage.addContent("EDML");
+            textMetadata.addContent(markupLanguage);
 
-			if(adlVersion!=null) {
-				Element markupLanguageVer = new Element("markupLanguageVersion",fitsNS);
-				markupLanguageVer.addContent(adlVersion);
-				textMetadata.addContent(markupLanguageVer);
-			}
-			if(adlCreator!=null) {
-				Element elem = new Element("creatingApplicationName",fitsNS);
-				elem.addContent(adlCreator);
-				fileInfo.addContent(elem);
-			}
+            if (adlVersion != null) {
+                Element markupLanguageVer = new Element("markupLanguageVersion", fitsNS);
+                markupLanguageVer.addContent(adlVersion);
+                textMetadata.addContent(markupLanguageVer);
+            }
+            if (adlCreator != null) {
+                Element elem = new Element("creatingApplicationName", fitsNS);
+                elem.addContent(adlCreator);
+                fileInfo.addContent(elem);
+            }
 
-			if(adlCreatorVersion!=null) {
-				Element elem = new Element("creatingApplicationVersion",fitsNS);
-				elem.addContent(adlCreatorVersion);
-				fileInfo.addContent(elem);
-			}
+            if (adlCreatorVersion != null) {
+                Element elem = new Element("creatingApplicationVersion", fitsNS);
+                elem.addContent(adlCreatorVersion);
+                fileInfo.addContent(elem);
+            }
 
-			//add file info section to root
-			root.addContent(fileInfo);
-			//add to metadata section
-			metadata.addContent(textMetadata);
-			//add metadata section to root
-			root.addContent(metadata);
-		}
+            // add file info section to root
+            root.addContent(fileInfo);
+            // add to metadata section
+            metadata.addContent(textMetadata);
+            // add metadata section to root
+            root.addContent(metadata);
+        }
 
-		return new Document(root);
+        return new Document(root);
+    }
 
+    private String getLineVal(String line) {
+        String[] parts = line.split("\t");
+        return parts[parts.length - 1];
+    }
 
-	}
+    public boolean isEnabled() {
+        return enabled;
+    }
 
-	private String getLineVal(String line) {
-		String[] parts = line.split("\t");
-		return parts[parts.length-1];
-	}
-
-
-	public boolean isEnabled() {
-		return enabled;
-	}
-
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
-
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/oisfileinfo/AudioInfo.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/oisfileinfo/AudioInfo.java
@@ -10,18 +10,6 @@
 
 package edu.harvard.hul.ois.fits.tools.oisfileinfo;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-
-import org.jdom2.Attribute;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.Namespace;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import edu.harvard.hcl.hclaps.bwav.WAVEFile;
 import edu.harvard.hcl.hclaps.bwav.chunks.FormatChunk;
 import edu.harvard.hcl.hclaps.util.ByteConvertor;
@@ -29,6 +17,16 @@ import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
 import edu.harvard.hul.ois.fits.tools.ToolBase;
 import edu.harvard.hul.ois.fits.tools.ToolOutput;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import org.jdom2.Attribute;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This uses the audio file parsing library hclaps.jar provided by Kaylie Ackerman
@@ -37,174 +35,169 @@ import edu.harvard.hul.ois.fits.tools.ToolOutput;
  */
 public class AudioInfo extends ToolBase {
 
-    private final static String TOOL_NAME = "OIS Audio Information";
-    private final static String TOOL_VERSION = "0.1";
-    private final static String TOOL_DATE = "2/17/11";
+    private static final String TOOL_NAME = "OIS Audio Information";
+    private static final String TOOL_VERSION = "0.1";
+    private static final String TOOL_DATE = "2/17/11";
 
-	private boolean enabled = true;
-	private Fits fits;
-	private static Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
-	private static Namespace xsiNS = Namespace.getNamespace("xsi","http://www.w3.org/2001/XMLSchema-instance");
+    private boolean enabled = true;
+    private Fits fits;
+    private static Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
+    private static Namespace xsiNS = Namespace.getNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
 
-	private static final Logger logger = LoggerFactory.getLogger(AudioInfo.class);
+    private static final Logger logger = LoggerFactory.getLogger(AudioInfo.class);
 
-	public AudioInfo(Fits fits) throws FitsToolException {
-		super();
-		this.fits = fits;
-		info.setName(TOOL_NAME);
-		info.setVersion(TOOL_VERSION);
-		info.setDate(TOOL_DATE);
-	}
-
-	public ToolOutput extractInfo(File file) throws FitsToolException {
-        logger.debug ("AudioInfo.extractInfo starting on " + file.getName());
-		long startTime = System.currentTimeMillis();
-		Document doc = createXml(file);
-		output = new ToolOutput(this,(Document)doc.clone(),doc, fits);
-		duration = System.currentTimeMillis()-startTime;
-		runStatus = RunStatus.SUCCESSFUL;
-        logger.debug ("AudioInfo.extractInfo finished on " + file.getName());
-		return output;
-	}
-
-	private Document createXml(File file) throws FitsToolException {
-
-		Element root = new Element("fits",fitsNS);
-		root.setAttribute(new Attribute("schemaLocation",
-										"http://hul.harvard.edu/ois/xml/ns/fits/fits_output " + fits.getExternalOutputSchema(),
-										xsiNS));
-
-		//If the file is a wav then parse and set audio metadata
-		int magicNum = -1;
-		try {
-			magicNum = tasteMagicNumber(file);
-		}
-		catch(IOException e) {
-			throw new FitsToolException("Error getting magic number for file", e);
-		}
-		if(magicNum == 0x57415645) {
-			doWav(root,file);
-		}
-		else {
-			//magicNum = 0x2E524D46 do RA?
-		}
-
-		return new Document(root);
+    public AudioInfo(Fits fits) throws FitsToolException {
+        super();
+        this.fits = fits;
+        info.setName(TOOL_NAME);
+        info.setVersion(TOOL_VERSION);
+        info.setDate(TOOL_DATE);
     }
 
-	private Element doWav(Element root, File file) throws FitsToolException {
-		WAVEFile wav = null;
-		try {
-			wav = new WAVEFile(file.getPath());
-		}
-		catch (FileNotFoundException e) {
-			throw new FitsToolException("File "+file.getName() + " not found",e);
-		}
+    public ToolOutput extractInfo(File file) throws FitsToolException {
+        logger.debug("AudioInfo.extractInfo starting on " + file.getName());
+        long startTime = System.currentTimeMillis();
+        Document doc = createXml(file);
+        output = new ToolOutput(this, (Document) doc.clone(), doc, fits);
+        duration = System.currentTimeMillis() - startTime;
+        runStatus = RunStatus.SUCCESSFUL;
+        logger.debug("AudioInfo.extractInfo finished on " + file.getName());
+        return output;
+    }
 
-		Element metadata = new Element("metadata",fitsNS);
-		Element audioMetadata = new Element("audio",fitsNS);
+    private Document createXml(File file) throws FitsToolException {
 
-		Element identification = new Element("identification",fitsNS);
-		Element identity = new Element("identity",fitsNS);
-		identity.setAttribute("format","Waveform Audio");
-		identity.setAttribute("mimetype","audio/x-wave");
-		//add identity to identification section
-		identification.addContent(identity);
-		//add identification section to root
-		root.addContent(identification);
+        Element root = new Element("fits", fitsNS);
+        root.setAttribute(new Attribute(
+                "schemaLocation",
+                "http://hul.harvard.edu/ois/xml/ns/fits/fits_output " + fits.getExternalOutputSchema(),
+                xsiNS));
 
-		Element numSamples = new Element("numSamples",fitsNS);
-		numSamples.setText(String.valueOf(wav.dataChunk().getNumberOfSampleFrames()));
-		audioMetadata.addContent(numSamples);
+        // If the file is a wav then parse and set audio metadata
+        int magicNum = -1;
+        try {
+            magicNum = tasteMagicNumber(file);
+        } catch (IOException e) {
+            throw new FitsToolException("Error getting magic number for file", e);
+        }
+        if (magicNum == 0x57415645) {
+            doWav(root, file);
+        } else {
+            // magicNum = 0x2E524D46 do RA?
+        }
 
-		Element samplesPerSecond = new Element("sampleRate",fitsNS);
-		samplesPerSecond.setText(String.valueOf(wav.formatChunk().getSamplesPerSecond()));
-		audioMetadata.addContent(samplesPerSecond);
+        return new Document(root);
+    }
 
-		Element audioDataEncoding = new Element("audioDataEncoding",fitsNS);
-		audioDataEncoding.setText(String.valueOf(FormatChunk.FormatTagDescription.getFormatTagDescription(wav.formatChunk().getFormatTag())));
-		audioMetadata.addContent(audioDataEncoding);
+    private Element doWav(Element root, File file) throws FitsToolException {
+        WAVEFile wav = null;
+        try {
+            wav = new WAVEFile(file.getPath());
+        } catch (FileNotFoundException e) {
+            throw new FitsToolException("File " + file.getName() + " not found", e);
+        }
 
-		Element blockAlign = new Element("blockAlign",fitsNS);
-		blockAlign.setText(String.valueOf(wav.formatChunk().getBlockAlign()));
-		audioMetadata.addContent(blockAlign);
+        Element metadata = new Element("metadata", fitsNS);
+        Element audioMetadata = new Element("audio", fitsNS);
 
-		Element time = new Element("time",fitsNS);
-		if(wav.bextChunk() != null) {
-			time.setText(String.valueOf(wav.bextChunk().getTimeReference()));
-		}
-		audioMetadata.addContent(time);
+        Element identification = new Element("identification", fitsNS);
+        Element identity = new Element("identity", fitsNS);
+        identity.setAttribute("format", "Waveform Audio");
+        identity.setAttribute("mimetype", "audio/x-wave");
+        // add identity to identification section
+        identification.addContent(identity);
+        // add identification section to root
+        root.addContent(identification);
 
-		Element numChannels = new Element("channels",fitsNS);
-		numChannels.setText(String.valueOf(wav.formatChunk().getNumberOfChannels()));
-		audioMetadata.addContent(numChannels);
+        Element numSamples = new Element("numSamples", fitsNS);
+        numSamples.setText(String.valueOf(wav.dataChunk().getNumberOfSampleFrames()));
+        audioMetadata.addContent(numSamples);
 
-		Element bitDepth = new Element("bitDepth",fitsNS);
-		bitDepth.setText(String.valueOf(wav.formatChunk().getBitsPerSample()));
-		audioMetadata.addContent(bitDepth);
+        Element samplesPerSecond = new Element("sampleRate", fitsNS);
+        samplesPerSecond.setText(String.valueOf(wav.formatChunk().getSamplesPerSecond()));
+        audioMetadata.addContent(samplesPerSecond);
 
-		Element wordSize = new Element("wordSize",fitsNS);
-		wordSize.setText(String.valueOf(wav.formatChunk().getBlockAlign() / wav.formatChunk().getNumberOfChannels()));
-		audioMetadata.addContent(wordSize);
+        Element audioDataEncoding = new Element("audioDataEncoding", fitsNS);
+        audioDataEncoding.setText(String.valueOf(FormatChunk.FormatTagDescription.getFormatTagDescription(
+                wav.formatChunk().getFormatTag())));
+        audioMetadata.addContent(audioDataEncoding);
 
-		Element offset = new Element("offset",fitsNS);
-		offset.setText(Long.toString(wav.dataChunk().getPositionInFile() + 8));
-		audioMetadata.addContent(offset);
+        Element blockAlign = new Element("blockAlign", fitsNS);
+        blockAlign.setText(String.valueOf(wav.formatChunk().getBlockAlign()));
+        audioMetadata.addContent(blockAlign);
 
-		Element soundField = new Element("soundField",fitsNS);
-		if (wav.formatChunk().getNumberOfChannels() == 1) {
-			soundField.setText("MONO");
-		}
-		else if (wav.formatChunk().getNumberOfChannels() == 2) {
-			soundField.setText("STEREO");
-		}
-		else {
-			soundField.setText("SURROUND");
-		}
+        Element time = new Element("time", fitsNS);
+        if (wav.bextChunk() != null) {
+            time.setText(String.valueOf(wav.bextChunk().getTimeReference()));
+        }
+        audioMetadata.addContent(time);
 
-		//add to metadata section
-		metadata.addContent(audioMetadata);
-		//add metadata section to root
-		root.addContent(metadata);
+        Element numChannels = new Element("channels", fitsNS);
+        numChannels.setText(String.valueOf(wav.formatChunk().getNumberOfChannels()));
+        audioMetadata.addContent(numChannels);
 
-		return root;
-	}
+        Element bitDepth = new Element("bitDepth", fitsNS);
+        bitDepth.setText(String.valueOf(wav.formatChunk().getBitsPerSample()));
+        audioMetadata.addContent(bitDepth);
 
+        Element wordSize = new Element("wordSize", fitsNS);
+        wordSize.setText(String.valueOf(
+                wav.formatChunk().getBlockAlign() / wav.formatChunk().getNumberOfChannels()));
+        audioMetadata.addContent(wordSize);
 
-	public boolean isEnabled() {
-		return enabled;
-	}
+        Element offset = new Element("offset", fitsNS);
+        offset.setText(Long.toString(wav.dataChunk().getPositionInFile() + 8));
+        audioMetadata.addContent(offset);
 
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
+        Element soundField = new Element("soundField", fitsNS);
+        if (wav.formatChunk().getNumberOfChannels() == 1) {
+            soundField.setText("MONO");
+        } else if (wav.formatChunk().getNumberOfChannels() == 2) {
+            soundField.setText("STEREO");
+        } else {
+            soundField.setText("SURROUND");
+        }
 
-	protected int tasteMagicNumber(File file) throws FileNotFoundException, IOException {
-		byte[] mn = new byte[12];
-		int rval = -1;
+        // add to metadata section
+        metadata.addContent(audioMetadata);
+        // add metadata section to root
+        root.addContent(metadata);
 
-		FileInputStream fis = new FileInputStream(file);
-		fis.read(mn);
-		fis.close();
+        return root;
+    }
 
-		byte[] buffer = new byte[4];
-		for (int i = 0; i < 4; i++)
-		{
-			buffer[i] = mn[i];
-		}
+    public boolean isEnabled() {
+        return enabled;
+    }
 
-		rval = (int)ByteConvertor.uIntForBytes(buffer, ByteConvertor.BIG);
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
 
-		if (rval == 0x52494646) //RIFF
-		{
-			buffer = new byte[4];
-			for (int i = 8; i < 12; i++)
-			{
-				buffer[i - 8] = mn[i];
-			}
-			rval = (int)ByteConvertor.uIntForBytes(buffer, ByteConvertor.BIG);
-		}
+    protected int tasteMagicNumber(File file) throws FileNotFoundException, IOException {
+        byte[] mn = new byte[12];
+        int rval = -1;
 
-		return rval;
-	}
+        FileInputStream fis = new FileInputStream(file);
+        fis.read(mn);
+        fis.close();
+
+        byte[] buffer = new byte[4];
+        for (int i = 0; i < 4; i++) {
+            buffer[i] = mn[i];
+        }
+
+        rval = (int) ByteConvertor.uIntForBytes(buffer, ByteConvertor.BIG);
+
+        if (rval == 0x52494646) // RIFF
+        {
+            buffer = new byte[4];
+            for (int i = 8; i < 12; i++) {
+                buffer[i - 8] = mn[i];
+            }
+            rval = (int) ByteConvertor.uIntForBytes(buffer, ByteConvertor.BIG);
+        }
+
+        return rval;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/oisfileinfo/FileInfo.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/oisfileinfo/FileInfo.java
@@ -10,22 +10,19 @@
 
 package edu.harvard.hul.ois.fits.tools.oisfileinfo;
 
+import com.twmacinta.util.MD5;
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import edu.harvard.hul.ois.fits.tools.ToolBase;
+import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-
 import org.apache.commons.io.FilenameUtils;
 import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
-
-import com.twmacinta.util.MD5;
-
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
-import edu.harvard.hul.ois.fits.tools.ToolBase;
-import edu.harvard.hul.ois.fits.tools.ToolOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,105 +33,104 @@ import org.slf4j.LoggerFactory;
  *  @see <a href="http://www.twmacinta.com/myjava/fast_md5.php">Fast MD5 Implementation in Java</a>
  */
 public class FileInfo extends ToolBase {
-    
+
     private boolean enabled = true;
     private Fits fits;
 
-    private final static String TOOL_NAME = "OIS File Information";
-    private final static String TOOL_VERSION = "1.0";
-    private final static String TOOL_DATE = "8/14/2019";
-    private final static Namespace xsiNS = Namespace.getNamespace("xsi","http://www.w3.org/2001/XMLSchema-instance");
-    private final static Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
+    private static final String TOOL_NAME = "OIS File Information";
+    private static final String TOOL_VERSION = "1.0";
+    private static final String TOOL_DATE = "8/14/2019";
+    private static final Namespace xsiNS = Namespace.getNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+    private static final Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
 
     private static final Logger logger = LoggerFactory.getLogger(FileInfo.class);
 
-    public FileInfo(Fits fits) throws FitsToolException{
-		super();
-        logger.debug ("Initializing FileInfo");
+    public FileInfo(Fits fits) throws FitsToolException {
+        super();
+        logger.debug("Initializing FileInfo");
         this.fits = fits;
         info.setName(TOOL_NAME);
-		info.setVersion(TOOL_VERSION);
-		info.setDate(TOOL_DATE);
-	}
-
-	public ToolOutput extractInfo(File file) throws FitsToolException {
-        logger.debug("FileInfo.extractInfo starting on " + file.getName());
-        long startTime = System.currentTimeMillis();
-		Document doc = createXml(file);
-		output = new ToolOutput(this,(Document)doc.clone(),doc, fits);
-		duration = System.currentTimeMillis()-startTime;
-		runStatus = RunStatus.SUCCESSFUL;
-        logger.debug("FileInfo.extractInfo finished on " + file.getName());
-		return output;
-	}
-
-	private Document createXml(File file) throws FitsToolException {
-
-
-		Element root = new Element("fits",fitsNS);
-		root.setAttribute(new Attribute("schemaLocation",
-										"http://hul.harvard.edu/ois/xml/ns/fits/fits_output " + fits.getExternalOutputSchema(),
-										xsiNS));
-		//fileinfo section
-		Element fileInfo = new Element("fileinfo",fitsNS);
-		//filepath
-		Element filepath = new Element("filepath",fitsNS);
-		filepath.setText(file.getAbsolutePath());
-		fileInfo.addContent(filepath);
-		//filename
-		Element fileName = new Element("filename",fitsNS);
-		fileName.setText(file.getName());
-		fileInfo.addContent(fileName);
-		//size
-		Element size = new Element("size",fitsNS);
-		size.setText(String.valueOf(file.length()));
-		fileInfo.addContent(size);
-		//Calculate the MD5 checksum
-		if (fits.getConfig().getBoolean("output.enable-checksum")) {
-			@SuppressWarnings("unchecked")
-			List<String> checsumExcludes = (List<String>)(List<?>)fits.getConfig().getList("output.checksum-exclusions[@exclude-exts]");
-			String ext = FilenameUtils.getExtension(file.getPath());
-			if(!hasExcludedExtensionForMD5(ext, checsumExcludes)) {
-				try {
-					String md5Hash = MD5.asHex(MD5.getHash(new File(file.getPath())));
-					Element signature = new Element("md5checksum",fitsNS);
-					signature.setText(md5Hash);
-					fileInfo.addContent(signature);
-				} catch (IOException e) {
-					throw new FitsToolException("Could not calculate the MD5 for "+file.getPath(),e);
-				}
-			}
-
-		}
-		//fslastmodified
-		Element fslastmodified = new Element("fslastmodified",fitsNS);
-		fslastmodified.setText(String.valueOf(file.lastModified()));
-		fileInfo.addContent(fslastmodified);
-		root.addContent(fileInfo);
-
-		return new Document(root);
+        info.setVersion(TOOL_VERSION);
+        info.setDate(TOOL_DATE);
     }
 
-	// NOTE: This check is separate from the tool extension exclusions
-	public boolean hasExcludedExtensionForMD5(String ext, List<String> excludedExtensions) {
-		for(String extension : excludedExtensions) {
-			if(extension.equalsIgnoreCase(ext)) {
-				return true;
-			}
-		}
-		return false;
-	}
+    public ToolOutput extractInfo(File file) throws FitsToolException {
+        logger.debug("FileInfo.extractInfo starting on " + file.getName());
+        long startTime = System.currentTimeMillis();
+        Document doc = createXml(file);
+        output = new ToolOutput(this, (Document) doc.clone(), doc, fits);
+        duration = System.currentTimeMillis() - startTime;
+        runStatus = RunStatus.SUCCESSFUL;
+        logger.debug("FileInfo.extractInfo finished on " + file.getName());
+        return output;
+    }
 
-	public Boolean canIdentify() {
-		return false;
-	}
+    private Document createXml(File file) throws FitsToolException {
 
+        Element root = new Element("fits", fitsNS);
+        root.setAttribute(new Attribute(
+                "schemaLocation",
+                "http://hul.harvard.edu/ois/xml/ns/fits/fits_output " + fits.getExternalOutputSchema(),
+                xsiNS));
+        // fileinfo section
+        Element fileInfo = new Element("fileinfo", fitsNS);
+        // filepath
+        Element filepath = new Element("filepath", fitsNS);
+        filepath.setText(file.getAbsolutePath());
+        fileInfo.addContent(filepath);
+        // filename
+        Element fileName = new Element("filename", fitsNS);
+        fileName.setText(file.getName());
+        fileInfo.addContent(fileName);
+        // size
+        Element size = new Element("size", fitsNS);
+        size.setText(String.valueOf(file.length()));
+        fileInfo.addContent(size);
+        // Calculate the MD5 checksum
+        if (fits.getConfig().getBoolean("output.enable-checksum")) {
+            @SuppressWarnings("unchecked")
+            List<String> checsumExcludes =
+                    (List<String>) (List<?>) fits.getConfig().getList("output.checksum-exclusions[@exclude-exts]");
+            String ext = FilenameUtils.getExtension(file.getPath());
+            if (!hasExcludedExtensionForMD5(ext, checsumExcludes)) {
+                try {
+                    String md5Hash = MD5.asHex(MD5.getHash(new File(file.getPath())));
+                    Element signature = new Element("md5checksum", fitsNS);
+                    signature.setText(md5Hash);
+                    fileInfo.addContent(signature);
+                } catch (IOException e) {
+                    throw new FitsToolException("Could not calculate the MD5 for " + file.getPath(), e);
+                }
+            }
+        }
+        // fslastmodified
+        Element fslastmodified = new Element("fslastmodified", fitsNS);
+        fslastmodified.setText(String.valueOf(file.lastModified()));
+        fileInfo.addContent(fslastmodified);
+        root.addContent(fileInfo);
 
-	public boolean isEnabled() {
-		return enabled;
-	}
+        return new Document(root);
+    }
 
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
+    // NOTE: This check is separate from the tool extension exclusions
+    public boolean hasExcludedExtensionForMD5(String ext, List<String> excludedExtensions) {
+        for (String extension : excludedExtensions) {
+            if (extension.equalsIgnoreCase(ext)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public Boolean canIdentify() {
+        return false;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/oisfileinfo/VTTTool.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/oisfileinfo/VTTTool.java
@@ -10,19 +10,17 @@
 
 package edu.harvard.hul.ois.fits.tools.oisfileinfo;
 
-import java.io.File;
-import java.io.FileReader;
-import java.util.Scanner;
-
-import org.jdom2.Attribute;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.Namespace;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
 import edu.harvard.hul.ois.fits.tools.ToolBase;
 import edu.harvard.hul.ois.fits.tools.ToolOutput;
+import java.io.File;
+import java.io.FileReader;
+import java.util.Scanner;
+import org.jdom2.Attribute;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,101 +29,97 @@ import org.slf4j.LoggerFactory;
  */
 public class VTTTool extends ToolBase {
 
-	private boolean enabled = true;
-	private Fits fits;
-	private final static Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
-	private final static Namespace xsiNS = Namespace.getNamespace("xsi","http://www.w3.org/2001/XMLSchema-instance");
-	private static final Logger logger = LoggerFactory.getLogger(VTTTool.class);
+    private boolean enabled = true;
+    private Fits fits;
+    private static final Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
+    private static final Namespace xsiNS = Namespace.getNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+    private static final Logger logger = LoggerFactory.getLogger(VTTTool.class);
 
-	private final static String VTT_TOOL_VERSION = "0.1";
-	private final static String VTT_IDENTIFIER = "WEBVTT";
+    private static final String VTT_TOOL_VERSION = "0.1";
+    private static final String VTT_IDENTIFIER = "WEBVTT";
 
-	public VTTTool(Fits fits) throws FitsToolException {
-		super();
-		this.fits = fits;
-		info.setName("VTT Tool");
-		info.setVersion(VTT_TOOL_VERSION);
-		info.setDate("02/23/16");
-	}
+    public VTTTool(Fits fits) throws FitsToolException {
+        super();
+        this.fits = fits;
+        info.setName("VTT Tool");
+        info.setVersion(VTT_TOOL_VERSION);
+        info.setDate("02/23/16");
+    }
 
-	public ToolOutput extractInfo(File file) throws FitsToolException {
-		logger.debug("VTTTool.extractInfo starting on " + file.getName());
-		long startTime = System.currentTimeMillis();
-		Document doc = createXml(file);
-		output = new ToolOutput(this,(Document)doc.clone(),doc, fits);
-		duration = System.currentTimeMillis()-startTime;
-		runStatus = RunStatus.SUCCESSFUL;
-		logger.debug("VTTTool.extractInfo finishing on " + file.getName());
-		return output;
-	}
+    public ToolOutput extractInfo(File file) throws FitsToolException {
+        logger.debug("VTTTool.extractInfo starting on " + file.getName());
+        long startTime = System.currentTimeMillis();
+        Document doc = createXml(file);
+        output = new ToolOutput(this, (Document) doc.clone(), doc, fits);
+        duration = System.currentTimeMillis() - startTime;
+        runStatus = RunStatus.SUCCESSFUL;
+        logger.debug("VTTTool.extractInfo finishing on " + file.getName());
+        return output;
+    }
 
-	private Document createXml(File file) throws FitsToolException {
+    private Document createXml(File file) throws FitsToolException {
 
-		Element root = new Element("fits",fitsNS);
-		root.setAttribute(new Attribute("schemaLocation",
-										"http://hul.harvard.edu/ois/xml/ns/fits/fits_output " + fits.getExternalOutputSchema(),
-										xsiNS));
+        Element root = new Element("fits", fitsNS);
+        root.setAttribute(new Attribute(
+                "schemaLocation",
+                "http://hul.harvard.edu/ois/xml/ns/fits/fits_output " + fits.getExternalOutputSchema(),
+                xsiNS));
 
-		if(file.getPath().toLowerCase().endsWith(".vtt")) {
+        if (file.getPath().toLowerCase().endsWith(".vtt")) {
 
-			boolean isVtt = false;
-			try	{
+            boolean isVtt = false;
+            try {
 
-				Scanner scanner = new Scanner(new FileReader(file));
-				try {
-					// Should be on the 1st line
-					String firstLine = scanner.nextLine();
+                Scanner scanner = new Scanner(new FileReader(file));
+                try {
+                    // Should be on the 1st line
+                    String firstLine = scanner.nextLine();
 
-					// Identifier should be on the 1st line
-					if(firstLine.trim().contains(VTT_IDENTIFIER)) {
-						isVtt = true;
-					}
-				}
-				finally {
-					//ensure the underlying stream is always closed
-					scanner.close();
-				}
-			}
-			catch (Exception e)	{
-				throw new FitsToolException("Error parsing VTT file", e);
-			}
+                    // Identifier should be on the 1st line
+                    if (firstLine.trim().contains(VTT_IDENTIFIER)) {
+                        isVtt = true;
+                    }
+                } finally {
+                    // ensure the underlying stream is always closed
+                    scanner.close();
+                }
+            } catch (Exception e) {
+                throw new FitsToolException("Error parsing VTT file", e);
+            }
 
-			if(isVtt) {
-				Element identification = new Element("identification",fitsNS);
-				Element identity = new Element("identity",fitsNS);
-				identity.setAttribute("format","WebVTT");
-				identity.setAttribute("mimetype","text/vtt");
-				identification.addContent(identity);
-				root.addContent(identification);
+            if (isVtt) {
+                Element identification = new Element("identification", fitsNS);
+                Element identity = new Element("identity", fitsNS);
+                identity.setAttribute("format", "WebVTT");
+                identity.setAttribute("mimetype", "text/vtt");
+                identification.addContent(identity);
+                root.addContent(identification);
 
-				Element fileInfo = new Element("fileinfo",fitsNS);
+                Element fileInfo = new Element("fileinfo", fitsNS);
 
-				//add file info section to root
-				root.addContent(fileInfo);
+                // add file info section to root
+                root.addContent(fileInfo);
 
-				// There really isn't any metadata to set
-				// Element metadata = new Element("metadata",fitsNS);
-				// Element textMetadata = new Element("text",fitsNS);
+                // There really isn't any metadata to set
+                // Element metadata = new Element("metadata",fitsNS);
+                // Element textMetadata = new Element("text",fitsNS);
 
-				////add to metadata section
-				//metadata.addContent(textMetadata);
+                //// add to metadata section
+                // metadata.addContent(textMetadata);
 
-				////add metadata section to root
-				//root.addContent(metadata);
-			}
+                //// add metadata section to root
+                // root.addContent(metadata);
+            }
+        }
 
+        return new Document(root);
+    }
 
-		}
+    public boolean isEnabled() {
+        return enabled;
+    }
 
-		return new Document(root);
-	}
-
-	public boolean isEnabled() {
-		return enabled;
-	}
-
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
-
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/oisfileinfo/XmlMetadata.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/oisfileinfo/XmlMetadata.java
@@ -10,18 +10,16 @@
 
 package edu.harvard.hul.ois.fits.tools.oisfileinfo;
 
-import java.io.File;
-import java.util.List;
-
-import org.jdom2.Attribute;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.Namespace;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
 import edu.harvard.hul.ois.fits.tools.ToolBase;
 import edu.harvard.hul.ois.fits.tools.ToolOutput;
+import java.io.File;
+import java.util.List;
+import org.jdom2.Attribute;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,138 +27,135 @@ import org.slf4j.LoggerFactory;
  */
 public class XmlMetadata extends ToolBase {
 
-    private final static Namespace xsiNS = Namespace.getNamespace("xsi","http://www.w3.org/2001/XMLSchema-instance");
-    private final static Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
+    private static final Namespace xsiNS = Namespace.getNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+    private static final Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
 
-    private final static String XML_SCHEMA_INSTANCE = "http://www.w3.org/2001/XMLSchema-instance";
-	private final static String XML_FORMAT = "Extensible Markup Language";
-	private final static String XML_MIME = "text/xml";
+    private static final String XML_SCHEMA_INSTANCE = "http://www.w3.org/2001/XMLSchema-instance";
+    private static final String XML_FORMAT = "Extensible Markup Language";
+    private static final String XML_MIME = "text/xml";
 
-    private final static String TOOL_NAME = "OIS XML Metadata";
-    private final static String TOOL_VERSION = "0.2";
-    private final static String TOOL_DATE = "12/22/10";
+    private static final String TOOL_NAME = "OIS XML Metadata";
+    private static final String TOOL_VERSION = "0.2";
+    private static final String TOOL_DATE = "12/22/10";
 
-	private boolean enabled = true;
-	private Fits fits;
+    private boolean enabled = true;
+    private Fits fits;
 
-	private static final Logger logger = LoggerFactory.getLogger(XmlMetadata.class);
+    private static final Logger logger = LoggerFactory.getLogger(XmlMetadata.class);
 
-	public XmlMetadata(Fits fits) throws FitsToolException{
-		super();
-		this.fits = fits;
-	    logger.debug ("Initializing XmlMetadata");
-		info.setName(TOOL_NAME);
-		info.setVersion(TOOL_VERSION);
-		info.setDate(TOOL_DATE);
-	}
-
-	public ToolOutput extractInfo(File file) throws FitsToolException {
-        logger.debug("XmlMetadata.extractInfo starting on " + file.getName());
-		long startTime = System.currentTimeMillis();
-		Document doc = createXml(file);
-		output = new ToolOutput(this,(Document)doc.clone(),doc, fits);
-		duration = System.currentTimeMillis()-startTime;
-		runStatus = RunStatus.SUCCESSFUL;
-        logger.debug("XmlMetadata.extractInfo finished on " + file.getName());
-		return output;
-	}
-
-	private Document createXml(File file) throws FitsToolException {
-
-
-		Element root = new Element("fits",fitsNS);
-		root.setAttribute(new Attribute("schemaLocation",
-										"http://hul.harvard.edu/ois/xml/ns/fits/fits_output " + fits.getExternalOutputSchema(),
-										xsiNS));
-		//If the file is XML then parse and set text metadata
-		if(file.getPath().toLowerCase().endsWith(".xml")) {
-			Element metadata = new Element("metadata",fitsNS);
-			Element textMetadata = new Element("text",fitsNS);
-
-			Document xml = null;
-			try {
-				saxBuilder.setFeature("http://apache.org/xml/features/validation/schema",false);
-				saxBuilder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-				xml = saxBuilder.build(file);
-			} catch (Exception e) {
-			    logger.error ("Error parsing "+file.getPath() +
-			            ": " + e.getClass().getName());
-				throw new FitsToolException("Error parsing "+file.getPath(),e);
-			}
-			if(xml != null) {
-				//assume we have at least well formed XML
-				Element identification = new Element("identification",fitsNS);
-				Element identity = new Element("identity",fitsNS);
-				identity.setAttribute("format",XML_FORMAT);
-				identity.setAttribute("mimetype",XML_MIME);
-				//add identity to identification section
-				identification.addContent(identity);
-				//add identification section to root
-				root.addContent(identification);
-
-				Element xmlRoot = xml.getRootElement();
-				String defaultNamespaceURI = xmlRoot.getNamespaceURI();
-				List<Namespace> namespaces = xmlRoot.getAdditionalNamespaces();
-				String schemaPrefix = null;
-				for(Namespace n : namespaces) {
-					if(n.getURI().equalsIgnoreCase(XML_SCHEMA_INSTANCE)) {
-						schemaPrefix = n.getPrefix();
-						break;
-					}
-				}
-
-				Namespace schemaNS = xmlRoot.getNamespace(schemaPrefix);
-				String schemaLocations = null;
-				String noNamespaceSchemaLocation = null;
-				if(schemaNS != null) {
-					schemaLocations = xmlRoot.getAttributeValue("schemaLocation",schemaNS);
-					noNamespaceSchemaLocation = xmlRoot.getAttributeValue("noNamespaceSchemaLocation",schemaNS);
-				}
-
-				String schemaURI = null;
-				if(schemaLocations != null && schemaLocations.length() > 0)  {
-					String[] locations = schemaLocations.split("\\s+");
-					for(int i=0;i<locations.length;i++) {
-						if(locations[i].equalsIgnoreCase(defaultNamespaceURI)) {
-							schemaURI = locations[i+1];
-							break;
-						}
-					}
-				}
-				else if(noNamespaceSchemaLocation != null && noNamespaceSchemaLocation.length() > 0)  {
-					schemaURI = noNamespaceSchemaLocation;
-				}
-
-				Element markupLanguage = new Element("markupLanguage",fitsNS);
-				markupLanguage.setText(schemaURI);
-				textMetadata.addContent(markupLanguage);
-
-				//check for doctype DTD
-				if(xml.getDocType() != null) {
-					if(xml.getDocType().getSystemID() != null) {
-						Element dtd = new Element("markupLanguage",fitsNS);
-						dtd.setText(xml.getDocType().getSystemID());
-						textMetadata.addContent(dtd);
-					}
-				}
-
-
-				//add to metadata section
-				metadata.addContent(textMetadata);
-				//add metadata section to root
-				root.addContent(metadata);
-			}
-		}
-
-		return new Document(root);
+    public XmlMetadata(Fits fits) throws FitsToolException {
+        super();
+        this.fits = fits;
+        logger.debug("Initializing XmlMetadata");
+        info.setName(TOOL_NAME);
+        info.setVersion(TOOL_VERSION);
+        info.setDate(TOOL_DATE);
     }
 
-	public boolean isEnabled() {
-		return enabled;
-	}
+    public ToolOutput extractInfo(File file) throws FitsToolException {
+        logger.debug("XmlMetadata.extractInfo starting on " + file.getName());
+        long startTime = System.currentTimeMillis();
+        Document doc = createXml(file);
+        output = new ToolOutput(this, (Document) doc.clone(), doc, fits);
+        duration = System.currentTimeMillis() - startTime;
+        runStatus = RunStatus.SUCCESSFUL;
+        logger.debug("XmlMetadata.extractInfo finished on " + file.getName());
+        return output;
+    }
 
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
+    private Document createXml(File file) throws FitsToolException {
 
+        Element root = new Element("fits", fitsNS);
+        root.setAttribute(new Attribute(
+                "schemaLocation",
+                "http://hul.harvard.edu/ois/xml/ns/fits/fits_output " + fits.getExternalOutputSchema(),
+                xsiNS));
+        // If the file is XML then parse and set text metadata
+        if (file.getPath().toLowerCase().endsWith(".xml")) {
+            Element metadata = new Element("metadata", fitsNS);
+            Element textMetadata = new Element("text", fitsNS);
+
+            Document xml = null;
+            try {
+                saxBuilder.setFeature("http://apache.org/xml/features/validation/schema", false);
+                saxBuilder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                xml = saxBuilder.build(file);
+            } catch (Exception e) {
+                logger.error(
+                        "Error parsing " + file.getPath() + ": " + e.getClass().getName());
+                throw new FitsToolException("Error parsing " + file.getPath(), e);
+            }
+            if (xml != null) {
+                // assume we have at least well formed XML
+                Element identification = new Element("identification", fitsNS);
+                Element identity = new Element("identity", fitsNS);
+                identity.setAttribute("format", XML_FORMAT);
+                identity.setAttribute("mimetype", XML_MIME);
+                // add identity to identification section
+                identification.addContent(identity);
+                // add identification section to root
+                root.addContent(identification);
+
+                Element xmlRoot = xml.getRootElement();
+                String defaultNamespaceURI = xmlRoot.getNamespaceURI();
+                List<Namespace> namespaces = xmlRoot.getAdditionalNamespaces();
+                String schemaPrefix = null;
+                for (Namespace n : namespaces) {
+                    if (n.getURI().equalsIgnoreCase(XML_SCHEMA_INSTANCE)) {
+                        schemaPrefix = n.getPrefix();
+                        break;
+                    }
+                }
+
+                Namespace schemaNS = xmlRoot.getNamespace(schemaPrefix);
+                String schemaLocations = null;
+                String noNamespaceSchemaLocation = null;
+                if (schemaNS != null) {
+                    schemaLocations = xmlRoot.getAttributeValue("schemaLocation", schemaNS);
+                    noNamespaceSchemaLocation = xmlRoot.getAttributeValue("noNamespaceSchemaLocation", schemaNS);
+                }
+
+                String schemaURI = null;
+                if (schemaLocations != null && schemaLocations.length() > 0) {
+                    String[] locations = schemaLocations.split("\\s+");
+                    for (int i = 0; i < locations.length; i++) {
+                        if (locations[i].equalsIgnoreCase(defaultNamespaceURI)) {
+                            schemaURI = locations[i + 1];
+                            break;
+                        }
+                    }
+                } else if (noNamespaceSchemaLocation != null && noNamespaceSchemaLocation.length() > 0) {
+                    schemaURI = noNamespaceSchemaLocation;
+                }
+
+                Element markupLanguage = new Element("markupLanguage", fitsNS);
+                markupLanguage.setText(schemaURI);
+                textMetadata.addContent(markupLanguage);
+
+                // check for doctype DTD
+                if (xml.getDocType() != null) {
+                    if (xml.getDocType().getSystemID() != null) {
+                        Element dtd = new Element("markupLanguage", fitsNS);
+                        dtd.setText(xml.getDocType().getSystemID());
+                        textMetadata.addContent(dtd);
+                    }
+                }
+
+                // add to metadata section
+                metadata.addContent(textMetadata);
+                // add metadata section to root
+                root.addContent(metadata);
+            }
+        }
+
+        return new Document(root);
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/tika/MetadataFormatter.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/tika/MetadataFormatter.java
@@ -13,165 +13,162 @@
  */
 package edu.harvard.hul.ois.fits.tools.tika;
 
+import com.google.gson.Gson;
 import java.text.NumberFormat;
 import java.text.ParsePosition;
 import java.util.Map;
-
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaType;
-
-import com.google.gson.Gson;
 
 /**
  * @author <a href="mailto:carl@openplanetsfoundation.org">Carl Wilson</a>
  */
 public final class MetadataFormatter {
-	private static MetadataFormatter INSTANCE = new MetadataFormatter();
+    private static MetadataFormatter INSTANCE = new MetadataFormatter();
 
-	private MetadataFormatter() {
-	}
+    private MetadataFormatter() {}
 
-	private static NumberFormat FORMATTER = NumberFormat.getInstance();
-	private static Gson GSON = new Gson();
+    private static NumberFormat FORMATTER = NumberFormat.getInstance();
+    private static Gson GSON = new Gson();
 
-	public static MetadataFormatter getInstance() {
-		return INSTANCE;
-	}
+    public static MetadataFormatter getInstance() {
+        return INSTANCE;
+    }
 
-	public String toJSON(Metadata metadata) {
-		StringBuilder sb = new StringBuilder();
-		sb.append("{ ");
-		boolean first = true;
-		for (String name : metadata.names()) {
-			if (!first) {
-				sb.append(",\n");
-			} else {
-				first = false;
-			}
-			sb.append(GSON.toJson(name));
-			sb.append(":");
-			sb.append(JSONValues(metadata.getValues(name)));
-		}
-		sb.append(" }");
-		return sb.toString();
-	}
+    public String toJSON(Metadata metadata) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{ ");
+        boolean first = true;
+        for (String name : metadata.names()) {
+            if (!first) {
+                sb.append(",\n");
+            } else {
+                first = false;
+            }
+            sb.append(GSON.toJson(name));
+            sb.append(":");
+            sb.append(JSONValues(metadata.getValues(name)));
+        }
+        sb.append(" }");
+        return sb.toString();
+    }
 
-	public static String toXML(Metadata metadata) {
-		StringBuilder sb = new StringBuilder();
-		sb.append("<metadata>");
-		String[] names = metadata.names();
-		for (String name : names) {
-			sb.append("<field name=\"");
-			sb.append(StringEscapeUtils.escapeXml(name));
-			sb.append("\">");
-			sb.append(XMLValues(metadata.getValues(name)));
-			sb.append("</field>");
-		}
-		sb.append("</metadata>");
-		return sb.toString();
-	}
+    public static String toXML(Metadata metadata) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<metadata>");
+        String[] names = metadata.names();
+        for (String name : names) {
+            sb.append("<field name=\"");
+            sb.append(StringEscapeUtils.escapeXml(name));
+            sb.append("\">");
+            sb.append(XMLValues(metadata.getValues(name)));
+            sb.append("</field>");
+        }
+        sb.append("</metadata>");
+        return sb.toString();
+    }
 
-	private static String JSONValues(String[] values) {
-		StringBuilder sb = new StringBuilder();
-		if (values.length > 1) {
-			sb.append("[");
-		}
-		for (int i = 0; i < values.length; i++) {
-			String value = values[i];
-			if (i > 0) {
-				sb.append(", ");
-			}
-			sb.append(GSON.toJson(formatValue(value)));
-		}
-		if (values.length > 1) {
-			sb.append("]");
-		}
-		return sb.toString();
-	}
+    private static String JSONValues(String[] values) {
+        StringBuilder sb = new StringBuilder();
+        if (values.length > 1) {
+            sb.append("[");
+        }
+        for (int i = 0; i < values.length; i++) {
+            String value = values[i];
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(GSON.toJson(formatValue(value)));
+        }
+        if (values.length > 1) {
+            sb.append("]");
+        }
+        return sb.toString();
+    }
 
-	private static String XMLValues(String[] values) {
-		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < values.length; i++) {
-			String value = values[i];
-			sb.append("<value>");
-			sb.append(formatValue(value));
-			sb.append("</value>");
-		}
-		return sb.toString();
-	}
+    private static String XMLValues(String[] values) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < values.length; i++) {
+            String value = values[i];
+            sb.append("<value>");
+            sb.append(formatValue(value));
+            sb.append("</value>");
+        }
+        return sb.toString();
+    }
 
-	private static String formatValue(String value) {
-//		String retVal = "null";
-		if (value != null && value.length() > 0) {
-			// Is it a number?
-			ParsePosition pos = new ParsePosition(0);
-			FORMATTER.parse(value, pos);
-			if (value.length() == pos.getIndex()) {
-				// It's a number. Remove leading zeros and output
-				value = value.replaceFirst("^0+(\\d)", "$1");
-			}
-			value = StringEscapeUtils.escapeXml(value);
-		}
-		return value;
-	}
+    private static String formatValue(String value) {
+        //		String retVal = "null";
+        if (value != null && value.length() > 0) {
+            // Is it a number?
+            ParsePosition pos = new ParsePosition(0);
+            FORMATTER.parse(value, pos);
+            if (value.length() == pos.getIndex()) {
+                // It's a number. Remove leading zeros and output
+                value = value.replaceFirst("^0+(\\d)", "$1");
+            }
+            value = StringEscapeUtils.escapeXml(value);
+        }
+        return value;
+    }
 
-	public static String toXML(MediaType mediaType) {
-		StringBuilder sb = new StringBuilder();
-		sb.append("<mediaType>");
-		sb.append("<type>");
-		sb.append(mediaType.getType());
-		sb.append("</type>");
-		sb.append("<subType>");
-		sb.append(mediaType.getSubtype());
-		sb.append("</subType>");
-		if (mediaType.hasParameters()) sb.append(XMLParameters(mediaType.getParameters()));
-		sb.append("</mediaType>");
-		return sb.toString();
-	}
+    public static String toXML(MediaType mediaType) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<mediaType>");
+        sb.append("<type>");
+        sb.append(mediaType.getType());
+        sb.append("</type>");
+        sb.append("<subType>");
+        sb.append(mediaType.getSubtype());
+        sb.append("</subType>");
+        if (mediaType.hasParameters()) sb.append(XMLParameters(mediaType.getParameters()));
+        sb.append("</mediaType>");
+        return sb.toString();
+    }
 
-	public static String XMLParameters(Map<String, String> parameters) {
-		StringBuilder sb = new StringBuilder();
-		sb.append("<parameters>");
-		for (String name : parameters.keySet()) {
-			sb.append("<parameter name=\"");
-			sb.append(name);
-			sb.append("\" value=\"");
-			sb.append(parameters.get(name));
-			sb.append("\"/>");
-		}
-		sb.append("</parameters>");
-		return sb.toString();
-	}
+    public static String XMLParameters(Map<String, String> parameters) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<parameters>");
+        for (String name : parameters.keySet()) {
+            sb.append("<parameter name=\"");
+            sb.append(name);
+            sb.append("\" value=\"");
+            sb.append(parameters.get(name));
+            sb.append("\"/>");
+        }
+        sb.append("</parameters>");
+        return sb.toString();
+    }
 
-	public static String toJSON(MediaType mediaType) {
-		StringBuilder sb = new StringBuilder();
-		sb.append("{");
-		sb.append("\"type\":");
-		sb.append(GSON.toJson(mediaType.getType()));
-		sb.append(", \"subtype\":");
-		sb.append(GSON.toJson(mediaType.getSubtype()));
-		if (mediaType.hasParameters()) sb.append(JSONParameters(mediaType.getParameters()));
-		sb.append("}");
-		return sb.toString();
-	}
+    public static String toJSON(MediaType mediaType) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        sb.append("\"type\":");
+        sb.append(GSON.toJson(mediaType.getType()));
+        sb.append(", \"subtype\":");
+        sb.append(GSON.toJson(mediaType.getSubtype()));
+        if (mediaType.hasParameters()) sb.append(JSONParameters(mediaType.getParameters()));
+        sb.append("}");
+        return sb.toString();
+    }
 
-	public static String JSONParameters(Map<String, String> parameters) {
-		StringBuilder sb = new StringBuilder();
-		sb.append(", \"parameters\":{");
-		boolean first = true;
-		for (String name : parameters.keySet()) {
-			if (!first) {
-				sb.append(",\n");
-			} else {
-				first = false;
-			}
-			sb.append("\"");
-			sb.append(name);
-			sb.append("\":");
-			sb.append(GSON.toJson(parameters.get(name)));
-		}
-		sb.append("}");
-		return sb.toString();
-	}
+    public static String JSONParameters(Map<String, String> parameters) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(", \"parameters\":{");
+        boolean first = true;
+        for (String name : parameters.keySet()) {
+            if (!first) {
+                sb.append(",\n");
+            } else {
+                first = false;
+            }
+            sb.append("\"");
+            sb.append(name);
+            sb.append("\":");
+            sb.append(GSON.toJson(parameters.get(name)));
+        }
+        sb.append("}");
+        return sb.toString();
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/tika/TikaTool.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/tika/TikaTool.java
@@ -10,6 +10,15 @@
 
 package edu.harvard.hul.ois.fits.tools.tika;
 
+import edu.harvard.hul.ois.fits.DocumentTypes;
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsMetadataValues;
+import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import edu.harvard.hul.ois.fits.tools.ToolBase;
+import edu.harvard.hul.ois.fits.tools.ToolInfo;
+import edu.harvard.hul.ois.fits.tools.ToolOutput;
+import edu.harvard.hul.ois.fits.tools.utils.XmlUtils;
+import edu.harvard.hul.ois.fits.util.DateTimeUtil;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -17,8 +26,6 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
-
-import edu.harvard.hul.ois.fits.util.DateTimeUtil;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.EncryptedDocumentException;
@@ -44,60 +51,51 @@ import org.jdom2.Element;
 import org.jdom2.Namespace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import edu.harvard.hul.ois.fits.DocumentTypes;
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsMetadataValues;
-import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
-import edu.harvard.hul.ois.fits.tools.ToolBase;
-import edu.harvard.hul.ois.fits.tools.ToolInfo;
-import edu.harvard.hul.ois.fits.tools.ToolOutput;
-import edu.harvard.hul.ois.fits.tools.utils.XmlUtils;
 import org.xml.sax.helpers.DefaultHandler;
 
 public class TikaTool extends ToolBase {
 
     /** Constants for all Tika property names, so that they're all gathered in
      *  one place and we don't have to fix inline names. */
-    private final static String P_AUTHOR = "author";
-    private final static String P_BITS = "bits";
-    private final static String P_CHANNELS = "channels";
-    private final static String P_COMPRESSION_COMPRESSION_TYPE_NAME = "Compression CompressionTypeName";
-    private final static String P_COMPRESSION_TYPE = "Compression Type";
-    private final static String P_DIMENSION_IMAGE_ORIENTATION ="Dimension ImageOrientation";
-    private final static String P_ENCODING = "encoding";
-    private final static String P_GENERATOR = "generator";
-    private final static String P_HEIGHT = "height";
-    private final static String P_IMAGE_HEIGHT = "Image Height";
-    private final static String P_IMAGE_WIDTH = "Image Width";
-    private final static String P_PDFX_VERSION = "GTS_PDFXVersion";
-    private final static String P_RESOLUTION_UNIT = "Resolution Unit";
-    private final static String P_SAMPLE_RATE = "samplerate";
-    private final static String P_TIFF_IMAGE_LENGTH = "tiff:ImageLength";
-    private final static String P_TIFF_IMAGE_WIDTH = "tiff:ImageWidth";
-    private final static String P_TIFF_RESOLUTION_UNIT = "tiff:ResolutionUnit";
-    private final static String P_TIFF_SAMPLES_PER_PIXEL = "tiff:SamplesPerPixel";
-    private final static String P_TIFF_X_RESOLUTION = "tiff:XResolution";
-    private final static String P_TIFF_Y_RESOLUTION = "tiff:YResolution";
-    private final static String P_WIDTH = "width";
-    private final static String P_X_RESOLUTION = "X Resolution";
-    private final static String P_Y_RESOLUTION = "Y Resolution";
-    private final static String P_XMP_AUDIO_CHANNEL_TYPE = "xmpDM:audioChannelType";
-    private final static String P_XMP_AUDIO_COMPRESSOR = "xmpDM:audioCompressor";
-    private final static String P_XMP_AUDIO_SAMPLE_RATE = "xmpDM:audioSampleRate";
-    private final static String P_XMP_AUDIO_SAMPLE_TYPE = "xmpDM:audioSampleType";
-    private final static String P_XMP_PIXEL_ASPECT_RATIO = "xmpDM:videoPixelAspectRatio";
-    private final static String P_XMP_VIDEO_COLOR_SPACE = "xmpDM:videoColorSpace";
-    private final static String P_XMP_VIDEO_FRAME_RATE = "xmpDM:videoFrameRate";
-    private final static String P_XMP_VIDEO_PIXEL_DEPTH = "xmpDM:videoPixelDepth";
-    private final static String P_XMP_NPAGES = "xmpTPg:NPages";
+    private static final String P_AUTHOR = "author";
 
+    private static final String P_BITS = "bits";
+    private static final String P_CHANNELS = "channels";
+    private static final String P_COMPRESSION_COMPRESSION_TYPE_NAME = "Compression CompressionTypeName";
+    private static final String P_COMPRESSION_TYPE = "Compression Type";
+    private static final String P_DIMENSION_IMAGE_ORIENTATION = "Dimension ImageOrientation";
+    private static final String P_ENCODING = "encoding";
+    private static final String P_GENERATOR = "generator";
+    private static final String P_HEIGHT = "height";
+    private static final String P_IMAGE_HEIGHT = "Image Height";
+    private static final String P_IMAGE_WIDTH = "Image Width";
+    private static final String P_PDFX_VERSION = "GTS_PDFXVersion";
+    private static final String P_RESOLUTION_UNIT = "Resolution Unit";
+    private static final String P_SAMPLE_RATE = "samplerate";
+    private static final String P_TIFF_IMAGE_LENGTH = "tiff:ImageLength";
+    private static final String P_TIFF_IMAGE_WIDTH = "tiff:ImageWidth";
+    private static final String P_TIFF_RESOLUTION_UNIT = "tiff:ResolutionUnit";
+    private static final String P_TIFF_SAMPLES_PER_PIXEL = "tiff:SamplesPerPixel";
+    private static final String P_TIFF_X_RESOLUTION = "tiff:XResolution";
+    private static final String P_TIFF_Y_RESOLUTION = "tiff:YResolution";
+    private static final String P_WIDTH = "width";
+    private static final String P_X_RESOLUTION = "X Resolution";
+    private static final String P_Y_RESOLUTION = "Y Resolution";
+    private static final String P_XMP_AUDIO_CHANNEL_TYPE = "xmpDM:audioChannelType";
+    private static final String P_XMP_AUDIO_COMPRESSOR = "xmpDM:audioCompressor";
+    private static final String P_XMP_AUDIO_SAMPLE_RATE = "xmpDM:audioSampleRate";
+    private static final String P_XMP_AUDIO_SAMPLE_TYPE = "xmpDM:audioSampleType";
+    private static final String P_XMP_PIXEL_ASPECT_RATIO = "xmpDM:videoPixelAspectRatio";
+    private static final String P_XMP_VIDEO_COLOR_SPACE = "xmpDM:videoColorSpace";
+    private static final String P_XMP_VIDEO_FRAME_RATE = "xmpDM:videoFrameRate";
+    private static final String P_XMP_VIDEO_PIXEL_DEPTH = "xmpDM:videoPixelDepth";
+    private static final String P_XMP_NPAGES = "xmpTPg:NPages";
 
     /** Enumeration of Tika properties. */
     private enum TikaProperty {
         AUTHOR,
         BITS,
-        //BITS_PER_SAMPLE,
+        // BITS_PER_SAMPLE,
         CATEGORY,
         CHANNELS,
         CHARACTER_COUNT,
@@ -137,61 +135,62 @@ public class TikaTool extends ToolBase {
 
     /** Map of Tika properties to TikaProperty
      */
-    private final static Map<String, TikaProperty> propertyNameMap =
-            new HashMap<String, TikaProperty>();
+    private static final Map<String, TikaProperty> propertyNameMap = new HashMap<String, TikaProperty>();
+
     static {
-        propertyNameMap.put (TikaCoreProperties.CREATOR.getName(), TikaProperty.AUTHOR);
-        propertyNameMap.put (P_AUTHOR, TikaProperty.AUTHOR);
-        propertyNameMap.put (Office.AUTHOR.getName(), TikaProperty.AUTHOR);
-        propertyNameMap.put (P_BITS, TikaProperty.BITS);
-        propertyNameMap.put (OfficeOpenXMLCore.CATEGORY.getName(), TikaProperty.CATEGORY);
-        propertyNameMap.put (P_CHANNELS, TikaProperty.CHANNELS);
-        propertyNameMap.put (Office.CHARACTER_COUNT.getName(), TikaProperty.CHARACTER_COUNT);
-        propertyNameMap.put (P_COMPRESSION_COMPRESSION_TYPE_NAME, TikaProperty.COMPRESSION_COMPRESSION_TYPE_NAME);
-        propertyNameMap.put (P_COMPRESSION_TYPE, TikaProperty.COMPRESSION_TYPE);
-        propertyNameMap.put (HttpHeaders.CONTENT_ENCODING, TikaProperty.CONTENT_ENCODING);
-        propertyNameMap.put (TikaCoreProperties.DESCRIPTION.getName(), TikaProperty.DESCRIPTION);
-        propertyNameMap.put (P_DIMENSION_IMAGE_ORIENTATION, TikaProperty.DIMENSION_IMAGE_ORIENTATION);
-        propertyNameMap.put (P_ENCODING, TikaProperty.ENCODING);
-        propertyNameMap.put (TikaCoreProperties.IDENTIFIER.getName(), TikaProperty.IDENTIFIER);
-        propertyNameMap.put (Office.IMAGE_COUNT.getName(), TikaProperty.IMAGE_COUNT);
-        propertyNameMap.put (P_IMAGE_HEIGHT, TikaProperty.IMAGE_HEIGHT);
-        propertyNameMap.put (P_TIFF_IMAGE_LENGTH, TikaProperty.IMAGE_HEIGHT);
-        propertyNameMap.put (P_HEIGHT, TikaProperty.IMAGE_HEIGHT);
-        propertyNameMap.put (P_IMAGE_WIDTH, TikaProperty.IMAGE_WIDTH);
-        propertyNameMap.put (P_TIFF_IMAGE_WIDTH, TikaProperty.IMAGE_WIDTH);
-        propertyNameMap.put (P_WIDTH, TikaProperty.IMAGE_WIDTH);
-        propertyNameMap.put (TikaCoreProperties.LANGUAGE.getName(), TikaProperty.LANGUAGE);
-        propertyNameMap.put (Office.LINE_COUNT.getName(), TikaProperty.LINE_COUNT);
-        propertyNameMap.put (Office.OBJECT_COUNT.getName(), TikaProperty.OBJECT_COUNT);
-        propertyNameMap.put (Office.PAGE_COUNT.getName(), TikaProperty.PAGE_COUNT);
-        propertyNameMap.put (P_XMP_NPAGES, TikaProperty.PAGE_COUNT);
-        propertyNameMap.put (Office.PARAGRAPH_COUNT.getName(), TikaProperty.PARAGRAPH_COUNT);
-        propertyNameMap.put (P_RESOLUTION_UNIT, TikaProperty.RESOLUTION_UNIT);
-        propertyNameMap.put (P_TIFF_RESOLUTION_UNIT, TikaProperty.RESOLUTION_UNIT);
-        propertyNameMap.put (TikaCoreProperties.RIGHTS.getName(), TikaProperty.RIGHTS);
-        propertyNameMap.put (P_SAMPLE_RATE, TikaProperty.SAMPLE_RATE);
-        propertyNameMap.put (P_XMP_AUDIO_SAMPLE_RATE, TikaProperty.SAMPLE_RATE);
-        propertyNameMap.put (OfficeOpenXMLExtended.DOC_SECURITY.getName(), TikaProperty.SECURITY);
-        propertyNameMap.put (Office.TABLE_COUNT.getName(), TikaProperty.TABLE_COUNT);
-        propertyNameMap.put (P_TIFF_SAMPLES_PER_PIXEL, TikaProperty.TIFF_SAMPLES_PER_PIXEL);
-        propertyNameMap.put (TikaCoreProperties.TITLE.getName(), TikaProperty.TITLE);
-        propertyNameMap.put (Office.WORD_COUNT.getName(), TikaProperty.WORD_COUNT);
-        propertyNameMap.put (P_X_RESOLUTION, TikaProperty.X_RESOLUTION);
-        propertyNameMap.put (P_TIFF_X_RESOLUTION, TikaProperty.X_RESOLUTION);
-        propertyNameMap.put (P_Y_RESOLUTION, TikaProperty.Y_RESOLUTION);
-        propertyNameMap.put (P_TIFF_Y_RESOLUTION, TikaProperty.Y_RESOLUTION);
-        propertyNameMap.put (P_XMP_AUDIO_CHANNEL_TYPE, TikaProperty.XMP_AUDIO_CHANNEL_TYPE);
-        propertyNameMap.put (P_XMP_AUDIO_COMPRESSOR, TikaProperty.XMP_AUDIO_COMPRESSOR);
-        propertyNameMap.put (P_XMP_AUDIO_SAMPLE_TYPE, TikaProperty.XMP_AUDIO_SAMPLE_TYPE);
-        propertyNameMap.put (P_XMP_PIXEL_ASPECT_RATIO, TikaProperty.XMP_PIXEL_ASPECT_RATIO);
-        propertyNameMap.put (P_XMP_VIDEO_COLOR_SPACE, TikaProperty.XMP_VIDEO_COLOR_SPACE);
-        propertyNameMap.put (P_XMP_VIDEO_FRAME_RATE, TikaProperty.XMP_VIDEO_FRAME_RATE);
-        propertyNameMap.put (P_XMP_VIDEO_PIXEL_DEPTH, TikaProperty.XMP_VIDEO_PIXEL_DEPTH);
+        propertyNameMap.put(TikaCoreProperties.CREATOR.getName(), TikaProperty.AUTHOR);
+        propertyNameMap.put(P_AUTHOR, TikaProperty.AUTHOR);
+        propertyNameMap.put(Office.AUTHOR.getName(), TikaProperty.AUTHOR);
+        propertyNameMap.put(P_BITS, TikaProperty.BITS);
+        propertyNameMap.put(OfficeOpenXMLCore.CATEGORY.getName(), TikaProperty.CATEGORY);
+        propertyNameMap.put(P_CHANNELS, TikaProperty.CHANNELS);
+        propertyNameMap.put(Office.CHARACTER_COUNT.getName(), TikaProperty.CHARACTER_COUNT);
+        propertyNameMap.put(P_COMPRESSION_COMPRESSION_TYPE_NAME, TikaProperty.COMPRESSION_COMPRESSION_TYPE_NAME);
+        propertyNameMap.put(P_COMPRESSION_TYPE, TikaProperty.COMPRESSION_TYPE);
+        propertyNameMap.put(HttpHeaders.CONTENT_ENCODING, TikaProperty.CONTENT_ENCODING);
+        propertyNameMap.put(TikaCoreProperties.DESCRIPTION.getName(), TikaProperty.DESCRIPTION);
+        propertyNameMap.put(P_DIMENSION_IMAGE_ORIENTATION, TikaProperty.DIMENSION_IMAGE_ORIENTATION);
+        propertyNameMap.put(P_ENCODING, TikaProperty.ENCODING);
+        propertyNameMap.put(TikaCoreProperties.IDENTIFIER.getName(), TikaProperty.IDENTIFIER);
+        propertyNameMap.put(Office.IMAGE_COUNT.getName(), TikaProperty.IMAGE_COUNT);
+        propertyNameMap.put(P_IMAGE_HEIGHT, TikaProperty.IMAGE_HEIGHT);
+        propertyNameMap.put(P_TIFF_IMAGE_LENGTH, TikaProperty.IMAGE_HEIGHT);
+        propertyNameMap.put(P_HEIGHT, TikaProperty.IMAGE_HEIGHT);
+        propertyNameMap.put(P_IMAGE_WIDTH, TikaProperty.IMAGE_WIDTH);
+        propertyNameMap.put(P_TIFF_IMAGE_WIDTH, TikaProperty.IMAGE_WIDTH);
+        propertyNameMap.put(P_WIDTH, TikaProperty.IMAGE_WIDTH);
+        propertyNameMap.put(TikaCoreProperties.LANGUAGE.getName(), TikaProperty.LANGUAGE);
+        propertyNameMap.put(Office.LINE_COUNT.getName(), TikaProperty.LINE_COUNT);
+        propertyNameMap.put(Office.OBJECT_COUNT.getName(), TikaProperty.OBJECT_COUNT);
+        propertyNameMap.put(Office.PAGE_COUNT.getName(), TikaProperty.PAGE_COUNT);
+        propertyNameMap.put(P_XMP_NPAGES, TikaProperty.PAGE_COUNT);
+        propertyNameMap.put(Office.PARAGRAPH_COUNT.getName(), TikaProperty.PARAGRAPH_COUNT);
+        propertyNameMap.put(P_RESOLUTION_UNIT, TikaProperty.RESOLUTION_UNIT);
+        propertyNameMap.put(P_TIFF_RESOLUTION_UNIT, TikaProperty.RESOLUTION_UNIT);
+        propertyNameMap.put(TikaCoreProperties.RIGHTS.getName(), TikaProperty.RIGHTS);
+        propertyNameMap.put(P_SAMPLE_RATE, TikaProperty.SAMPLE_RATE);
+        propertyNameMap.put(P_XMP_AUDIO_SAMPLE_RATE, TikaProperty.SAMPLE_RATE);
+        propertyNameMap.put(OfficeOpenXMLExtended.DOC_SECURITY.getName(), TikaProperty.SECURITY);
+        propertyNameMap.put(Office.TABLE_COUNT.getName(), TikaProperty.TABLE_COUNT);
+        propertyNameMap.put(P_TIFF_SAMPLES_PER_PIXEL, TikaProperty.TIFF_SAMPLES_PER_PIXEL);
+        propertyNameMap.put(TikaCoreProperties.TITLE.getName(), TikaProperty.TITLE);
+        propertyNameMap.put(Office.WORD_COUNT.getName(), TikaProperty.WORD_COUNT);
+        propertyNameMap.put(P_X_RESOLUTION, TikaProperty.X_RESOLUTION);
+        propertyNameMap.put(P_TIFF_X_RESOLUTION, TikaProperty.X_RESOLUTION);
+        propertyNameMap.put(P_Y_RESOLUTION, TikaProperty.Y_RESOLUTION);
+        propertyNameMap.put(P_TIFF_Y_RESOLUTION, TikaProperty.Y_RESOLUTION);
+        propertyNameMap.put(P_XMP_AUDIO_CHANNEL_TYPE, TikaProperty.XMP_AUDIO_CHANNEL_TYPE);
+        propertyNameMap.put(P_XMP_AUDIO_COMPRESSOR, TikaProperty.XMP_AUDIO_COMPRESSOR);
+        propertyNameMap.put(P_XMP_AUDIO_SAMPLE_TYPE, TikaProperty.XMP_AUDIO_SAMPLE_TYPE);
+        propertyNameMap.put(P_XMP_PIXEL_ASPECT_RATIO, TikaProperty.XMP_PIXEL_ASPECT_RATIO);
+        propertyNameMap.put(P_XMP_VIDEO_COLOR_SPACE, TikaProperty.XMP_VIDEO_COLOR_SPACE);
+        propertyNameMap.put(P_XMP_VIDEO_FRAME_RATE, TikaProperty.XMP_VIDEO_FRAME_RATE);
+        propertyNameMap.put(P_XMP_VIDEO_PIXEL_DEPTH, TikaProperty.XMP_VIDEO_PIXEL_DEPTH);
     }
 
     /** Map of Tika compression types to FITS compression types */
-    private final static Map<String, String> compressionTypeMap = new HashMap<String, String>();
+    private static final Map<String, String> compressionTypeMap = new HashMap<String, String>();
+
     static {
         compressionTypeMap.put("lzw", FitsMetadataValues.CMPR_LZW);
         compressionTypeMap.put("JPEG", FitsMetadataValues.CMPR_JPEG);
@@ -200,11 +199,11 @@ public class TikaTool extends ToolBase {
         compressionTypeMap.put("deflate", FitsMetadataValues.CMPR_DEFLATE);
     }
 
-    private final static Namespace fitsNS = Namespace.getNamespace (Fits.XML_NAMESPACE);
-    private final static String TOOL_NAME = "Tika";
-    private final static String TOOL_VERSION = "2.3.0";  // Hard-coded version till we can do better
+    private static final Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
+    private static final String TOOL_NAME = "Tika";
+    private static final String TOOL_VERSION = "2.3.0"; // Hard-coded version till we can do better
 
-    private final static MimeTypes mimeTypes = MimeTypes.getDefaultMimeTypes();
+    private static final MimeTypes mimeTypes = MimeTypes.getDefaultMimeTypes();
     private final Parser tikaParser;
 
     private static final Logger logger = LoggerFactory.getLogger(TikaTool.class);
@@ -220,13 +219,13 @@ public class TikaTool extends ToolBase {
             throw new FitsToolException("Problem loading tika-config.xml", e);
         }
         this.fits = fits;
-        logger.debug ("Initializing TikaTool");
-        info = new ToolInfo(TOOL_NAME, TOOL_VERSION,"");
+        logger.debug("Initializing TikaTool");
+        info = new ToolInfo(TOOL_NAME, TOOL_VERSION, "");
     }
 
     public ToolOutput extractInfo(File file) throws FitsToolException {
         logger.debug("TikaTool.extractInfo starting on " + file.getName());
-    	long startTime = System.currentTimeMillis();
+        long startTime = System.currentTimeMillis();
         Metadata metadata = new Metadata();
 
         InputStream instrm = null;
@@ -234,10 +233,10 @@ public class TikaTool extends ToolBase {
             instrm = TikaInputStream.get(file.toPath(), metadata);
         } catch (FileNotFoundException e) {
             logger.debug(("FileNotFoundException with Tika on file " + file.getAbsolutePath()));
-            throw new FitsToolException ("Can't open file with Tika", e);
+            throw new FitsToolException("Can't open file with Tika", e);
         } catch (IOException e) {
-            logger.debug (e.getClass().getName() + " in Tika: " + e.getMessage());
-            throw new FitsToolException ("IOException in Tika", e);
+            logger.debug(e.getClass().getName() + " in Tika: " + e.getMessage());
+            throw new FitsToolException("IOException in Tika", e);
         }
 
         try {
@@ -260,34 +259,34 @@ public class TikaTool extends ToolBase {
         }
 
         // Now we start constructing the tool output JDOM document
-        Document toolData = buildToolData (metadata);
+        Document toolData = buildToolData(metadata);
         // Now construct the raw data JDOM document
-        Document rawData = buildRawData (metadata);
-        ToolOutput output = new ToolOutput (this, toolData, rawData, fits);
-        duration = System.currentTimeMillis()-startTime;
+        Document rawData = buildRawData(metadata);
+        ToolOutput output = new ToolOutput(this, toolData, rawData, fits);
+        duration = System.currentTimeMillis() - startTime;
         runStatus = RunStatus.SUCCESSFUL;
-        logger.debug ("Tika.extractInfo finished on " + file.getName());
+        logger.debug("Tika.extractInfo finished on " + file.getName());
         return output;
     }
 
-	public boolean isEnabled() {
-		return enabled;
-	}
+    public boolean isEnabled() {
+        return enabled;
+    }
 
-	public void setEnabled(boolean value) {
-		enabled = value;
-	}
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
 
-	/* Create the tool data from the Metadata object */
-	private Document buildToolData (Metadata metadata) throws FitsToolException {
-        //String mimeType =  DocumentTypes.normalizeMimeType(metadata.get (P_CONTENT_TYPE));
+    /* Create the tool data from the Metadata object */
+    private Document buildToolData(Metadata metadata) throws FitsToolException {
+        // String mimeType =  DocumentTypes.normalizeMimeType(metadata.get (P_CONTENT_TYPE));
         String mimeType = FitsMetadataValues.getInstance().normalizeMimeType(metadata.get(Metadata.CONTENT_TYPE));
 
-        Element fitsElem = new Element ("fits", fitsNS);
-        Document toolDoc = new Document (fitsElem);
-        Element idElem = new Element ("identification", fitsNS);
+        Element fitsElem = new Element("fits", fitsNS);
+        Document toolDoc = new Document(fitsElem);
+        Element idElem = new Element("identification", fitsNS);
         fitsElem.addContent(idElem);
-        Element identityElem = new Element ("identity", fitsNS);
+        Element identityElem = new Element("identity", fitsNS);
         // Format and mime type info.
 
         String formatType = getFormatType(mimeType);
@@ -296,58 +295,57 @@ public class TikaTool extends ToolBase {
         String pdfaVersion = metadata.get(PDF.PDFA_VERSION);
         String pdfxVersion = metadata.get(P_PDFX_VERSION);
         if (pdfaVersion != null) {
-        	formatType = "PDF/A";
+            formatType = "PDF/A";
         } else if (pdfxVersion != null) {
-        	formatType = "PDF/X";
+            formatType = "PDF/X";
         }
         String version = null;
         if (pdfaVersion != null) {
-        	version = pdfaVersion;
+            version = pdfaVersion;
         } else if (pdfxVersion != null) {
-        	version = pdfxVersion;
+            version = pdfxVersion;
         } else if (pdfVersion != null) {
-        	version = pdfVersion;
+            version = pdfVersion;
         }
         if (version != null) {
-        	Element versionElem = new Element("version", fitsNS);
-        	versionElem.addContent(version);
-        	identityElem.addContent(versionElem);
+            Element versionElem = new Element("version", fitsNS);
+            versionElem.addContent(version);
+            identityElem.addContent(versionElem);
         }
 
-        Attribute attr = new Attribute ("format", formatType);
-        identityElem.setAttribute (attr);
-        attr = new Attribute ("mimetype", mimeType);
-        identityElem.setAttribute (attr);
-        idElem.addContent (identityElem);
-        Element fileInfoElem = buildFileInfoElement (metadata);
-        fitsElem.addContent (fileInfoElem);
+        Attribute attr = new Attribute("format", formatType);
+        identityElem.setAttribute(attr);
+        attr = new Attribute("mimetype", mimeType);
+        identityElem.setAttribute(attr);
+        idElem.addContent(identityElem);
+        Element fileInfoElem = buildFileInfoElement(metadata);
+        fitsElem.addContent(fileInfoElem);
 
-        Element metadataElem = buildMetadataElement (metadata, mimeType);
-        fitsElem.addContent (metadataElem);
+        Element metadataElem = buildMetadataElement(metadata, mimeType);
+        fitsElem.addContent(metadataElem);
 
         return toolDoc;
-	}
+    }
 
-	/* Create a dummy raw data object */
-	private Document buildRawData (Metadata metadata) throws FitsToolException {
-	    String xml = MetadataFormatter.toXML(metadata);
-	    xml = XmlUtils.cleanXmlNulls(xml);
-	    StringReader srdr = new StringReader (xml);
+    /* Create a dummy raw data object */
+    private Document buildRawData(Metadata metadata) throws FitsToolException {
+        String xml = MetadataFormatter.toXML(metadata);
+        xml = XmlUtils.cleanXmlNulls(xml);
+        StringReader srdr = new StringReader(xml);
 
-	    try {
-	        Document rawDoc = saxBuilder.build (srdr);
-	        return rawDoc;
-	    }
-	    catch (Exception e) {
-	        throw new FitsToolException ("Exception reading metadata", e);
-	    }
-	}
+        try {
+            Document rawDoc = saxBuilder.build(srdr);
+            return rawDoc;
+        } catch (Exception e) {
+            throw new FitsToolException("Exception reading metadata", e);
+        }
+    }
 
     /* Build the file information.
      * Tika can deliver the same property with different names, sometimes for
      * the same file.
      */
-    private Element buildFileInfoElement (Metadata metadata) {
+    private Element buildFileInfoElement(Metadata metadata) {
         String lastModified = metadata.get(TikaCoreProperties.MODIFIED);
         String created = metadata.get(TikaCoreProperties.CREATED);
         String contentLength = metadata.get(Metadata.CONTENT_LENGTH);
@@ -359,111 +357,104 @@ public class TikaTool extends ToolBase {
 
         // look for creating application
         String appName = "";
-        if(producer != null && creatorTool != null) {
-        	appName = producer + "/" + creatorTool;
-        }
-        else if(producer != null) {
-        	appName = producer;
-        }
-        else if(creatorTool != null) {
-        	appName = creatorTool;
-        }
-        else if (generator !=null) {
-        	appName = generator;
+        if (producer != null && creatorTool != null) {
+            appName = producer + "/" + creatorTool;
+        } else if (producer != null) {
+            appName = producer;
+        } else if (creatorTool != null) {
+            appName = creatorTool;
+        } else if (generator != null) {
+            appName = generator;
         }
         if (applicationName != null) {
-        	appName = applicationName;
+            appName = applicationName;
         }
 
-
         // Put together the fileinfo element
-        Element fileInfoElem = new Element ("fileinfo", fitsNS);
+        Element fileInfoElem = new Element("fileinfo", fitsNS);
         if (lastModified != null) {
-            Element lastModElem = new Element (FitsMetadataValues.LAST_MODIFIED, fitsNS);
-            lastModElem.addContent (DateTimeUtil.standardize(lastModified));
-            fileInfoElem.addContent (lastModElem);
+            Element lastModElem = new Element(FitsMetadataValues.LAST_MODIFIED, fitsNS);
+            lastModElem.addContent(DateTimeUtil.standardize(lastModified));
+            fileInfoElem.addContent(lastModElem);
         }
 
         if (created != null) {
-            Element createdElem = new Element (FitsMetadataValues.CREATED, fitsNS);
+            Element createdElem = new Element(FitsMetadataValues.CREATED, fitsNS);
             createdElem.addContent(DateTimeUtil.standardize(created));
             fileInfoElem.addContent(createdElem);
         }
 
         if (appName != null) {
-            Element appNameElem = new Element (FitsMetadataValues.CREATING_APPLICATION_NAME, fitsNS);
-            appNameElem.addContent (appName);
-            fileInfoElem.addContent (appNameElem);
+            Element appNameElem = new Element(FitsMetadataValues.CREATING_APPLICATION_NAME, fitsNS);
+            appNameElem.addContent(appName);
+            fileInfoElem.addContent(appNameElem);
         }
 
         if (applicationVersion != null) {
-            Element appVersionElem = new Element (FitsMetadataValues.CREATING_APPLICATION_VERSION, fitsNS);
-            appVersionElem.addContent (applicationVersion);
-            fileInfoElem.addContent (appVersionElem);
+            Element appVersionElem = new Element(FitsMetadataValues.CREATING_APPLICATION_VERSION, fitsNS);
+            appVersionElem.addContent(applicationVersion);
+            fileInfoElem.addContent(appVersionElem);
         }
 
         if (contentLength != null) {
-            Element sizeElem = new Element (FitsMetadataValues.SIZE, fitsNS);
-            sizeElem.addContent (contentLength);
-            fileInfoElem.addContent (sizeElem);
+            Element sizeElem = new Element(FitsMetadataValues.SIZE, fitsNS);
+            sizeElem.addContent(contentLength);
+            fileInfoElem.addContent(sizeElem);
         }
         return fileInfoElem;
+    }
 
-	}
+    private String getFormatType(String mime) throws FitsToolException {
+        String format = "";
+        try {
+            MimeType mimeType = mimeTypes.forName(mime);
+            format = mimeType.getDescription();
 
-	private String getFormatType(String mime) throws FitsToolException {
-	    String format = "";
-	    try {
-	        MimeType mimeType = mimeTypes.forName(mime);
-	        format = mimeType.getDescription();
+            // try mapping the format to the standard form
+            if (format != null) {
+                String stdFormat = FitsMetadataValues.getInstance().normalizeFormat(format);
+                if (stdFormat != null) {
+                    format = stdFormat;
+                }
+            }
 
-	        //try mapping the format to the standard form
-	        if(format != null) {
-	        	String stdFormat = FitsMetadataValues.getInstance().normalizeFormat(format);
-	        	if(stdFormat != null) {
-	        		format = stdFormat;
-	        	}
-	        }
+            // check if we need to get the format name based on the mime type
+            String stdText = FitsMetadataValues.getInstance().getFormatForMime(mime);
+            if (stdText != null) {
+                format = stdText;
+            }
 
-	        // check if we need to get the format name based on the mime type
-	        String stdText = FitsMetadataValues.getInstance().getFormatForMime(mime);
-	        if (stdText != null) {
-	            format = stdText;
-	        }
+            // it may be necessary to get format name based on tool element rather than mime type
 
-	        // it may be necessary to get format name based on tool element rather than mime type
+            return format;
+        } catch (MimeTypeException e) {
+            throw new FitsToolException("Tika error looking up mime type");
+        }
+    }
 
-
-
-	        return format;
-	    } catch (MimeTypeException e) {
-	        throw new FitsToolException("Tika error looking up mime type");
-	    }
-	}
-
-    private Element buildMetadataElement (Metadata metadata, String mimeType) {
+    private Element buildMetadataElement(Metadata metadata, String mimeType) {
         DocumentTypes.Doctype doctype = DocumentTypes.mimeToDoctype(mimeType);
-        Element metadataElem = new Element ("metadata", fitsNS);
+        Element metadataElem = new Element("metadata", fitsNS);
         switch (doctype) {
             case AUDIO:
-                Element audioElem = buildAudioElement (metadata);
-                metadataElem.addContent (audioElem);
+                Element audioElem = buildAudioElement(metadata);
+                metadataElem.addContent(audioElem);
                 break;
             case IMAGE:
-                Element imageElem = buildImageElement (metadata);
-                metadataElem.addContent (imageElem);
+                Element imageElem = buildImageElement(metadata);
+                metadataElem.addContent(imageElem);
                 break;
             case DOCUMENT:
-                Element docElem = buildDocElement (metadata, "application/pdf".equals(mimeType));
-                metadataElem.addContent (docElem);
+                Element docElem = buildDocElement(metadata, "application/pdf".equals(mimeType));
+                metadataElem.addContent(docElem);
                 break;
             case TEXT:
-                Element textElem = buildTextElement (metadata);
-                metadataElem.addContent (textElem);
+                Element textElem = buildTextElement(metadata);
+                metadataElem.addContent(textElem);
                 break;
             case VIDEO:
-                Element videoElem = buildVideoElement (metadata);
-                metadataElem.addContent (videoElem);
+                Element videoElem = buildVideoElement(metadata);
+                metadataElem.addContent(videoElem);
                 break;
             default:
                 break;
@@ -474,7 +465,7 @@ public class TikaTool extends ToolBase {
     /* Return an element for an audio file */
     private Element buildAudioElement(Metadata metadata) {
         String[] metadataNames = metadata.names();
-        Element elem = new Element (FitsMetadataValues.AUDIO, fitsNS);
+        Element elem = new Element(FitsMetadataValues.AUDIO, fitsNS);
         boolean titleReported = false;
         boolean authorReported = false;
         for (String name : metadataNames) {
@@ -485,98 +476,97 @@ public class TikaTool extends ToolBase {
             String value = metadata.get(name);
 
             switch (prop) {
-
                 case BITS:
-                    addSimpleElement (elem, FitsMetadataValues.BIT_DEPTH, value);
+                    addSimpleElement(elem, FitsMetadataValues.BIT_DEPTH, value);
                     break;
 
                 case TITLE:
                     if (!titleReported) {
-                        addSimpleElement (elem, FitsMetadataValues.TITLE, value);
+                        addSimpleElement(elem, FitsMetadataValues.TITLE, value);
                         titleReported = true;
                     }
                     break;
 
                 case AUTHOR:
                     if (!authorReported) {
-                        addSimpleElement (elem, FitsMetadataValues.AUTHOR, value);
+                        addSimpleElement(elem, FitsMetadataValues.AUTHOR, value);
                         authorReported = true;
                     }
                     break;
 
                 case CHANNELS:
-                    addSimpleElement (elem, FitsMetadataValues.CHANNELS, value);
+                    addSimpleElement(elem, FitsMetadataValues.CHANNELS, value);
                     break;
 
                 case COMPRESSION_TYPE:
-                    addSimpleElement (elem, FitsMetadataValues.COMPRESSION_SCHEME, value);
+                    addSimpleElement(elem, FitsMetadataValues.COMPRESSION_SCHEME, value);
                     break;
 
-//			Tika is not outputting the correct bits per sample
-//           case DATA_BITS_PER_SAMPLE:
-//               addSimpleElement (elem, FitsMetadataValues.BIT_DEPTH, value);
-//               break;
+                    //			Tika is not outputting the correct bits per sample
+                    //           case DATA_BITS_PER_SAMPLE:
+                    //               addSimpleElement (elem, FitsMetadataValues.BIT_DEPTH, value);
+                    //               break;
 
                 case ENCODING:
-                    addSimpleElement (elem, FitsMetadataValues.AUDIO_DATA_ENCODING, value);
+                    addSimpleElement(elem, FitsMetadataValues.AUDIO_DATA_ENCODING, value);
                     break;
 
                 case SAMPLE_RATE:
-                    addSimpleElement (elem, FitsMetadataValues.SAMPLE_RATE, value);
+                    addSimpleElement(elem, FitsMetadataValues.SAMPLE_RATE, value);
             }
         }
         return elem;
     }
 
-	/* Return an element for an image file */
-	private Element buildImageElement(Metadata metadata) {
+    /* Return an element for an image file */
+    private Element buildImageElement(Metadata metadata) {
         String[] metadataNames = metadata.names();
-	    Element elem = new Element (FitsMetadataValues.IMAGE, fitsNS);
-	    boolean bpsReported = false;
-	    boolean widthReported = false;
-	    boolean heightReported = false;
-	    boolean xresReported = false;
+        Element elem = new Element(FitsMetadataValues.IMAGE, fitsNS);
+        boolean bpsReported = false;
+        boolean widthReported = false;
+        boolean heightReported = false;
+        boolean xresReported = false;
         boolean yresReported = false;
         boolean resUnitReported = false;
-	    for (String name : metadataNames) {
-	        TikaProperty prop = propertyNameMap.get(name);
-	        if (prop == null) {
-	            // a property we don't know about?
-	            continue;
-	        }
-	        String value = metadata.get(name);
+        for (String name : metadataNames) {
+            TikaProperty prop = propertyNameMap.get(name);
+            if (prop == null) {
+                // a property we don't know about?
+                continue;
+            }
+            String value = metadata.get(name);
 
             int idx;
             switch (prop) {
                 case DIMENSION_IMAGE_ORIENTATION:
-                    if ("Normal".equals (value)) {
-                        addSimpleElement (elem, FitsMetadataValues.ORIENTATION, "normal*");
+                    if ("Normal".equals(value)) {
+                        addSimpleElement(elem, FitsMetadataValues.ORIENTATION, "normal*");
                     }
                     break;
                 case IMAGE_WIDTH:
                     if (!widthReported) {
-                        idx = value.indexOf (" pixels");
+                        idx = value.indexOf(" pixels");
                         if (idx > 0) {
-                            value = value.substring (0, idx);
+                            value = value.substring(0, idx);
                         }
-                        addSimpleElement (elem, FitsMetadataValues.IMAGE_WIDTH, value);
+                        addSimpleElement(elem, FitsMetadataValues.IMAGE_WIDTH, value);
                         widthReported = true;
                     }
                     break;
 
                 case IMAGE_HEIGHT:
                     if (!heightReported) {
-                        idx = value.indexOf (" pixels");
+                        idx = value.indexOf(" pixels");
                         if (idx > 0) {
-                            value = value.substring (0, idx);
+                            value = value.substring(0, idx);
                         }
-                        addSimpleElement (elem, FitsMetadataValues.IMAGE_HEIGHT, value);
+                        addSimpleElement(elem, FitsMetadataValues.IMAGE_HEIGHT, value);
                         heightReported = true;
                     }
                     break;
 
                 case TIFF_SAMPLES_PER_PIXEL:
-                    addSimpleElement (elem, FitsMetadataValues.SAMPLES_PER_PIXEL, value);
+                    addSimpleElement(elem, FitsMetadataValues.SAMPLES_PER_PIXEL, value);
                     break;
 
                 case COMPRESSION_TYPE:
@@ -585,51 +575,50 @@ public class TikaTool extends ToolBase {
                     if (stdValue != null) {
                         value = stdValue;
                     }
-                    addSimpleElement (elem, FitsMetadataValues.COMPRESSION_SCHEME, value);
+                    addSimpleElement(elem, FitsMetadataValues.COMPRESSION_SCHEME, value);
                     break;
 
-// Tika is not outputting the correct bits per sample
-//	        case TIFF_BITS_PER_SAMPLE:
-//	        case DATA_BITS_PER_SAMPLE:
-//	            // We may get the same data in more than one property
-//	            if (!bpsReported) {
-//	                addSimpleElement (elem, FitsMetadataValues.BITS_PER_SAMPLE, value);
-//	                bpsReported = true;
-//	            }
-//	            break;
+                    // Tika is not outputting the correct bits per sample
+                    //	        case TIFF_BITS_PER_SAMPLE:
+                    //	        case DATA_BITS_PER_SAMPLE:
+                    //	            // We may get the same data in more than one property
+                    //	            if (!bpsReported) {
+                    //	                addSimpleElement (elem, FitsMetadataValues.BITS_PER_SAMPLE, value);
+                    //	                bpsReported = true;
+                    //	            }
+                    //	            break;
 
                 case RESOLUTION_UNIT:
                     if (!resUnitReported) {
-                        if(value.equals("Inch")) {
+                        if (value.equals("Inch")) {
                             value = "In.";
                         }
-                        addSimpleElement (elem, FitsMetadataValues.SAMPLING_FREQUENCY_UNIT, value);
+                        addSimpleElement(elem, FitsMetadataValues.SAMPLING_FREQUENCY_UNIT, value);
                         resUnitReported = true;
                     }
                     break;
 
                 case X_RESOLUTION:
                     if (!xresReported) {
-                        int ix = value.indexOf (" dot");
+                        int ix = value.indexOf(" dot");
                         if (ix > 0) {
-                            value = value.substring (0, ix);
+                            value = value.substring(0, ix);
                         }
-                        addSimpleElement (elem, FitsMetadataValues.X_SAMPLING_FREQUENCY, value);
+                        addSimpleElement(elem, FitsMetadataValues.X_SAMPLING_FREQUENCY, value);
                         xresReported = true;
                     }
                     break;
 
                 case Y_RESOLUTION:
                     if (!yresReported) {
-                        int ix = value.indexOf (" dot");
+                        int ix = value.indexOf(" dot");
                         if (ix > 0) {
-                            value = value.substring (0, ix);
+                            value = value.substring(0, ix);
                         }
-                        addSimpleElement (elem, FitsMetadataValues.Y_SAMPLING_FREQUENCY, value);
+                        addSimpleElement(elem, FitsMetadataValues.Y_SAMPLING_FREQUENCY, value);
                         yresReported = true;
                     }
                     break;
-
             }
         }
         return elem;
@@ -638,11 +627,11 @@ public class TikaTool extends ToolBase {
     /* Return an element for an document file */
     private Element buildDocElement(Metadata metadata, boolean isPdf) {
         String[] metadataNames = metadata.names();
-        Element elem = new Element (FitsMetadataValues.DOCUMENT, fitsNS);
+        Element elem = new Element(FitsMetadataValues.DOCUMENT, fitsNS);
 
         String subject = metadata.get(TikaCoreProperties.SUBJECT.getName());
         if (subject != null) {
-            addSimpleElement (elem, FitsMetadataValues.SUBJECT, subject);
+            addSimpleElement(elem, FitsMetadataValues.SUBJECT, subject);
         }
 
         boolean titleReported = false;
@@ -663,7 +652,7 @@ public class TikaTool extends ToolBase {
             switch (prop) {
                 case TITLE:
                     if (!titleReported) {
-                        addSimpleElement (elem, FitsMetadataValues.TITLE, value);
+                        addSimpleElement(elem, FitsMetadataValues.TITLE, value);
                         titleReported = true;
                     }
                     break;
@@ -674,7 +663,7 @@ public class TikaTool extends ToolBase {
                         // otherwise will skip and let another tool deal with this.
                         String[] values = metadata.getValues(name);
                         if (values != null && values.length == 1) {
-                            addSimpleElement (elem, FitsMetadataValues.AUTHOR, value);
+                            addSimpleElement(elem, FitsMetadataValues.AUTHOR, value);
                         }
                         authorReported = true;
                     }
@@ -682,32 +671,32 @@ public class TikaTool extends ToolBase {
 
                 case PAGE_COUNT:
                     if (!pageCountReported) {
-                        addSimpleElement (elem, FitsMetadataValues.PAGE_COUNT, value);
+                        addSimpleElement(elem, FitsMetadataValues.PAGE_COUNT, value);
                         pageCountReported = true;
                     }
                     break;
 
                 case CATEGORY:
-                    addSimpleElement (elem, FitsMetadataValues.CATEGORY, value);
+                    addSimpleElement(elem, FitsMetadataValues.CATEGORY, value);
                     break;
 
                 case WORD_COUNT:
                     if (!wordCountReported) {
-                        addSimpleElement (elem, FitsMetadataValues.WORD_COUNT, value);
+                        addSimpleElement(elem, FitsMetadataValues.WORD_COUNT, value);
                         wordCountReported = true;
                     }
                     break;
 
                 case CHARACTER_COUNT:
-                    addSimpleElement (elem, FitsMetadataValues.CHARACTER_COUNT, value);
+                    addSimpleElement(elem, FitsMetadataValues.CHARACTER_COUNT, value);
                     break;
 
                 case LINE_COUNT:
-                    addSimpleElement (elem, FitsMetadataValues.LINE_COUNT, value);
+                    addSimpleElement(elem, FitsMetadataValues.LINE_COUNT, value);
                     break;
 
                 case PARAGRAPH_COUNT:
-                    addSimpleElement (elem, FitsMetadataValues.PARAGRAPH_COUNT, value);
+                    addSimpleElement(elem, FitsMetadataValues.PARAGRAPH_COUNT, value);
                     break;
 
                 case LANGUAGE:
@@ -717,7 +706,7 @@ public class TikaTool extends ToolBase {
                 case RIGHTS:
                     if (!rightsReported) {
                         value = "yes";
-                        addSimpleElement (elem, FitsMetadataValues.IS_RIGHTS_MANAGED, value);
+                        addSimpleElement(elem, FitsMetadataValues.IS_RIGHTS_MANAGED, value);
                         rightsReported = true;
                     }
                     break;
@@ -769,7 +758,7 @@ public class TikaTool extends ToolBase {
     /* Return an element for a text file */
     private Element buildTextElement(Metadata metadata) {
         String[] metadataNames = metadata.names();
-        Element elem = new Element (FitsMetadataValues.TEXT, fitsNS);
+        Element elem = new Element(FitsMetadataValues.TEXT, fitsNS);
         for (String name : metadataNames) {
             TikaProperty prop = propertyNameMap.get(name);
             if (prop == null) {
@@ -780,15 +769,15 @@ public class TikaTool extends ToolBase {
 
             switch (prop) {
                 case TITLE:
-                    addSimpleElement (elem, FitsMetadataValues.TITLE, value);
+                    addSimpleElement(elem, FitsMetadataValues.TITLE, value);
                     break;
 
                 case CONTENT_ENCODING:
-                    addSimpleElement (elem, FitsMetadataValues.CHARSET, value);
+                    addSimpleElement(elem, FitsMetadataValues.CHARSET, value);
                     break;
 
                 case WORD_COUNT:
-                    addSimpleElement (elem, FitsMetadataValues.WORD_COUNT, value);
+                    addSimpleElement(elem, FitsMetadataValues.WORD_COUNT, value);
                     break;
             }
         }
@@ -798,7 +787,7 @@ public class TikaTool extends ToolBase {
     /* Return an element for an video file */
     private Element buildVideoElement(Metadata metadata) {
         String[] metadataNames = metadata.names();
-        Element elem = new Element (FitsMetadataValues.VIDEO, fitsNS);
+        Element elem = new Element(FitsMetadataValues.VIDEO, fitsNS);
         boolean heightReported = false;
         boolean compressionTypeReported = false;
 
@@ -810,31 +799,30 @@ public class TikaTool extends ToolBase {
             String value = metadata.get(name);
 
             switch (prop) {
-
                 case TITLE:
-                    addSimpleElement (elem, FitsMetadataValues.TITLE, value);
+                    addSimpleElement(elem, FitsMetadataValues.TITLE, value);
                     break;
 
                 case AUTHOR:
-                    addSimpleElement (elem, FitsMetadataValues.AUTHOR, value);
+                    addSimpleElement(elem, FitsMetadataValues.AUTHOR, value);
                     break;
 
                 case XMP_AUDIO_CHANNEL_TYPE:
-                    addSimpleElement (elem, FitsMetadataValues.AUDIO_CHANNEL_TYPE, value);
+                    addSimpleElement(elem, FitsMetadataValues.AUDIO_CHANNEL_TYPE, value);
                     break;
 
                 case SAMPLE_RATE:
-                    addSimpleElement (elem, FitsMetadataValues.AUDIO_SAMPLE_RATE, value);
+                    addSimpleElement(elem, FitsMetadataValues.AUDIO_SAMPLE_RATE, value);
                     break;
 
                 case XMP_AUDIO_SAMPLE_TYPE:
-                    addSimpleElement (elem, FitsMetadataValues.AUDIO_SAMPLE_TYPE, value);
+                    addSimpleElement(elem, FitsMetadataValues.AUDIO_SAMPLE_TYPE, value);
                     break;
 
                 case XMP_AUDIO_COMPRESSOR:
                 case COMPRESSION_TYPE:
                     if (!compressionTypeReported) {
-                        addSimpleElement (elem, FitsMetadataValues.COMPRESSION_SCHEME, value);
+                        addSimpleElement(elem, FitsMetadataValues.COMPRESSION_SCHEME, value);
                         compressionTypeReported = true;
                     }
                     break;
@@ -848,20 +836,20 @@ public class TikaTool extends ToolBase {
                     break;
 
                 case XMP_VIDEO_PIXEL_DEPTH:
-                    addSimpleElement (elem, FitsMetadataValues.BIT_DEPTH, value);
+                    addSimpleElement(elem, FitsMetadataValues.BIT_DEPTH, value);
                     break;
 
                 case XMP_VIDEO_COLOR_SPACE:
-                    addSimpleElement (elem, FitsMetadataValues.COLOR_SPACE, value);
+                    addSimpleElement(elem, FitsMetadataValues.COLOR_SPACE, value);
                     break;
 
                 case IMAGE_HEIGHT:
                     if (!heightReported) {
-                        int idx = value.indexOf (" pixels");
+                        int idx = value.indexOf(" pixels");
                         if (idx > 0) {
-                            value = value.substring (0, idx);
+                            value = value.substring(0, idx);
                         }
-                        addSimpleElement (elem, FitsMetadataValues.IMAGE_HEIGHT, value);
+                        addSimpleElement(elem, FitsMetadataValues.IMAGE_HEIGHT, value);
                         heightReported = true;
                     }
                     break;
@@ -870,12 +858,9 @@ public class TikaTool extends ToolBase {
         return elem;
     }
 
-
-
-    private void addSimpleElement (Element parent, String tag, String value ) {
-        Element newElem = new Element (tag, fitsNS);
-        newElem.addContent (value);
-        parent.addContent (newElem);
+    private void addSimpleElement(Element parent, String tag, String value) {
+        Element newElem = new Element(tag, fitsNS);
+        newElem.addContent(value);
+        parent.addContent(newElem);
     }
-
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/utils/CommandLine.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/utils/CommandLine.java
@@ -10,49 +10,46 @@
 
 package edu.harvard.hul.ois.fits.tools.utils;
 
+import edu.harvard.hul.ois.fits.exceptions.FitsToolCLIException;
 import java.io.*;
 import java.util.List;
-
-import edu.harvard.hul.ois.fits.exceptions.FitsToolCLIException;
 
 /**
  *  A static class for command line invocation.
  */
 public abstract class CommandLine {
-	public static String exec(List<String> cmd, String directory) throws FitsToolCLIException {
-		String output = null;
-		ByteArrayOutputStream bos = new ByteArrayOutputStream();
-		try {
-			//Runtime rt = Runtime.getRuntime();
-			//Process proc = rt.exec(cmd.toString());
+    public static String exec(List<String> cmd, String directory) throws FitsToolCLIException {
+        String output = null;
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try {
+            // Runtime rt = Runtime.getRuntime();
+            // Process proc = rt.exec(cmd.toString());
 
-			ProcessBuilder builder = new ProcessBuilder(cmd);
-			if(directory != null) {
-				builder.directory(new File(directory));
-			}
-			Process proc = builder.start();
+            ProcessBuilder builder = new ProcessBuilder(cmd);
+            if (directory != null) {
+                builder.directory(new File(directory));
+            }
+            Process proc = builder.start();
 
-			StreamGobbler errorGobbler = new StreamGobbler(proc.getErrorStream(),bos);
-			StreamGobbler outputGobbler = new StreamGobbler(proc.getInputStream(),bos);
-			errorGobbler.start();
-			outputGobbler.start();
-			proc.waitFor();
-		    errorGobbler.join();
-		    outputGobbler.join();
-		    //output = sb.toString();
-		    bos.flush();
-			output = new String(bos.toByteArray());
-		}
-		catch (Exception e) {
-			throw new FitsToolCLIException("Error calling external command line routine",e);
-		}
-		finally {
-			try {
-				bos.close();
-			} catch (IOException e) {
-				throw new FitsToolCLIException("Error closing external command line output stream",e);
-			}
-		}
-		return output;
-	}
+            StreamGobbler errorGobbler = new StreamGobbler(proc.getErrorStream(), bos);
+            StreamGobbler outputGobbler = new StreamGobbler(proc.getInputStream(), bos);
+            errorGobbler.start();
+            outputGobbler.start();
+            proc.waitFor();
+            errorGobbler.join();
+            outputGobbler.join();
+            // output = sb.toString();
+            bos.flush();
+            output = new String(bos.toByteArray());
+        } catch (Exception e) {
+            throw new FitsToolCLIException("Error calling external command line routine", e);
+        } finally {
+            try {
+                bos.close();
+            } catch (IOException e) {
+                throw new FitsToolCLIException("Error closing external command line output stream", e);
+            }
+        }
+        return output;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/utils/StreamGobbler.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/utils/StreamGobbler.java
@@ -16,48 +16,44 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class StreamGobbler extends Thread {
-	private InputStream is;
-	private OutputStream os;
+    private InputStream is;
+    private OutputStream os;
 
-	private static final Logger logger = LoggerFactory.getLogger(StreamGobbler.class);
+    private static final Logger logger = LoggerFactory.getLogger(StreamGobbler.class);
 
-	/** Constructor with no output stream. Output from the process
-	 *  will be discarded.
-	 */
-	StreamGobbler(InputStream is) {
-		this(is, null);
-	}
+    /** Constructor with no output stream. Output from the process
+     *  will be discarded.
+     */
+    StreamGobbler(InputStream is) {
+        this(is, null);
+    }
 
-	/** Constructor with output stream. Output from the process will
-	 *  be sent to it on a line-by-line basis.
-	 */
-	StreamGobbler(InputStream is, OutputStream redirect) {
-		this.is = is;
-		this.os = redirect;
-	}
+    /** Constructor with output stream. Output from the process will
+     *  be sent to it on a line-by-line basis.
+     */
+    StreamGobbler(InputStream is, OutputStream redirect) {
+        this.is = is;
+        this.os = redirect;
+    }
 
-	public void run() {
-		try {
-			PrintWriter pw = null;
-			if (os != null)
-				pw = new PrintWriter(os);
+    public void run() {
+        try {
+            PrintWriter pw = null;
+            if (os != null) pw = new PrintWriter(os);
 
-			InputStreamReader isr = new InputStreamReader(is);
-			BufferedReader br = new BufferedReader(isr);
-			String line = null;
-			while ((line = br.readLine()) != null) {
-				if (pw != null)
-					pw.println(line);
-			}
-			if (pw != null)
-				pw.flush();
-		} catch (IOException ioe) {
-			logger.error("Error reading input command.", ioe);
-		}
-	}
+            InputStreamReader isr = new InputStreamReader(is);
+            BufferedReader br = new BufferedReader(isr);
+            String line = null;
+            while ((line = br.readLine()) != null) {
+                if (pw != null) pw.println(line);
+            }
+            if (pw != null) pw.flush();
+        } catch (IOException ioe) {
+            logger.error("Error reading input command.", ioe);
+        }
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/utils/XmlUtils.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/utils/XmlUtils.java
@@ -13,7 +13,6 @@ package edu.harvard.hul.ois.fits.tools.utils;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -36,74 +35,70 @@ public class XmlUtils {
      * @param element
      * @return the element value or empty string
      */
-	public static String getDomValue(Document dom, String element) {
-        XPathExpression<Element> expr = xFactory.compile("//"+element, Filters.element());
+    public static String getDomValue(Document dom, String element) {
+        XPathExpression<Element> expr = xFactory.compile("//" + element, Filters.element());
         Element e = expr.evaluateFirst(dom);
-		if(e != null) {
-			return e.getText();
-		}
-		return null;
-	}
+        if (e != null) {
+            return e.getText();
+        }
+        return null;
+    }
 
-	/**
-	 * concatenates the values of all elements children into a single string and returns it
-	 * @param dom
-	 * @param element
-	 * @return String
-	 */
-	public static String getChildDomValues(Document dom, String element) {
-		String s = "";
-        XPathExpression<Element> expr = xFactory.compile("//"+element, Filters.element());
+    /**
+     * concatenates the values of all elements children into a single string and returns it
+     * @param dom
+     * @param element
+     * @return String
+     */
+    public static String getChildDomValues(Document dom, String element) {
+        String s = "";
+        XPathExpression<Element> expr = xFactory.compile("//" + element, Filters.element());
         Element e = expr.evaluateFirst(dom);
-		if(e != null) {
-			for(Element ee : (List<Element>)e.getChildren()) {
-				s = s + ee.getText() + " ";
-			}
-			return s;
-		}
-		return null;
-	}
+        if (e != null) {
+            for (Element ee : (List<Element>) e.getChildren()) {
+                s = s + ee.getText() + " ";
+            }
+            return s;
+        }
+        return null;
+    }
 
-	public static Element getChildWithAttribute(Element e, Attribute a) {
-		Element foundE = null;
-		Attribute aa = e.getAttribute(a.getName());
-		if(aa != null && aa.getValue().equalsIgnoreCase(a.getValue())) {
-			return e;
-		}
-		for(Element ee:(List<Element>)e.getChildren()) {
-			foundE = getChildWithAttribute(ee,a);
-			if(foundE != null) {
-				break;
-			}
-		}
-		return foundE;
-	}
+    public static Element getChildWithAttribute(Element e, Attribute a) {
+        Element foundE = null;
+        Attribute aa = e.getAttribute(a.getName());
+        if (aa != null && aa.getValue().equalsIgnoreCase(a.getValue())) {
+            return e;
+        }
+        for (Element ee : (List<Element>) e.getChildren()) {
+            foundE = getChildWithAttribute(ee, a);
+            if (foundE != null) {
+                break;
+            }
+        }
+        return foundE;
+    }
 
-	public static String cleanXmlNulls(String xml) {
-		Pattern pattern = null;
-		Matcher matcher = null;
-		pattern = Pattern.compile("[\\000]*");
-		matcher = pattern.matcher(xml);
-		if (matcher.find()) {
-		   xml = matcher.replaceAll("");
-		}
-		return xml;
-	}
+    public static String cleanXmlNulls(String xml) {
+        Pattern pattern = null;
+        Matcher matcher = null;
+        pattern = Pattern.compile("[\\000]*");
+        matcher = pattern.matcher(xml);
+        if (matcher.find()) {
+            xml = matcher.replaceAll("");
+        }
+        return xml;
+    }
 
-	/**
-	 * Determines if a String contains all numeric values.
-	 * Returns true if it does, otherwise return false.
-	 * @param str
-	 * @return boolean
-	 */
-	public static boolean isNumeric(String str)
-	{
-	    for (char c : str.toCharArray())
-	    {
-	        if (!Character.isDigit(c)) return false;
-	    }
-	    return true;
-	}
-
-
+    /**
+     * Determines if a String contains all numeric values.
+     * Returns true if it does, otherwise return false.
+     * @param str
+     * @return boolean
+     */
+    public static boolean isNumeric(String str) {
+        for (char c : str.toCharArray()) {
+            if (!Character.isDigit(c)) return false;
+        }
+        return true;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/utils/XsltTransformMap.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/utils/XsltTransformMap.java
@@ -10,38 +10,34 @@
 
 package edu.harvard.hul.ois.fits.tools.utils;
 
+import edu.harvard.hul.ois.fits.exceptions.FitsConfigurationException;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
-
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.commons.configuration.XMLConfiguration;
 
-import edu.harvard.hul.ois.fits.exceptions.FitsConfigurationException;
-
 public class XsltTransformMap {
 
-	public static Hashtable<String,String> getMap(String config) throws FitsConfigurationException {
-		Hashtable<String,String> mappings = new Hashtable<String,String>();
-		XMLConfiguration conf = null;
-		try {
-			conf = new XMLConfiguration(config);
-		} catch (ConfigurationException e) {
-			throw new FitsConfigurationException("Error reading "+config+"fits.xml",e);
-		}
+    public static Hashtable<String, String> getMap(String config) throws FitsConfigurationException {
+        Hashtable<String, String> mappings = new Hashtable<String, String>();
+        XMLConfiguration conf = null;
+        try {
+            conf = new XMLConfiguration(config);
+        } catch (ConfigurationException e) {
+            throw new FitsConfigurationException("Error reading " + config + "fits.xml", e);
+        }
 
-		@SuppressWarnings("rawtypes")
-		List fields = conf.configurationsAt("map");
-		for(@SuppressWarnings("rawtypes")
-		Iterator it = fields.iterator(); it.hasNext();)	{
-		    HierarchicalConfiguration sub = (HierarchicalConfiguration) it.next();
-		    // sub contains now all data about a single field
-		    String format = sub.getString("[@format]");
-		    String transform = sub.getString("[@transform]");
-		    mappings.put(format,transform);
-		}
-		return mappings;
-	}
-
+        @SuppressWarnings("rawtypes")
+        List fields = conf.configurationsAt("map");
+        for (@SuppressWarnings("rawtypes") Iterator it = fields.iterator(); it.hasNext(); ) {
+            HierarchicalConfiguration sub = (HierarchicalConfiguration) it.next();
+            // sub contains now all data about a single field
+            String format = sub.getString("[@format]");
+            String transform = sub.getString("[@transform]");
+            mappings.put(format, transform);
+        }
+        return mappings;
+    }
 }

--- a/src/main/java/edu/harvard/hul/ois/fits/util/DateTimeUtil.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/util/DateTimeUtil.java
@@ -10,16 +10,6 @@
 
 package edu.harvard.hul.ois.fits.util;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.format.SignStyle;
-import java.time.temporal.TemporalAccessor;
-
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
@@ -29,6 +19,16 @@ import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoField.YEAR;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.SignStyle;
+import java.time.temporal.TemporalAccessor;
 
 /**
  * Utility class for working with timestamps
@@ -125,15 +125,15 @@ public final class DateTimeUtil {
             .toFormatter();
 
     private static final DateTimeFormatter[] FORMATTERS = new DateTimeFormatter[] {
-            DateTimeFormatter.ISO_DATE_TIME,
-            DateTimeFormatter.ISO_DATE,
-            DATE_TIME_WITH_SPACE,
-            DateTimeFormatter.BASIC_ISO_DATE,
-            DateTimeFormatter.RFC_1123_DATE_TIME,
-            DATE_TIME_WITH_COLON,
-            DATE_WITH_COLON,
-            DATE_TIME_WITH_PERIOD,
-            DATE_WITH_PERIOD
+        DateTimeFormatter.ISO_DATE_TIME,
+        DateTimeFormatter.ISO_DATE,
+        DATE_TIME_WITH_SPACE,
+        DateTimeFormatter.BASIC_ISO_DATE,
+        DateTimeFormatter.RFC_1123_DATE_TIME,
+        DATE_TIME_WITH_COLON,
+        DATE_WITH_COLON,
+        DATE_TIME_WITH_PERIOD,
+        DATE_WITH_PERIOD
     };
 
     private DateTimeUtil() {
@@ -167,7 +167,8 @@ public final class DateTimeUtil {
 
         for (DateTimeFormatter formatter : FORMATTERS) {
             try {
-                parsed = formatter.parseBest(originalTimestamp,
+                parsed = formatter.parseBest(
+                        originalTimestamp,
                         OffsetDateTime::from,
                         ZonedDateTime::from,
                         LocalDateTime::from,
@@ -192,7 +193,4 @@ public final class DateTimeUtil {
 
         return standardized;
     }
-
-
-
 }

--- a/src/main/java/nz/govt/natlib/adapter/wordperfect/WPAdapter.java
+++ b/src/main/java/nz/govt/natlib/adapter/wordperfect/WPAdapter.java
@@ -12,7 +12,7 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *  
+ *
  *  2016 - Minor changes have been made to the original code by Harvard University.
  *  The original Apache license still applies.
  */
@@ -22,7 +22,6 @@ package nz.govt.natlib.adapter.wordperfect;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-
 import nz.govt.natlib.adapter.AdapterUtils;
 import nz.govt.natlib.adapter.DataAdapter;
 import nz.govt.natlib.fx.BooleanElement;
@@ -44,422 +43,464 @@ import nz.govt.natlib.meta.log.LogMessage;
 
 /**
  * Adapter for WordPerfect documents.
- * 
+ *
  * @author unascribed
  * @version 1.0
  */
-
 public class WPAdapter extends DataAdapter {
 
-	// header
-	private Element wpHeaderElement = new CompoundElement(
-			new String[] { "marker", "file-type", "offset", "product",
-					"file-sub-type", "major-version", "minor-version",
-					"encrypted", "reserved" },
-			new Element[] {
-					new ByteChomperElement(IntegerElement.BYTE_SIZE),
-					// new
-					// IntegerElement(IntegerElement.BYTE_SIZE,false,IntegerElement.DECIMAL_FORMAT),
-					new FixedLengthStringElement(3, true),
-					new ByteChomperElement(IntegerElement.INT_SIZE),
-					// new
-					// IntegerElement(IntegerElement.INT_SIZE,false,IntegerElement.DECIMAL_FORMAT),
-					new EnumeratedElement(new IntegerElement(
-							IntegerElement.BYTE_SIZE, false,
-							IntegerElement.HEX_FORMAT), new String[] { "0x1",
-							"0x2", "0x3", "0x4", "0x5", "0x6", "0x7", "0x8",
-							"0x9", "0xa", "0xb", "0xc", "0xd", "0xe", "0xf",
-							"0x10" }, new String[] { "WordPerfect", "Shell",
-							"Notebook", "Calculator", "File Manager",
-							"Calendar", "Program Editor/Ed Editor",
-							"Macro Editor", "PlanPerfect", "DataPerfect",
-							"Mail", "Printer (PTR.EXE)", "Scheduler",
-							"WordPerfect Office", "DrawPerfect",
-							"LetterPerfect" }, "unknown"),
-					new EnumeratedElement(
-							new IntegerElement(IntegerElement.BYTE_SIZE, false,
-									IntegerElement.HEX_FORMAT),
-							new String[] { "0x1", "0x2", "0x3", "0xa", "0xb",
-									"0xc", "0xd", "0xe", "0xf", "0x10", "0x11",
-									"0x12", "0x13", "0x14", "0x15", "0x16",
-									"0x17", "0x18", "0x19", "0x1a", "0x1b",
-									"0x1c", "0x1d", "0x1e", "0x1f", "0x20",
-									"0x21", "0x22", "0x23", "0x24", "0x25",
-									"0x26", "0x27", "0x28", "0x29", "0x2a",
-									"0x2b", "0x2c", "0x2d", "0x2e", "0x2f",
-									"0x30", "0x38" },
-							new String[] {
-									"macro file",
-									"WordPerfect help file",
-									"keyboard definition file",
-									"Document",
-									"dictionary file",
-									"thesaurus file",
-									"block",
-									"rectangular block",
-									"column block",
-									"printer resource file (PRS)",
-									"setup file",
-									"prefix information file",
-									"printer resource file (ALL)",
-									"display resource file (DRS)",
-									"overlay file (WP.FIL)",
-									"graphics file (WPG)",
-									"hyphenation code module",
-									"hyphenation data module",
-									"macro resource file (MRS)",
-									"graphics driver (WPD)",
-									"hyphenation lex module",
-									"Printer Q codes (used by VAX/DG)",
-									"Spell code module�word list",
-									"WP.QRS file (WP5.1 equation resource file)",
-									"Reserved", "VAX .SET",
-									"Spell code module�rules",
-									"Dictionary�rules", "Reserved",
-									"WP5.1 Graphics/Text Drivers",
-									"Rhymer word file (WPCorp product, TSR)",
-									"Rhymer pronunciation file", "Reserved",
-									"Reserved",
-									"WP51.INS file (install options file)",
-									"Mouse driver for WP5.1",
-									"UNIX Setup file for WP5.0",
-									"MAC WP2.0 document",
-									"VAX file (WP4.2 document)",
-									"External Spell Code Module (WP5.1)",
-									"External Spell Dictionary",
-									"MAC SOFT graphics file",
-									"WPWin 5.1 Application Resource Library added for WPWin 5.1" },
-							"unknown"),
-					new WPMajorVersionIntegerElement(IntegerElement.BYTE_SIZE,
-							false),
-					new IntegerElement(IntegerElement.BYTE_SIZE, false,
-							IntegerElement.DECIMAL_FORMAT),
-					new BooleanElement(IntegerElement.SHORT_SIZE),
-					new ByteChomperElement(2) });
+    // header
+    private Element wpHeaderElement = new CompoundElement(
+            new String[] {
+                "marker",
+                "file-type",
+                "offset",
+                "product",
+                "file-sub-type",
+                "major-version",
+                "minor-version",
+                "encrypted",
+                "reserved"
+            },
+            new Element[] {
+                new ByteChomperElement(IntegerElement.BYTE_SIZE),
+                // new
+                // IntegerElement(IntegerElement.BYTE_SIZE,false,IntegerElement.DECIMAL_FORMAT),
+                new FixedLengthStringElement(3, true),
+                new ByteChomperElement(IntegerElement.INT_SIZE),
+                // new
+                // IntegerElement(IntegerElement.INT_SIZE,false,IntegerElement.DECIMAL_FORMAT),
+                new EnumeratedElement(
+                        new IntegerElement(IntegerElement.BYTE_SIZE, false, IntegerElement.HEX_FORMAT),
+                        new String[] {
+                            "0x1", "0x2", "0x3", "0x4", "0x5", "0x6", "0x7", "0x8", "0x9", "0xa", "0xb", "0xc", "0xd",
+                            "0xe", "0xf", "0x10"
+                        },
+                        new String[] {
+                            "WordPerfect",
+                            "Shell",
+                            "Notebook",
+                            "Calculator",
+                            "File Manager",
+                            "Calendar",
+                            "Program Editor/Ed Editor",
+                            "Macro Editor",
+                            "PlanPerfect",
+                            "DataPerfect",
+                            "Mail",
+                            "Printer (PTR.EXE)",
+                            "Scheduler",
+                            "WordPerfect Office",
+                            "DrawPerfect",
+                            "LetterPerfect"
+                        },
+                        "unknown"),
+                new EnumeratedElement(
+                        new IntegerElement(IntegerElement.BYTE_SIZE, false, IntegerElement.HEX_FORMAT),
+                        new String[] {
+                            "0x1", "0x2", "0x3", "0xa", "0xb", "0xc", "0xd", "0xe", "0xf", "0x10", "0x11", "0x12",
+                            "0x13", "0x14", "0x15", "0x16", "0x17", "0x18", "0x19", "0x1a", "0x1b", "0x1c", "0x1d",
+                            "0x1e", "0x1f", "0x20", "0x21", "0x22", "0x23", "0x24", "0x25", "0x26", "0x27", "0x28",
+                            "0x29", "0x2a", "0x2b", "0x2c", "0x2d", "0x2e", "0x2f", "0x30", "0x38"
+                        },
+                        new String[] {
+                            "macro file",
+                            "WordPerfect help file",
+                            "keyboard definition file",
+                            "Document",
+                            "dictionary file",
+                            "thesaurus file",
+                            "block",
+                            "rectangular block",
+                            "column block",
+                            "printer resource file (PRS)",
+                            "setup file",
+                            "prefix information file",
+                            "printer resource file (ALL)",
+                            "display resource file (DRS)",
+                            "overlay file (WP.FIL)",
+                            "graphics file (WPG)",
+                            "hyphenation code module",
+                            "hyphenation data module",
+                            "macro resource file (MRS)",
+                            "graphics driver (WPD)",
+                            "hyphenation lex module",
+                            "Printer Q codes (used by VAX/DG)",
+                            "Spell code module�word list",
+                            "WP.QRS file (WP5.1 equation resource file)",
+                            "Reserved",
+                            "VAX .SET",
+                            "Spell code module�rules",
+                            "Dictionary�rules",
+                            "Reserved",
+                            "WP5.1 Graphics/Text Drivers",
+                            "Rhymer word file (WPCorp product, TSR)",
+                            "Rhymer pronunciation file",
+                            "Reserved",
+                            "Reserved",
+                            "WP51.INS file (install options file)",
+                            "Mouse driver for WP5.1",
+                            "UNIX Setup file for WP5.0",
+                            "MAC WP2.0 document",
+                            "VAX file (WP4.2 document)",
+                            "External Spell Code Module (WP5.1)",
+                            "External Spell Dictionary",
+                            "MAC SOFT graphics file",
+                            "WPWin 5.1 Application Resource Library added for WPWin 5.1"
+                        },
+                        "unknown"),
+                new WPMajorVersionIntegerElement(IntegerElement.BYTE_SIZE, false),
+                new IntegerElement(IntegerElement.BYTE_SIZE, false, IntegerElement.DECIMAL_FORMAT),
+                new BooleanElement(IntegerElement.SHORT_SIZE),
+                new ByteChomperElement(2)
+            });
 
-	// graphics
-	private Element graphicElement = new CompoundElement(
-			new String[] { "graphic-images" },
-			new Element[] { new IntegerElement(IntegerElement.SHORT_SIZE,
-					false, IntegerElement.DECIMAL_FORMAT),
-			// :
-			// : note: there's more but only the image data itself...
-			});
+    // graphics
+    private Element graphicElement = new CompoundElement(new String[] {"graphic-images"}, new Element[] {
+        new IntegerElement(IntegerElement.SHORT_SIZE, false, IntegerElement.DECIMAL_FORMAT),
+        // :
+        // : note: there's more but only the image data itself...
+    });
 
-	// printer
-	private Element printerElement = new CompoundElement(new String[] { "name",
-			"filename", "n/o", "top-margin", "bottom-margin", "left-margin",
-			"right-margin", "flags", "date", "time" }, new Element[] {
-			new FixedLengthStringElement(37, true),
-			new FixedLengthStringElement(13, true),
-			new ByteChomperElement(24),
-			new IntegerElement(IntegerElement.SHORT_SIZE, false,
-					IntegerElement.DECIMAL_FORMAT),
-			new IntegerElement(IntegerElement.SHORT_SIZE, false,
-					IntegerElement.DECIMAL_FORMAT),
-			new IntegerElement(IntegerElement.SHORT_SIZE, false,
-					IntegerElement.DECIMAL_FORMAT),
-			new IntegerElement(IntegerElement.SHORT_SIZE, false,
-					IntegerElement.DECIMAL_FORMAT),
-			new CompoundBitElement(new String[] { "selected", "initialise",
-					"hzone-diabled", "orientation" },
-					new CompoundBitElement.BitElement[] {
-							new CompoundBitElement.BooleanBitReader(1),
-							new CompoundBitElement.BooleanBitReader(1),
-							new CompoundBitElement.BooleanBitReader(1),
-							new CompoundBitElement.BitReader(4), }, false),
-			new CompoundBitElement(new String[] { "day", "month", "year" },
-					new CompoundBitElement.BitElement[] {
-							new CompoundBitElement.BitReader(4),
-							new CompoundBitElement.BitReader(4),
-							new CompoundBitElement.AddingBitReader(7, 80), },
-					false),
-			new CompoundBitElement(new String[] { "seconds", "minutes" },
-					new CompoundBitElement.BitElement[] {
-							new CompoundBitElement.BitReader(4),
-							new CompoundBitElement.BitReader(4), }, false), });
+    // printer
+    private Element printerElement = new CompoundElement(
+            new String[] {
+                "name",
+                "filename",
+                "n/o",
+                "top-margin",
+                "bottom-margin",
+                "left-margin",
+                "right-margin",
+                "flags",
+                "date",
+                "time"
+            },
+            new Element[] {
+                new FixedLengthStringElement(37, true),
+                new FixedLengthStringElement(13, true),
+                new ByteChomperElement(24),
+                new IntegerElement(IntegerElement.SHORT_SIZE, false, IntegerElement.DECIMAL_FORMAT),
+                new IntegerElement(IntegerElement.SHORT_SIZE, false, IntegerElement.DECIMAL_FORMAT),
+                new IntegerElement(IntegerElement.SHORT_SIZE, false, IntegerElement.DECIMAL_FORMAT),
+                new IntegerElement(IntegerElement.SHORT_SIZE, false, IntegerElement.DECIMAL_FORMAT),
+                new CompoundBitElement(
+                        new String[] {"selected", "initialise", "hzone-diabled", "orientation"},
+                        new CompoundBitElement.BitElement[] {
+                            new CompoundBitElement.BooleanBitReader(1),
+                            new CompoundBitElement.BooleanBitReader(1),
+                            new CompoundBitElement.BooleanBitReader(1),
+                            new CompoundBitElement.BitReader(4),
+                        },
+                        false),
+                new CompoundBitElement(
+                        new String[] {"day", "month", "year"},
+                        new CompoundBitElement.BitElement[] {
+                            new CompoundBitElement.BitReader(4),
+                            new CompoundBitElement.BitReader(4),
+                            new CompoundBitElement.AddingBitReader(7, 80),
+                        },
+                        false),
+                new CompoundBitElement(
+                        new String[] {"seconds", "minutes"},
+                        new CompoundBitElement.BitElement[] {
+                            new CompoundBitElement.BitReader(4), new CompoundBitElement.BitReader(4),
+                        },
+                        false),
+            });
 
-	// document flags
-	private Element documentElement = new CompoundElement(new String[] {
-			"flags", "quality", "redline-char", "width", "binding-width",
-			"printer-select", "reserved", "display-pitch", "resolution",
-			"reserved" }, new Element[] {
-			new CompoundBitElement(new String[] { "display-pitch-auto", "",
-					"requires-formatting", "requires-regenerating",
-					"manual-pitch", "requires-update-links",
-					"do-not-display-codes" },
-					new CompoundBitElement.BitElement[] {
-							new CompoundBitElement.BooleanBitReader(1),
-							new CompoundBitElement.BitChomper(2),
-							new CompoundBitElement.BooleanBitReader(1),
-							new CompoundBitElement.BooleanBitReader(1),
-							new CompoundBitElement.BooleanBitReader(1),
-							new CompoundBitElement.BooleanBitReader(1),
-							new CompoundBitElement.BooleanBitReader(1), },
-					false),
-			new CompoundBitElement(new String[] { "print-quality",
-					"graphics-quality" }, new CompoundBitElement.BitElement[] {
-					new CompoundBitElement.BitReader(4),
-					new CompoundBitElement.BitReader(4), }, false),
-			new IntegerElement(IntegerElement.SHORT_SIZE, false,
-					IntegerElement.DECIMAL_FORMAT),
-			new IntegerElement(IntegerElement.SHORT_SIZE, false,
-					IntegerElement.DECIMAL_FORMAT),
-			new IntegerElement(IntegerElement.SHORT_SIZE, false,
-					IntegerElement.DECIMAL_FORMAT),
-			new IntegerElement(IntegerElement.BYTE_SIZE, false,
-					IntegerElement.DECIMAL_FORMAT),
-			new ByteChomperElement(IntegerElement.SHORT_SIZE),
-			new IntegerElement(IntegerElement.SHORT_SIZE, false,
-					IntegerElement.DECIMAL_FORMAT),
-			new IntegerElement(IntegerElement.SHORT_SIZE, false,
-					IntegerElement.DECIMAL_FORMAT),
-			new ByteChomperElement(IntegerElement.SHORT_SIZE), });
+    // document flags
+    private Element documentElement = new CompoundElement(
+            new String[] {
+                "flags",
+                "quality",
+                "redline-char",
+                "width",
+                "binding-width",
+                "printer-select",
+                "reserved",
+                "display-pitch",
+                "resolution",
+                "reserved"
+            },
+            new Element[] {
+                new CompoundBitElement(
+                        new String[] {
+                            "display-pitch-auto",
+                            "",
+                            "requires-formatting",
+                            "requires-regenerating",
+                            "manual-pitch",
+                            "requires-update-links",
+                            "do-not-display-codes"
+                        },
+                        new CompoundBitElement.BitElement[] {
+                            new CompoundBitElement.BooleanBitReader(1),
+                            new CompoundBitElement.BitChomper(2),
+                            new CompoundBitElement.BooleanBitReader(1),
+                            new CompoundBitElement.BooleanBitReader(1),
+                            new CompoundBitElement.BooleanBitReader(1),
+                            new CompoundBitElement.BooleanBitReader(1),
+                            new CompoundBitElement.BooleanBitReader(1),
+                        },
+                        false),
+                new CompoundBitElement(
+                        new String[] {"print-quality", "graphics-quality"},
+                        new CompoundBitElement.BitElement[] {
+                            new CompoundBitElement.BitReader(4), new CompoundBitElement.BitReader(4),
+                        },
+                        false),
+                new IntegerElement(IntegerElement.SHORT_SIZE, false, IntegerElement.DECIMAL_FORMAT),
+                new IntegerElement(IntegerElement.SHORT_SIZE, false, IntegerElement.DECIMAL_FORMAT),
+                new IntegerElement(IntegerElement.SHORT_SIZE, false, IntegerElement.DECIMAL_FORMAT),
+                new IntegerElement(IntegerElement.BYTE_SIZE, false, IntegerElement.DECIMAL_FORMAT),
+                new ByteChomperElement(IntegerElement.SHORT_SIZE),
+                new IntegerElement(IntegerElement.SHORT_SIZE, false, IntegerElement.DECIMAL_FORMAT),
+                new IntegerElement(IntegerElement.SHORT_SIZE, false, IntegerElement.DECIMAL_FORMAT),
+                new ByteChomperElement(IntegerElement.SHORT_SIZE),
+            });
 
-	// document summary part1 (5.0)
-	private Element summaryElement = new CompoundElement(new String[] {
-			"created", "name", "type", "subject", "author", "typist",
-			"abstract" }, new Element[] { new StringElement(),
-			new StringElement(), new StringElement(), new StringElement(),
-			new StringElement(), new StringElement(), new StringElement(), });
+    // document summary part1 (5.0)
+    private Element summaryElement = new CompoundElement(
+            new String[] {"created", "name", "type", "subject", "author", "typist", "abstract"}, new Element[] {
+                new StringElement(),
+                new StringElement(),
+                new StringElement(),
+                new StringElement(),
+                new StringElement(),
+                new StringElement(),
+                new StringElement(),
+            });
 
-	// document summary part2 (5.1+)
-	private Element summary2Element = new CompoundElement(new String[] {
-			"account", "keywords", "", "created-ISO", "" }, new Element[] {
-			new StringElement(), new StringElement(),
-			new ByteChomperElement(1), new StringElement(),
-			new ByteChomperElement(1), });
+    // document summary part2 (5.1+)
+    private Element summary2Element =
+            new CompoundElement(new String[] {"account", "keywords", "", "created-ISO", ""}, new Element[] {
+                new StringElement(), new StringElement(),
+                new ByteChomperElement(1), new StringElement(),
+                new ByteChomperElement(1),
+            });
 
-	public String getVersion() {
-		return "1.0";
-	}
+    public String getVersion() {
+        return "1.0";
+    }
 
-	public boolean acceptsFile(File file) {
-		boolean wp = false;
-		DataSource ftk = null;
-		try {
-			ftk = new FileDataSource(file);
-			// Header and default information
-			byte[] fileHead = ftk.getData(4);
-			// decimal values of expected first 4 bytes of a Word Perfect file
-			byte[] acceptableWordPerfectHead = { -1, 87, 80, 67 };  // {(unprintable),W,P,C} for "�WPC"
-			// compare inital bytes of input file with expected bytes
-			wp = Arrays.equals(fileHead, acceptableWordPerfectHead);
-			
-//			String head = FXUtil.getFixedStringValue(ftk, 4);
-//			if ((head.equals("�WPC"))) { // DO NOT USE: different encoding on different platforms
-//				wp = true;
-//			}
-			
-		} catch (IOException ex) {
-			LogManager.getInstance().logMessage(LogMessage.WORTHLESS_CHATTER,
-					"IO Exception determining WordPerfect file type");
-		}
-		finally {
-			AdapterUtils.close(ftk);
-		}
-		return wp;
-	}
+    public boolean acceptsFile(File file) {
+        boolean wp = false;
+        DataSource ftk = null;
+        try {
+            ftk = new FileDataSource(file);
+            // Header and default information
+            byte[] fileHead = ftk.getData(4);
+            // decimal values of expected first 4 bytes of a Word Perfect file
+            byte[] acceptableWordPerfectHead = {-1, 87, 80, 67}; // {(unprintable),W,P,C} for "�WPC"
+            // compare inital bytes of input file with expected bytes
+            wp = Arrays.equals(fileHead, acceptableWordPerfectHead);
 
-	public String getOutputType() {
-		return "wordperfect.dtd";
-	}
+            //			String head = FXUtil.getFixedStringValue(ftk, 4);
+            //			if ((head.equals("�WPC"))) { // DO NOT USE: different encoding on different platforms
+            //				wp = true;
+            //			}
 
-	public String getInputType() {
-		return "application/vnd.wordperfect";
-	}
+        } catch (IOException ex) {
+            LogManager.getInstance()
+                    .logMessage(LogMessage.WORTHLESS_CHATTER, "IO Exception determining WordPerfect file type");
+        } finally {
+            AdapterUtils.close(ftk);
+        }
+        return wp;
+    }
 
-	public String getName() {
-		return "Corel Wordperfect Adapter";
-	}
+    public String getOutputType() {
+        return "wordperfect.dtd";
+    }
 
-	public String getDescription() {
-		return "Adapts all Corel WordPerfect files from version 5.1 to 12.0";
-	}
+    public String getInputType() {
+        return "application/vnd.wordperfect";
+    }
 
-	public void adapt(File file, ParserContext ctx) throws IOException {
-		// Add the MetaData to the tree!
-		DataSource ftk = new FileDataSource(file);
-		ctx.fireStartParseEvent("wordperfect");
-		writeFileInfo(file, ctx);
-		// ctx.fireParseEvent("Version", "");
-		try {
-			ctx.fireStartParseEvent("header");
-			wpHeaderElement.read(ftk, ctx);
-			ctx.fireEndParseEvent("header");
-			boolean fivePointOnePlus = ctx
-					.getIntAttribute("wordperfect.header.minor-version") >= 1;
-			boolean sixPlus = Double.parseDouble(ctx
-					.getAttribute("wordperfect.header.major-version")
-					+ "") >= 6;
+    public String getName() {
+        return "Corel Wordperfect Adapter";
+    }
 
-			if (sixPlus) {
-				// next version should encompass WordPerfect 6.0+
-			} else {
+    public String getDescription() {
+        return "Adapts all Corel WordPerfect files from version 5.1 to 12.0";
+    }
 
-				IndexHeaderElement indexReader = new IndexHeaderElement();
-				PacketHeaderElement blockHead = new PacketHeaderElement();
-				boolean readingBlocks = true;
-				boolean summary = false;
-				while (readingBlocks) {
-					indexReader.read(ftk, ctx);
-					// System.out.println(indexReader);
-					for (int i = 0; i < indexReader.count - 1; i++) {
-						blockHead.read(ftk, ctx);
-						// arrange to retrive the data from the appropriate
-						// place
-						long pos = ftk.getPosition();
-						ftk.setPosition(blockHead.dataOffset);
+    public void adapt(File file, ParserContext ctx) throws IOException {
+        // Add the MetaData to the tree!
+        DataSource ftk = new FileDataSource(file);
+        ctx.fireStartParseEvent("wordperfect");
+        writeFileInfo(file, ctx);
+        // ctx.fireParseEvent("Version", "");
+        try {
+            ctx.fireStartParseEvent("header");
+            wpHeaderElement.read(ftk, ctx);
+            ctx.fireEndParseEvent("header");
+            boolean fivePointOnePlus = ctx.getIntAttribute("wordperfect.header.minor-version") >= 1;
+            boolean sixPlus = Double.parseDouble(ctx.getAttribute("wordperfect.header.major-version") + "") >= 6;
 
-						// System.out.println(" >"+blockHead);
-						switch (blockHead.getType()) {
-						case 0xc:
-							ctx.fireStartParseEvent("printer");
-							printerElement.read(ftk, ctx);
-							ctx.fireEndParseEvent("printer");
-							break;
-						case 0x8:
-							ctx.fireStartParseEvent("graphics");
-							graphicElement.read(ftk, ctx);
-							ctx.fireEndParseEvent("graphics");
-							break;
-						case 0x6:
-							ctx.fireStartParseEvent("document");
-							documentElement.read(ftk, ctx);
-							ctx.fireEndParseEvent("document");
-							break;
-						case 0x1:
-							ctx.fireStartParseEvent("summary");
-							summary = true;
-							// System.out.println("Found Sumary at :"
-							//		+ ftk.getPosition());
-							summaryElement.read(ftk, ctx);
-							if (fivePointOnePlus) {
-								summary2Element.read(ftk, ctx);
-							}
-							ctx.fireEndParseEvent("summary");
-							break;
-						}
+            if (sixPlus) {
+                // next version should encompass WordPerfect 6.0+
+            } else {
 
-						// move back to the next block...
-						ftk.setPosition(pos);
-					}
+                IndexHeaderElement indexReader = new IndexHeaderElement();
+                PacketHeaderElement blockHead = new PacketHeaderElement();
+                boolean readingBlocks = true;
+                boolean summary = false;
+                while (readingBlocks) {
+                    indexReader.read(ftk, ctx);
+                    // System.out.println(indexReader);
+                    for (int i = 0; i < indexReader.count - 1; i++) {
+                        blockHead.read(ftk, ctx);
+                        // arrange to retrive the data from the appropriate
+                        // place
+                        long pos = ftk.getPosition();
+                        ftk.setPosition(blockHead.dataOffset);
 
-					// now move to the next block...
-					if (indexReader.getNextBlockOffset() == 0) {
-						readingBlocks = false;
-						break;
-					}
-					ftk.setPosition(indexReader.getNextBlockOffset());
-				}
+                        // System.out.println(" >"+blockHead);
+                        switch (blockHead.getType()) {
+                            case 0xc:
+                                ctx.fireStartParseEvent("printer");
+                                printerElement.read(ftk, ctx);
+                                ctx.fireEndParseEvent("printer");
+                                break;
+                            case 0x8:
+                                ctx.fireStartParseEvent("graphics");
+                                graphicElement.read(ftk, ctx);
+                                ctx.fireEndParseEvent("graphics");
+                                break;
+                            case 0x6:
+                                ctx.fireStartParseEvent("document");
+                                documentElement.read(ftk, ctx);
+                                ctx.fireEndParseEvent("document");
+                                break;
+                            case 0x1:
+                                ctx.fireStartParseEvent("summary");
+                                summary = true;
+                                // System.out.println("Found Sumary at :"
+                                //		+ ftk.getPosition());
+                                summaryElement.read(ftk, ctx);
+                                if (fivePointOnePlus) {
+                                    summary2Element.read(ftk, ctx);
+                                }
+                                ctx.fireEndParseEvent("summary");
+                                break;
+                        }
 
-				if (!summary) {
-					ctx.fireParseEvent("summary", "");
-				}
-			}
-		} finally {
-			AdapterUtils.close(ftk);
-		}
-		ctx.fireEndParseEvent("wordperfect");
-	}
+                        // move back to the next block...
+                        ftk.setPosition(pos);
+                    }
 
-	private class IndexHeaderElement extends Element {
-		int type = 0;
+                    // now move to the next block...
+                    if (indexReader.getNextBlockOffset() == 0) {
+                        readingBlocks = false;
+                        break;
+                    }
+                    ftk.setPosition(indexReader.getNextBlockOffset());
+                }
 
-		int count = 0;
+                if (!summary) {
+                    ctx.fireParseEvent("summary", "");
+                }
+            }
+        } finally {
+            AdapterUtils.close(ftk);
+        }
+        ctx.fireEndParseEvent("wordperfect");
+    }
 
-		int length = 0;
+    private class IndexHeaderElement extends Element {
+        int type = 0;
 
-		int nextBlockOffset = 0;
+        int count = 0;
 
-		public void read(DataSource data, ParserContext ctx) throws IOException {
-			byte[] buf = data.getData(IntegerElement.SHORT_SIZE);
-			type = (int) FXUtil.getNumericalValue(buf, false);
-			buf = data.getData(IntegerElement.SHORT_SIZE);
-			count = (int) FXUtil.getNumericalValue(buf, false);
-			buf = data.getData(IntegerElement.SHORT_SIZE);
-			length = (int) FXUtil.getNumericalValue(buf, false);
-			buf = data.getData(IntegerElement.INT_SIZE);
-			nextBlockOffset = (int) FXUtil.getNumericalValue(buf, false);
-		}
+        int length = 0;
 
-		public String toString() {
-			return "WP Index [" + type + "]: indices=" + count + ", len="
-					+ length + ", next=" + nextBlockOffset;
-		}
+        int nextBlockOffset = 0;
 
-		/**
-		 * @return
-		 */
-		public int getCount() {
-			return count;
-		}
+        public void read(DataSource data, ParserContext ctx) throws IOException {
+            byte[] buf = data.getData(IntegerElement.SHORT_SIZE);
+            type = (int) FXUtil.getNumericalValue(buf, false);
+            buf = data.getData(IntegerElement.SHORT_SIZE);
+            count = (int) FXUtil.getNumericalValue(buf, false);
+            buf = data.getData(IntegerElement.SHORT_SIZE);
+            length = (int) FXUtil.getNumericalValue(buf, false);
+            buf = data.getData(IntegerElement.INT_SIZE);
+            nextBlockOffset = (int) FXUtil.getNumericalValue(buf, false);
+        }
 
-		/**
-		 * @return
-		 */
-		public int getLength() {
-			return length;
-		}
+        public String toString() {
+            return "WP Index [" + type + "]: indices=" + count + ", len=" + length + ", next=" + nextBlockOffset;
+        }
 
-		/**
-		 * @return
-		 */
-		public int getNextBlockOffset() {
-			return nextBlockOffset;
-		}
+        /**
+         * @return
+         */
+        public int getCount() {
+            return count;
+        }
 
-		/**
-		 * @return
-		 */
-		public int getType() {
-			return type;
-		}
+        /**
+         * @return
+         */
+        public int getLength() {
+            return length;
+        }
 
-	}
+        /**
+         * @return
+         */
+        public int getNextBlockOffset() {
+            return nextBlockOffset;
+        }
 
-	private class PacketHeaderElement extends Element {
-		int type = 0;
+        /**
+         * @return
+         */
+        public int getType() {
+            return type;
+        }
+    }
 
-		int length = 0;
+    private class PacketHeaderElement extends Element {
+        int type = 0;
 
-		int dataOffset = 0;
+        int length = 0;
 
-		public void read(DataSource data, ParserContext ctx) throws IOException {
-			byte[] buf = data.getData(IntegerElement.SHORT_SIZE);
-			type = (int) FXUtil.getNumericalValue(buf, false);
-			buf = data.getData(IntegerElement.INT_SIZE);
-			length = (int) FXUtil.getNumericalValue(buf, false);
-			buf = data.getData(IntegerElement.INT_SIZE);
-			dataOffset = (int) FXUtil.getNumericalValue(buf, false);
-		}
+        int dataOffset = 0;
 
-		public String toString() {
-			return "WP Block [" + type + "]: len=" + length + ", offset="
-					+ dataOffset;
-		}
+        public void read(DataSource data, ParserContext ctx) throws IOException {
+            byte[] buf = data.getData(IntegerElement.SHORT_SIZE);
+            type = (int) FXUtil.getNumericalValue(buf, false);
+            buf = data.getData(IntegerElement.INT_SIZE);
+            length = (int) FXUtil.getNumericalValue(buf, false);
+            buf = data.getData(IntegerElement.INT_SIZE);
+            dataOffset = (int) FXUtil.getNumericalValue(buf, false);
+        }
 
-		/**
-		 * @return
-		 */
-		public int getDataOffset() {
-			return dataOffset;
-		}
+        public String toString() {
+            return "WP Block [" + type + "]: len=" + length + ", offset=" + dataOffset;
+        }
 
-		/**
-		 * @return
-		 */
-		public int getLength() {
-			return length;
-		}
+        /**
+         * @return
+         */
+        public int getDataOffset() {
+            return dataOffset;
+        }
 
-		/**
-		 * @return
-		 */
-		public int getType() {
-			return type;
-		}
+        /**
+         * @return
+         */
+        public int getLength() {
+            return length;
+        }
 
-	}
-
+        /**
+         * @return
+         */
+        public int getType() {
+            return type;
+        }
+    }
 }

--- a/src/main/java/nz/govt/natlib/meta/config/Config.java
+++ b/src/main/java/nz/govt/natlib/meta/config/Config.java
@@ -12,7 +12,7 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *  
+ *
  *  2015 - Minor changes have been made to the original code by Harvard University.
  *  The original Apache license still applies.
  */
@@ -31,7 +31,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Result;
@@ -41,1096 +40,1052 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-
 import nz.govt.natlib.AdapterFactory;
 import nz.govt.natlib.FileUtil;
 import nz.govt.natlib.adapter.DataAdapter;
 import nz.govt.natlib.fx.FXUtil;
 import nz.govt.natlib.meta.log.LogManager;
 import nz.govt.natlib.meta.log.LogMessage;
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-//import blowfishj.BlowfishEasy;
+// import blowfishj.BlowfishEasy;
 
 /**
  * The original class has been changed to allow the substitution of a different
  * ClassLoader class in the method
  * private boolean initAdapters(Node node)
  * Since the method was private it could not be overridden.
- * 
+ *
  * @author Nic Evans
  * @version 1.0
  */
 public class Config {
 
-	private static final String ROOT_TAG = "meta-config";
+    private static final String ROOT_TAG = "meta-config";
 
-	private static final String INPUT_FILES_TAG = "input-files";
+    private static final String INPUT_FILES_TAG = "input-files";
 
-	private static final String HARVESTER_TAG = "harvester";
+    private static final String HARVESTER_TAG = "harvester";
 
-	private static final String PARAMETER_TAG = "parameter";
+    private static final String PARAMETER_TAG = "parameter";
 
-	private static final String XML_BASE_TAG = "xml-location";
+    private static final String XML_BASE_TAG = "xml-location";
 
-	private static final String JAR_BASE_TAG = "jar-location";
+    private static final String JAR_BASE_TAG = "jar-location";
 
-	private static final String JAR_TAG = "jar";
+    private static final String JAR_TAG = "jar";
 
-	private static final String TITLE_TAG = "title";
+    private static final String TITLE_TAG = "title";
 
-	private static final String ADMIN_PASSWORD_TAG = "admin-password";
+    private static final String ADMIN_PASSWORD_TAG = "admin-password";
 
-	private static final String ADAPTERS_TAG = "adapters";
+    private static final String ADAPTERS_TAG = "adapters";
 
-	private static final String PROFILES_TAG = "profiles";
+    private static final String PROFILES_TAG = "profiles";
 
-	private static final String PROFILE_TAG = "profile";
+    private static final String PROFILE_TAG = "profile";
 
-	private static final String PROFILE_DEFAULT_NAME_TAG = "default";
+    private static final String PROFILE_DEFAULT_NAME_TAG = "default";
 
-	private static final String MAPS_TAG = "xslt-map";
+    private static final String MAPS_TAG = "xslt-map";
 
-	private static final String MAP_TAG = "map";
+    private static final String MAP_TAG = "map";
 
-	private static final String ADAPTER_TAG = "adapter";
+    private static final String ADAPTER_TAG = "adapter";
 
-	private static final String CLASS_TAG = "class";
+    private static final String CLASS_TAG = "class";
 
-	private static final String OUTPUT_DTD_TAG = "output-dtd";
+    private static final String OUTPUT_DTD_TAG = "output-dtd";
 
-	private static final String INPUT_DTD_TAG = "input-dtd";
+    private static final String INPUT_DTD_TAG = "input-dtd";
 
-	private static final String XSLT_TAG = "xslt";
+    private static final String XSLT_TAG = "xslt";
 
-	private static final String DOC_NAME_TAG = "doc-name";
+    private static final String DOC_NAME_TAG = "doc-name";
 
-	private static final String CONFIGURATIONS_TAG = "configurations";
+    private static final String CONFIGURATIONS_TAG = "configurations";
 
-	private static final String CONFIGURATION_TAG = "configuration";
+    private static final String CONFIGURATION_TAG = "configuration";
 
-	private static final String NAME_TAG = "name";
+    private static final String NAME_TAG = "name";
 
-	private static final String VALUE_TAG = "value";
+    private static final String VALUE_TAG = "value";
 
-	private static final String OUTPUT_DIRECTORY_TAG = "output-directory";
+    private static final String OUTPUT_DIRECTORY_TAG = "output-directory";
 
-	private static final String DIR_NAME_TAG = "dir";
+    private static final String DIR_NAME_TAG = "dir";
 
-	private static final String LOG_TAG = "log-dir";
+    private static final String LOG_TAG = "log-dir";
 
-	private static final String URL_TAG = "url";
+    private static final String URL_TAG = "url";
 
-	private static final String USERS_TAG = "users";
+    private static final String USERS_TAG = "users";
 
-	private static final String USER_TAG = "user";
+    private static final String USER_TAG = "user";
 
-	private static final String USER_NAME_TAG = "name";
+    private static final String USER_NAME_TAG = "name";
 
-	private static final String USER_DEFAULT_NAME_TAG = "default";
+    private static final String USER_DEFAULT_NAME_TAG = "default";
 
-	private static final int USER_ADDED = 0;
+    private static final int USER_ADDED = 0;
 
-	private static final int USER_REMOVED = 1;
+    private static final int USER_REMOVED = 1;
 
-	private static final int PROFILE_ADDED = 0;
+    private static final int PROFILE_ADDED = 0;
 
-	private static final int PROFILE_REMOVED = 1;
+    private static final int PROFILE_REMOVED = 1;
 
-	private static final int PROFILE_CHANGED = 2;
+    private static final int PROFILE_CHANGED = 2;
 
-	private static final String SEED = "9B73B749C6A2EA4112400B66EB1E762F";
+    private static final String SEED = "9B73B749C6A2EA4112400B66EB1E762F";
 
-	public static final String SYSTEM_ADAPTER = "[SYSTEM]";
+    public static final String SYSTEM_ADAPTER = "[SYSTEM]";
 
-	private static Config instance;
+    private static Config instance;
 
-	private static Config editInstance;
-	
-	// custom ClassLoader; system ClassLoader if none set.
-	private static ClassLoader classLoader;
+    private static Config editInstance;
 
-	private ArrayList configMapping;
+    // custom ClassLoader; system ClassLoader if none set.
+    private static ClassLoader classLoader;
 
-	private ArrayList users;
+    private ArrayList configMapping;
 
-	private ArrayList profiles;
+    private ArrayList users;
 
-	private Profile defaultProfile;
+    private ArrayList profiles;
 
-	private Profile currentProfile;
+    private Profile defaultProfile;
 
-	private Node usersNode;
+    private Profile currentProfile;
 
-	private Node baseXMLDir;
+    private Node usersNode;
 
-	private Node baseJarDir;
-
-	private Node appName;
-
-	private Node adaptersNode;
-
-	private Node adminPasswordNode;
-
-	private static final String copyright = '\u00A9' + " National Library of New Zealand";
-
-	private Node baseHarvestDir;
-
-	private Node logDirectory;
-
-	private Node mapNode;
-
-	private Node profileNode;
-
-	private Node configNode;
-
-	private Document configDoc;
-
-	private User defaultUser;
-
-	private ArrayList configs = new ArrayList();
-
-	private HashMap adapterJarLocations = new HashMap();
-
-	private HashSet userListeners = new HashSet();
-
-	private HashSet profileListeners = new HashSet();
-
-	private String adminPassword;
-
-	private Config() {
-		configMapping = new ArrayList();
-		users = new ArrayList();
-		readConfig();
-	}
-
-	public void setJarForAdapter(DataAdapter adapter, String jar) {
-		adapterJarLocations.put(adapter.getClass(), jar);
-	}
-
-	public String getJarForAdapter(DataAdapter adapter) {
-		return (String) adapterJarLocations.get(adapter.getClass());
-	}
-
-	private Config(Config original) {
-		configMapping = (ArrayList) original.configMapping.clone();
-		users = (ArrayList) original.users.clone();
-		profiles = new ArrayList();
-		currentProfile = original.currentProfile;
-		defaultProfile = original.defaultProfile;
-		defaultUser = original.defaultUser;
-		Iterator it = original.profiles.iterator();
-		while (it.hasNext()) {
-			Profile origP = (Profile) it.next();
-			Profile p = new Profile();
-			p.setName(origP.getName());
-			p.setInputDirectory(origP.getInputDirectory());
-			p.setLogDirectory(origP.getLogDirectory());
-			Iterator ads = origP.getAdapterClasses();
-			while (ads.hasNext()) {
-				p.setAdapter((String) ads.next(), true);
-			}
-			baseXMLDir = original.baseXMLDir;
-			baseJarDir = original.baseJarDir;
-			profiles.add(p);
-			if (original.currentProfile.getName().equals(p.getName())) {
-				currentProfile = p;
-			}
-			if (original.defaultProfile.getName().equals(p.getName())) {
-				defaultProfile = p;
-			}
-		}
-		configs = (ArrayList) original.configs.clone();
-		adapterJarLocations = (HashMap) original.adapterJarLocations.clone();
-	}
-
-	public static synchronized void saveAdapterEdit() {
-		instance.adapterJarLocations = editInstance.adapterJarLocations;
-		instance.configMapping = editInstance.configMapping;
-	}
-
-	public static synchronized void saveEdit() {
-		instance.configMapping = editInstance.configMapping;
-		instance.users = editInstance.users;
-		instance.profiles = editInstance.profiles;
-		instance.defaultProfile = editInstance.defaultProfile;
-		instance.defaultUser = editInstance.defaultUser;
-		Profile old = instance.currentProfile;
-		instance.currentProfile = editInstance.currentProfile;
-		if (!old.equals(instance.currentProfile)) {
-			instance.fireProfileEvent(PROFILE_CHANGED, old);
-		}
-		instance.configs = editInstance.configs;
-		instance.adapterJarLocations = editInstance.adapterJarLocations;
-	}
-
-	public synchronized static Config getInstance() {
-		if (classLoader == null) {
-			// If no class loader set use default -- the system class loader.
-			Config.classLoader = ClassLoader.getSystemClassLoader();
-		}
-		if (instance == null) {
-			instance = new Config();
-		}
-		return instance;
-	}
-
-	/**
-	 * Allow for the configuration of a ClassLoader other than the
-	 * default system class loader for loading the Adapter classes
-	 * registered in config.xml.
-	 * 
-	 * @param cl - An alternative, custom class loader.
-	 * @see #initAdapters(Node)
-	 */
-	public synchronized static void setClassLoader(final ClassLoader cl) {
-		if (cl != null) {
-			Config.classLoader = cl;
-		}
-	}
-
-	public synchronized static Config getEditInstance(boolean renew) {
-		if ((editInstance == null) || renew) {
-			editInstance = new Config(Config.getInstance());
-		}
-		return editInstance;
-	}
-
-	public synchronized static Config getEditInstance() {
-		return getEditInstance(false);
-	}
-
-	public ArrayList getAvailableConfigs() {
-		return configs;
-	}
-	
-	/**
-	 * Get the configuration with a given name.
-	 * @param name The name of the configuration to retrieve.
-	 * @return The Configuration object.
-	 */
-	public Configuration getConfiguration(String name) throws ConfigurationException {
-		Iterator it = configs.iterator();
-		while (it.hasNext()) {
-			Configuration c = (Configuration) it.next();
-			if (c.getName().equalsIgnoreCase(name)) {
-				return c;
-			}
-		}
-		
-		// We haven't found the configuration, return null.
-		throw new ConfigurationException("Could not find a configuration with the name " + name);
-	}
-
-	public ArrayList getAvailableProfiles() {
-		return profiles;
-	}
-
-	public Profile getDefaultProfile() {
-		return defaultProfile;
-	}
-
-//	public void setAdminPassword(String oldPassword, String password) {
-//		if (oldPassword.equals(adminPassword)) {
-//			adminPassword = password;
-//			BlowfishEasy bfish = new BlowfishEasy(SEED.toCharArray());
-//			adminPasswordNode.setNodeValue(bfish.encryptString(password));
-//		}
-//	}
-
-	public boolean checkAdminPassword(String pass) {
-		if (pass != null) {
-			return pass.equals(adminPassword);
-		}
-		return false;
-	}
-
-	public Profile getCurrentProfile() {
-		return currentProfile;
-	}
-
-	public void setCurrentProfile(Profile current) {
-		currentProfile = current;
-	}
-
-	public void addConfig(Configuration config) {
-		configs.add(config);
-	}
-
-	public User getDefaultUser() {
-		return defaultUser;
-	}
-
-	public void setDefaultUser(User user) {
-		this.defaultUser = user;
-	}
-
-	public String getBaseHarvestDir() {
-		return getCurrentProfile().getInputDirectory();
-	}
-
-	public void setBaseHarvestDir(String baseHarvestDir) {
-		getCurrentProfile().setInputDirectory(baseHarvestDir);
-	}
-
-	public String getXMLBaseURL() {
-		String st = baseXMLDir.getNodeValue();
-		try {
-			File f = new File(st);
-			return f.getAbsolutePath();
-		} catch (Exception ex) {
-			LogManager.getInstance().logMessage(ex);
-		}
-		return st;
-	}
-
-	public String getJarBaseURL() {
-		String st = baseJarDir.getNodeValue();
-		try {
-			File f = new File(st);
-			return f.getAbsolutePath();
-		} catch (Exception ex) {
-			LogManager.getInstance().logMessage(ex);
-		}
-		return st;
-	}
-
-	public void setXMLBaseURL(String url) {
-		baseXMLDir.setNodeValue(url);
-	}
-
-	public void setJarBaseURL(String url) {
-		baseJarDir.setNodeValue(url);
-	}
-
-	public String getApplicationName() {
-		return appName.getNodeValue();
-	}
-
-	public void setApplicationName(String name) {
-		appName.setNodeValue(name);
-	}
-
-	public String getCopyright() {
-		return copyright;
-	}
-
-	public void setLogDirectory(String logDirectory) {
-		instance.getCurrentProfile().setLogDirectory(logDirectory);
-	}
-
-	public String getLogDirectory() {
-		return instance.getCurrentProfile().getLogDirectory();
-	}
-
-	public void addMapping(String inputDTD, String outputDTD,
-			String xsltFunction) {
-		configMapping
-				.add(new ConfigMapEntry(inputDTD, outputDTD, xsltFunction));
-	}
-
-	public String createLogFileName() {
-		DateFormat formatter = new SimpleDateFormat("MMMdyyyy_Hmmss");
-		Date now = new Date();
-		String nowText = formatter.format(now);
-		return getLogDirectory() + "/nlnz_" + nowText + ".log";
-	}
-
-	public ConfigMapEntry getMapping(String inputDTD, String outputDTD) {
-		Iterator it = configMapping.iterator();
-		while (it.hasNext()) {
-			ConfigMapEntry entry = (ConfigMapEntry) it.next();
-			if (entry.getInputDTD().equals(inputDTD)
-					&& entry.getOutputDTD().equals(outputDTD)) {
-				return entry;
-			}
-		}
-		return null; // no function exists to do this transform...
-	}
-
-	public ConfigMapEntry[] getMappings() {
-		ConfigMapEntry[] maps = new ConfigMapEntry[configMapping.size()];
-		configMapping.toArray(maps);
-		return maps;
-	}
-
-	public void addMapping(ConfigMapEntry mapping) {
-		configMapping.add(mapping);
-	}
-
-	public void removeMapping(ConfigMapEntry mapping) {
-		configMapping.remove(mapping);
-	}
-
-	public void removeConfig(Configuration config) {
-		configs.remove(config);
-	}
-
-	public User[] getUsers() {
-		User[] u = new User[users.size()];
-		users.toArray(u);
-		return u;
-	}
-
-	public void writeNewConfig() throws IOException {
-		// find out where...
-		URL furl = classLoader.getResource("saveconfig.xml");
-		// remove spaces - if any...
-		String configPath = URLDecoder.decode(furl.getPath(), "UTF-8");
-		File configFile = new File(configPath);
-		File backup = new File(configFile.getPath() + ".bak");
-		// backup - if poss
-		boolean backedup = (backup.delete() && configFile.renameTo(backup));
-		if (!backedup) {
-			LogMessage msg = new LogMessage(LogMessage.INFO, configFile,
-					"Config File not backed up",
-					"check file system permissions etc");
-			LogManager.getInstance().logMessage(msg);
-		}
-		try {
-			DocumentBuilderFactory factory = DocumentBuilderFactory
-					.newInstance();
-
-			// Prepare the DOM document for writing
-			Source source = new DOMSource(configDoc);
-
-			// Prepare the output file
-			Result result = new StreamResult(configFile);
-
-			// Write the DOM document to the file
-			Transformer xformer = TransformerFactory.newInstance()
-					.newTransformer();
-			xformer.transform(source, result);
-		} catch (TransformerException ex) {
-			throw new RuntimeException(ex);
-		}
-
-	}
-
-	public void writeConfig() throws IOException {
-
-		// find out where...
-		URL furl = classLoader.getResource("config.xml");
-		try {
-			writeProfiles();
-			writeAdapters();
-			writeUsers();
-			writeMaps();
-			writeConfigurations();
-		} catch (Exception e) {
-			LogManager.getInstance().logMessage(e);
-		}
-		// remove spaces - if any...
-		String configPath = URLDecoder.decode(furl.getPath(), "UTF-8");
-
-		File configFile = new File(configPath);
-		File backup = new File(configFile.getPath() + ".bak");
-		System.out.println(backup);
-
-		// backup - if poss
-		LogMessage msg = new LogMessage(LogMessage.INFO, configFile,
-				"Backing up config: " + configFile.getAbsolutePath(),
-				"Backing up to: " + backup.getAbsolutePath());
-		LogManager.getInstance().logMessage(msg);
-		LogMessage msg2 = new LogMessage(LogMessage.INFO, configFile,
-				"Backup deleted: " + backup.delete(), "");
-		LogManager.getInstance().logMessage(msg2);
-		boolean backedup = FileUtil.copy(configFile.getAbsolutePath(), backup
-				.getAbsolutePath());// fconfigFile.renameTo(backup));
-		if (!backedup) {
-			LogMessage msg3 = new LogMessage(LogMessage.INFO, configFile,
-					"Config File not backed up",
-					"check file system permissions etc");
-			LogManager.getInstance().logMessage(msg3);
-		}
-
-		try {
-			DocumentBuilderFactory factory = DocumentBuilderFactory
-					.newInstance();
-
-			// Prepare the DOM document for writing
-			Source source = new DOMSource(configDoc);
-
-			// Prepare the output file
-			Result result = new StreamResult(configFile.getAbsolutePath());
-
-			// Write the DOM document to the file
-			Transformer xformer = TransformerFactory.newInstance()
-					.newTransformer();
-			System.out.println(source.getSystemId());
-			System.out.println(result.getSystemId());
-			xformer.transform(source, result);
-		} catch (TransformerException ex) {
-			ex.printStackTrace();
-			throw new RuntimeException(ex);
-		}
-	}
-
-	/** The cool stuff that reads the config... * */
-	private void readConfig() {
-		try {
-			DocumentBuilderFactory factory = DocumentBuilderFactory
-					.newInstance();
-			factory.setValidating(false);
-			DocumentBuilder builder = factory.newDocumentBuilder();
-
-			// find the file...
-			InputStream cfgFile = null;
-			try {
-				cfgFile = classLoader.getResourceAsStream("config.xml");
-				configDoc = builder.parse(cfgFile);
-			}
-			catch(Throwable t) { 
-				throw new RuntimeException("Config file not found - make sure it is in the classpath", t);				
-			}
-			finally {
-				cfgFile.close();
-			}
-			//configDoc = builder.parse(configFile);
-
-			// find the <meta-config> tag
-			Node metaConfig = null;
-			for (int i = 0; i < configDoc.getChildNodes().getLength(); i++) {
-				if (ROOT_TAG.equalsIgnoreCase(configDoc.getChildNodes().item(i)
-						.getNodeName())) {
-					metaConfig = configDoc.getChildNodes().item(i);
-				}
-			}
-			if (metaConfig == null) {
-				throw new RuntimeException(
-						"Root element <meta-config> not found in config.xml");
-			}
-
-			NodeList nodes = metaConfig.getChildNodes();
-			boolean app = false, adapters = false, maps = false, configs = false, profiles = false, users = false;
-			for (int i = 0; i < nodes.getLength(); i++) {
-				if (initApplication(nodes.item(i)))
-					app = true;
-				if (initAdapters(nodes.item(i)))
-					adapters = true;
-				if (initMaps(nodes.item(i)))
-					maps = true;
-				if (initConfigs(nodes.item(i)))
-					configs = true;
-				if (initProfiles(nodes.item(i)))
-					profiles = true;
-				if (initUsers(nodes.item(i)))
-					users = true;
-			}
-
-			if (!app) {
-				System.out
-						.println("No application configuration information found in config.xml");
-			}
-			if (!adapters) {
-				System.out.println("No Adapters found in config.xml");
-			}
-			if (!maps) {
-				System.out.println("No Maps found in config.xml");
-			}
-			if (!configs) {
-				System.out
-						.println("No processing configurations found in config.xml");
-			}
-			if (!profiles) {
-				System.out.println("No profiles found in config.xml");
-			}
-			if (!users) {
-				System.out.println("Incorrect users tag in config.xml");
-			}
-		} catch (Throwable ex) {
-			ex.printStackTrace();
-		}
-
-	}
-
-	private boolean initApplication(Node node) {
-		boolean foundInit = false;
-		if (HARVESTER_TAG.equalsIgnoreCase(node.getNodeName())) {
-			NodeList nodes = node.getChildNodes();
-			for (int i = 0; i < nodes.getLength(); i++) {
-				Node appParam = nodes.item(i);
-				if (TITLE_TAG.equalsIgnoreCase(appParam.getNodeName())) {
-					appName = appParam.getAttributes().getNamedItem(NAME_TAG);
-				}
-				if (INPUT_FILES_TAG.equalsIgnoreCase(appParam.getNodeName())) {
-					baseHarvestDir = appParam.getAttributes().getNamedItem(
-							DIR_NAME_TAG);
-				}
-				if (XML_BASE_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
-					baseXMLDir = appParam.getAttributes().getNamedItem(URL_TAG);
-					foundInit = true;
-				}
-				if (JAR_BASE_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
-					baseJarDir = appParam.getAttributes().getNamedItem(URL_TAG);
-					Loader.setJarDir(baseJarDir.getNodeValue());
-				}
-				if (ADMIN_PASSWORD_TAG.equalsIgnoreCase(nodes.item(i)
-						.getNodeName())) {
-					// the value is in the tag - not an attribute...
-					adminPasswordNode = appParam.getFirstChild();
-//					readAdminPassword(appParam.getFirstChild().getNodeValue());
-				}
-				if (LOG_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
-					// the value is in the tag - not an attribute...
-					logDirectory = appParam.getAttributes().getNamedItem(
-							DIR_NAME_TAG);
-				}
-			}
-		}
-		return foundInit;
-	}
-
-//	private void readAdminPassword(String hashedValue) {
-//		// System.out.println(hashedValue);
-//		BlowfishEasy bf = new BlowfishEasy(SEED.toCharArray());
-//		// System.out.println(bf);
-//		adminPassword = bf.decryptString(hashedValue);// .trim();
-//		// System.out.println(adminPassword);
-//	}
-
-	private boolean initAdapters(Node node) throws ClassNotFoundException,
-			IllegalAccessException, InstantiationException {
-		boolean initAdapter = false;
-		if (ADAPTERS_TAG.equalsIgnoreCase(node.getNodeName())) {
-			adaptersNode = node;
-			NodeList nodes = node.getChildNodes();
-			for (int i = 0; i < nodes.getLength(); i++) {
-				if (ADAPTER_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
-					Node adapterNode = nodes.item(i);
-					NamedNodeMap map = adapterNode.getAttributes();
-					String className = map.getNamedItem(CLASS_TAG)
-							.getNodeValue();
-					// String outputDTD =
-					// map.getNamedItem(OUTPUT_DTD_TAG).getNodeValue();
-					// create it and set it up...
-					DataAdapter adapter = null;
-					try {
-						adapter = (DataAdapter) Class.forName(className, true,
-								classLoader)
-								.getDeclaredConstructor()
-								.newInstance();
-						String jarName = map.getNamedItem(JAR_TAG)
-								.getNodeValue();
-						setJarForAdapter(adapter, jarName);
-					} catch (ClassCastException e) {
-						LogManager
-								.getInstance()
-								.logMessage(
-										new LogMessage(
-												LogMessage.ERROR,
-												e,
-												"Adapter class " + className
-														+ " not found",
-												"Invalid adapter entry in config.xml file - check contents using admin tool or filesystem"));
-					} catch (Exception e) {
-						LogManager
-								.getInstance()
-								.logMessage(
-										new LogMessage(
-												LogMessage.ERROR,
-												e,
-												"Adapter class " + className
-														+ " not found",
-												"Invalid adapter entry in config.xml file - check contents using admin tool or filesystem"));
-					}
-
-					// are there any properties for the adapter.
-					NodeList params = adapterNode.getChildNodes();
-					for (int p = 0; p < params.getLength(); p++) {
-						if (PARAMETER_TAG.equalsIgnoreCase(params.item(p)
-								.getNodeName())) {
-							NamedNodeMap paramMap = params.item(p)
-									.getAttributes();
-							String name = paramMap.getNamedItem(NAME_TAG)
-									.getNodeValue();
-							String value = paramMap.getNamedItem(VALUE_TAG)
-									.getNodeValue();
-							try {
-								FXUtil.setProperty(adapter, name, value);
-							} catch (Exception ex) {
-								throw new RuntimeException(
-										"Invalid Adapter parameter");
-							}
-						}
-					}
-
-					// tell the directory about the adapter...
-					if (adapter != null) {
-						AdapterFactory.getInstance().addAdapter(adapter);
-						initAdapter = true;
-					}
-				}
-			}
-		}
-		return initAdapter;
-	}
-
-	private boolean initProfiles(Node node) throws ClassNotFoundException,
-			IllegalAccessException, InstantiationException {
-		boolean initProfiles = false;
-		if (PROFILES_TAG.equalsIgnoreCase(node.getNodeName())) {
-			profileNode = node;
-			profiles = new ArrayList();
-			NamedNodeMap nodeMap = node.getAttributes();
-			String defaultProfileName = nodeMap.getNamedItem(
-					PROFILE_DEFAULT_NAME_TAG).getNodeValue();
-			NodeList nodes = node.getChildNodes();
-			for (int i = 0; i < nodes.getLength(); i++) {
-				if (PROFILE_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
-					Profile prof = new Profile();
-					Node profileNode = nodes.item(i);
-					NamedNodeMap map = profileNode.getAttributes();
-					String profileName = map.getNamedItem(NAME_TAG)
-							.getNodeValue();
-					prof.setName(profileName);
-					if (profileName.equals(defaultProfileName)) {
-						defaultProfile = prof;
-						currentProfile = prof;
-					}
-					NodeList profileNodes = profileNode.getChildNodes();
-					for (int elem = 0; elem < profileNodes.getLength(); elem++) {
-						Node profileElement = profileNodes.item(elem);
-						if (Config.LOG_TAG.equalsIgnoreCase(profileElement
-								.getNodeName())) {
-							prof.setLogDirectory(profileElement.getAttributes()
-									.getNamedItem(DIR_NAME_TAG).getNodeValue());
-						} else if (Config.INPUT_FILES_TAG
-								.equalsIgnoreCase(profileElement.getNodeName())) {
-							prof.setInputDirectory(profileElement
-									.getAttributes().getNamedItem(DIR_NAME_TAG)
-									.getNodeValue());
-						} else if (Config.ADAPTER_TAG
-								.equalsIgnoreCase(profileElement.getNodeName())) {
-							NamedNodeMap adapterMap = profileElement
-									.getAttributes();
-							String adapterClass = adapterMap.getNamedItem(
-									CLASS_TAG).getNodeValue();
-							prof.setAdapter(adapterClass, true);
-						}
-					}
-					profiles.add(prof);
-					initProfiles = true;
-				}
-			}
-		}
-		return initProfiles;
-	}
-
-	public void removeUser(User user) {
-		users.remove(user);
-		fireUserEvent(USER_REMOVED, user);
-	}
-
-	public User addUser(User user) {
-		users.add(user);
-		fireUserEvent(USER_ADDED, user);
-		return user;
-	}
-
-	public void addProfile(Profile p) {
-		if (!profiles.contains(p)) {
-			profiles.add(p);
-			fireProfileEvent(PROFILE_ADDED, p);
-		}
-	}
-
-	public boolean removeProfile(Profile p) {
-		if (profiles.size() > 1) {
-			if (profiles.contains(p)) {
-				profiles.remove(p);
-				if (p.equals(defaultProfile)) {
-					defaultProfile = (Profile) profiles.get(0);
-				}
-				if (p.equals(currentProfile)) {
-					currentProfile = (Profile) profiles.get(0);
-				}
-				fireProfileEvent(PROFILE_REMOVED, p);
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private void fireUserEvent(int type, User user) {
-		Iterator it = userListeners.iterator();
-		while (it.hasNext()) {
-			UserListener ul = (UserListener) it.next();
-			switch (type) {
-			case USER_ADDED:
-				ul.userAdded(user);
-				break;
-			case USER_REMOVED:
-				ul.userRemoved(user);
-				break;
-			}
-		}
-	}
-
-	private void fireProfileEvent(int type, Profile p) {
-		Iterator it = profileListeners.iterator();
-		while (it.hasNext()) {
-			ProfileListener pl = (ProfileListener) it.next();
-			switch (type) {
-			case PROFILE_ADDED:
-				pl.profileAdded(p);
-				break;
-			case PROFILE_REMOVED:
-				pl.profileRemoved(p);
-				break;
-			case PROFILE_CHANGED:
-				pl.profileChanged(p);
-				break;
-			}
-		}
-	}
-
-	private boolean initUsers(Node node) throws ClassNotFoundException,
-			IllegalAccessException, InstantiationException {
-		boolean result = false;
-		if (USERS_TAG.equalsIgnoreCase(node.getNodeName())) {
-			String defaultUserName = node.getAttributes().getNamedItem(
-					USER_DEFAULT_NAME_TAG).getNodeValue();
-			if (defaultUserName != null) {
-				result = true;
-			}
-			NodeList nodes = node.getChildNodes();
-			usersNode = node;
-			for (int i = 0; i < nodes.getLength(); i++) {
-				Node appParam = nodes.item(i);
-				if (USER_TAG.equalsIgnoreCase(appParam.getNodeName())) {
-					Node name = appParam.getAttributes().getNamedItem(
-							USER_NAME_TAG);
-					User u = new User(name.getNodeValue());
-					users.add(u);
-					if (u.getName().equals(defaultUserName)) {
-						defaultUser = u;
-					}
-				}
-			}
-		}
-		return result;
-	}
-
-	private boolean initMaps(Node node) throws ClassNotFoundException,
-			IllegalAccessException, InstantiationException {
-		boolean initMaps = false;
-		if (MAPS_TAG.equalsIgnoreCase(node.getNodeName())) {
-			mapNode = node;
-			NodeList nodes = node.getChildNodes();
-			for (int i = 0; i < nodes.getLength(); i++) {
-				if (MAP_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
-					Node mapNode = nodes.item(i);
-					NodeList map = mapNode.getChildNodes();
-					String inDTD = null;
-					String outDTD = null;
-					String xsltDoc = null;
-					for (int elem = 0; elem < map.getLength(); elem++) {
-						Node mapElement = map.item(elem);
-						if (INPUT_DTD_TAG.equalsIgnoreCase(mapElement
-								.getNodeName())) {
-							inDTD = mapElement.getAttributes().getNamedItem(
-									DOC_NAME_TAG).getNodeValue();
-						}
-						if (OUTPUT_DTD_TAG.equalsIgnoreCase(mapElement
-								.getNodeName())) {
-							outDTD = mapElement.getAttributes().getNamedItem(
-									DOC_NAME_TAG).getNodeValue();
-						}
-						if (XSLT_TAG.equalsIgnoreCase(mapElement.getNodeName())) {
-							xsltDoc = mapElement.getAttributes().getNamedItem(
-									DOC_NAME_TAG).getNodeValue();
-						}
-					}
-
-					// set up the mappings...
-					addMapping(inDTD, outDTD, xsltDoc);
-					initMaps = true;
-				}
-			}
-		}
-		return initMaps;
-	}
-
-	private boolean initConfigs(Node node) throws ClassNotFoundException,
-			IllegalAccessException, InstantiationException {
-		boolean initConfigs = false;
-		if (CONFIGURATIONS_TAG.equalsIgnoreCase(node.getNodeName())) {
-			NodeList nodes = node.getChildNodes();
-			for (int i = 0; i < nodes.getLength(); i++) {
-				if (CONFIGURATION_TAG.equalsIgnoreCase(nodes.item(i)
-						.getNodeName())) {
-					configNode = node;
-					Node mapNode = nodes.item(i);
-					NodeList map = mapNode.getChildNodes();
-					String name = mapNode.getAttributes()
-							.getNamedItem(NAME_TAG).getNodeValue();
-					String outputDir = null;
-					String outputDTD = null;
-					String className = null;
-					for (int elem = 0; elem < map.getLength(); elem++) {
-						Node mapElement = map.item(elem);
-						if (OUTPUT_DIRECTORY_TAG.equalsIgnoreCase(mapElement
-								.getNodeName())) {
-							outputDir = mapElement.getAttributes()
-									.getNamedItem(DIR_NAME_TAG).getNodeValue();
-						}
-						if (OUTPUT_DTD_TAG.equalsIgnoreCase(mapElement
-								.getNodeName())) {
-							// optional...
-							outputDTD = mapElement.getAttributes()
-									.getNamedItem(DOC_NAME_TAG).getNodeValue();
-						}
-						if (HARVESTER_TAG.equalsIgnoreCase(mapElement
-								.getNodeName())) {
-							// optional...
-							className = mapElement.getAttributes()
-									.getNamedItem(CLASS_TAG).getNodeValue();
-						}
-					}
-
-					// set up the mappings...
-					Configuration config = new Configuration(name, className,
-							outputDir, outputDTD);
-					addConfig(config);
-					initConfigs = true;
-				}
-			}
-		}
-		return initConfigs;
-	}
-
-	private boolean writeUsers() {
-		while (usersNode.hasChildNodes()) {
-			usersNode.removeChild(usersNode.getFirstChild());
-		}
-		Element userEl = (Element) usersNode;
-		userEl.setAttribute("default", getDefaultUser().getName());
-		Iterator it = users.iterator();
-		while (it.hasNext()) {
-			User user = (User) it.next();
-			Element userNode = configDoc.createElement("user");
-			userNode.setAttribute("name", user.getName());
-			usersNode.appendChild(userNode);
-		}
-		return true;
-	}
-
-	private boolean writeProfiles() {
-		while (profileNode.hasChildNodes()) {
-			profileNode.removeChild(profileNode.getFirstChild());
-		}
-		Iterator it = profiles.iterator();
-		while (it.hasNext()) {
-			Profile prof = (Profile) it.next();
-			Element profNode = configDoc.createElement("profile");
-			profNode.setAttribute("name", prof.getName());
-			Element inpDirNode = configDoc.createElement(INPUT_FILES_TAG);
-			inpDirNode.setAttribute(DIR_NAME_TAG, prof.getInputDirectory());
-			Element logDirNode = configDoc.createElement(LOG_TAG);
-			logDirNode.setAttribute(DIR_NAME_TAG, prof.getLogDirectory());
-			profNode.appendChild(inpDirNode);
-			profNode.appendChild(logDirNode);
-			Iterator ad = prof.getAdapterClasses();
-			while (ad.hasNext()) {
-				String adClass = (String) ad.next();
-				Element adapNode = configDoc.createElement(ADAPTER_TAG);
-				adapNode.setAttribute(CLASS_TAG, adClass);
-				profNode.appendChild(adapNode);
-			}
-			profileNode.appendChild(profNode);
-		}
-		return true;
-	}
-
-	private boolean writeMaps() {
-		while (mapNode.hasChildNodes()) {
-			mapNode.removeChild(mapNode.getFirstChild());
-		}
-		Iterator it = this.configMapping.iterator();
-		while (it.hasNext()) {
-			ConfigMapEntry map = (ConfigMapEntry) it.next();
-			Element mapSubNode = configDoc.createElement("map");
-			Element inpDTDNode = configDoc.createElement(INPUT_DTD_TAG);
-			inpDTDNode.setAttribute(DOC_NAME_TAG, map.getInputDTD());
-			Element outDTDNode = configDoc.createElement(OUTPUT_DTD_TAG);
-			outDTDNode.setAttribute(DOC_NAME_TAG, map.getOutputDTD());
-			Element mapXSLTNode = configDoc.createElement(XSLT_TAG);
-			mapXSLTNode.setAttribute(DOC_NAME_TAG, map.getXsltFunction());
-			mapSubNode.appendChild(inpDTDNode);
-			mapSubNode.appendChild(outDTDNode);
-			mapSubNode.appendChild(mapXSLTNode);
-			mapNode.appendChild(mapSubNode);
-		}
-		return true;
-	}
-
-	private boolean writeAdapters() {
-		while (adaptersNode.hasChildNodes()) {
-			adaptersNode.removeChild(adaptersNode.getFirstChild());
-		}
-		DataAdapter[] ads = AdapterFactory.getInstance().getAdapters();
-		for (int i = 0; i < ads.length; i++) {
-			Element adSubNode = configDoc.createElement(ADAPTER_TAG);
-			adSubNode.setAttribute(CLASS_TAG, ads[i].getClass().getName());
-			String ot = ads[i].getOutputType();
-			if ((ot != null) && (ot.length() > 0)) {
-				adSubNode.setAttribute(OUTPUT_DTD_TAG, ads[i].getOutputType());
-			}
-			String jar = getJarForAdapter(ads[i]);
-			if ((jar != null) && (jar.length() > 0)) {
-				adSubNode.setAttribute(JAR_TAG, getJarForAdapter(ads[i]));
-			}
-			Element adParamNode = configDoc.createElement(PARAMETER_TAG);
-			// FXUtil.get
-			// ads[i].
-			// adParamNode.
-			adaptersNode.appendChild(adSubNode);
-		}
-		return true;
-	}
-
-	private boolean writeConfigurations() {
-		while (configNode.hasChildNodes()) {
-			configNode.removeChild(configNode.getFirstChild());
-		}
-		Iterator it = this.configs.iterator();
-		while (it.hasNext()) {
-			Configuration config = (Configuration) it.next();
-			Element configSubNode = configDoc.createElement("configuration");
-			configSubNode.setAttribute(NAME_TAG, config.getName());
-			Element outputDirNode = configDoc
-					.createElement(OUTPUT_DIRECTORY_TAG);
-			outputDirNode.setAttribute(DIR_NAME_TAG, config
-					.getOutputDirectory());
-			configSubNode.appendChild(outputDirNode);
-			Element harvesterNode = configDoc.createElement(HARVESTER_TAG);
-			harvesterNode.setAttribute(CLASS_TAG, config.getClassName());
-			configSubNode.appendChild(harvesterNode);
-			configNode.appendChild(configSubNode);
-		}
-		return true;
-	}
-
-	public void addUserListener(UserListener ul) {
-		userListeners.add(ul);
-	}
-
-	public void removeUserListener(UserListener ul) {
-		userListeners.remove(ul);
-	}
-
-	public void addProfileListener(ProfileListener pl) {
-		profileListeners.add(pl);
-	}
-
-	public void removeProfileListener(ProfileListener pl) {
-		profileListeners.remove(pl);
-	}
+    private Node baseXMLDir;
 
+    private Node baseJarDir;
+
+    private Node appName;
+
+    private Node adaptersNode;
+
+    private Node adminPasswordNode;
+
+    private static final String copyright = '\u00A9' + " National Library of New Zealand";
+
+    private Node baseHarvestDir;
+
+    private Node logDirectory;
+
+    private Node mapNode;
+
+    private Node profileNode;
+
+    private Node configNode;
+
+    private Document configDoc;
+
+    private User defaultUser;
+
+    private ArrayList configs = new ArrayList();
+
+    private HashMap adapterJarLocations = new HashMap();
+
+    private HashSet userListeners = new HashSet();
+
+    private HashSet profileListeners = new HashSet();
+
+    private String adminPassword;
+
+    private Config() {
+        configMapping = new ArrayList();
+        users = new ArrayList();
+        readConfig();
+    }
+
+    public void setJarForAdapter(DataAdapter adapter, String jar) {
+        adapterJarLocations.put(adapter.getClass(), jar);
+    }
+
+    public String getJarForAdapter(DataAdapter adapter) {
+        return (String) adapterJarLocations.get(adapter.getClass());
+    }
+
+    private Config(Config original) {
+        configMapping = (ArrayList) original.configMapping.clone();
+        users = (ArrayList) original.users.clone();
+        profiles = new ArrayList();
+        currentProfile = original.currentProfile;
+        defaultProfile = original.defaultProfile;
+        defaultUser = original.defaultUser;
+        Iterator it = original.profiles.iterator();
+        while (it.hasNext()) {
+            Profile origP = (Profile) it.next();
+            Profile p = new Profile();
+            p.setName(origP.getName());
+            p.setInputDirectory(origP.getInputDirectory());
+            p.setLogDirectory(origP.getLogDirectory());
+            Iterator ads = origP.getAdapterClasses();
+            while (ads.hasNext()) {
+                p.setAdapter((String) ads.next(), true);
+            }
+            baseXMLDir = original.baseXMLDir;
+            baseJarDir = original.baseJarDir;
+            profiles.add(p);
+            if (original.currentProfile.getName().equals(p.getName())) {
+                currentProfile = p;
+            }
+            if (original.defaultProfile.getName().equals(p.getName())) {
+                defaultProfile = p;
+            }
+        }
+        configs = (ArrayList) original.configs.clone();
+        adapterJarLocations = (HashMap) original.adapterJarLocations.clone();
+    }
+
+    public static synchronized void saveAdapterEdit() {
+        instance.adapterJarLocations = editInstance.adapterJarLocations;
+        instance.configMapping = editInstance.configMapping;
+    }
+
+    public static synchronized void saveEdit() {
+        instance.configMapping = editInstance.configMapping;
+        instance.users = editInstance.users;
+        instance.profiles = editInstance.profiles;
+        instance.defaultProfile = editInstance.defaultProfile;
+        instance.defaultUser = editInstance.defaultUser;
+        Profile old = instance.currentProfile;
+        instance.currentProfile = editInstance.currentProfile;
+        if (!old.equals(instance.currentProfile)) {
+            instance.fireProfileEvent(PROFILE_CHANGED, old);
+        }
+        instance.configs = editInstance.configs;
+        instance.adapterJarLocations = editInstance.adapterJarLocations;
+    }
+
+    public static synchronized Config getInstance() {
+        if (classLoader == null) {
+            // If no class loader set use default -- the system class loader.
+            Config.classLoader = ClassLoader.getSystemClassLoader();
+        }
+        if (instance == null) {
+            instance = new Config();
+        }
+        return instance;
+    }
+
+    /**
+     * Allow for the configuration of a ClassLoader other than the
+     * default system class loader for loading the Adapter classes
+     * registered in config.xml.
+     *
+     * @param cl - An alternative, custom class loader.
+     * @see #initAdapters(Node)
+     */
+    public static synchronized void setClassLoader(final ClassLoader cl) {
+        if (cl != null) {
+            Config.classLoader = cl;
+        }
+    }
+
+    public static synchronized Config getEditInstance(boolean renew) {
+        if ((editInstance == null) || renew) {
+            editInstance = new Config(Config.getInstance());
+        }
+        return editInstance;
+    }
+
+    public static synchronized Config getEditInstance() {
+        return getEditInstance(false);
+    }
+
+    public ArrayList getAvailableConfigs() {
+        return configs;
+    }
+
+    /**
+     * Get the configuration with a given name.
+     * @param name The name of the configuration to retrieve.
+     * @return The Configuration object.
+     */
+    public Configuration getConfiguration(String name) throws ConfigurationException {
+        Iterator it = configs.iterator();
+        while (it.hasNext()) {
+            Configuration c = (Configuration) it.next();
+            if (c.getName().equalsIgnoreCase(name)) {
+                return c;
+            }
+        }
+
+        // We haven't found the configuration, return null.
+        throw new ConfigurationException("Could not find a configuration with the name " + name);
+    }
+
+    public ArrayList getAvailableProfiles() {
+        return profiles;
+    }
+
+    public Profile getDefaultProfile() {
+        return defaultProfile;
+    }
+
+    //	public void setAdminPassword(String oldPassword, String password) {
+    //		if (oldPassword.equals(adminPassword)) {
+    //			adminPassword = password;
+    //			BlowfishEasy bfish = new BlowfishEasy(SEED.toCharArray());
+    //			adminPasswordNode.setNodeValue(bfish.encryptString(password));
+    //		}
+    //	}
+
+    public boolean checkAdminPassword(String pass) {
+        if (pass != null) {
+            return pass.equals(adminPassword);
+        }
+        return false;
+    }
+
+    public Profile getCurrentProfile() {
+        return currentProfile;
+    }
+
+    public void setCurrentProfile(Profile current) {
+        currentProfile = current;
+    }
+
+    public void addConfig(Configuration config) {
+        configs.add(config);
+    }
+
+    public User getDefaultUser() {
+        return defaultUser;
+    }
+
+    public void setDefaultUser(User user) {
+        this.defaultUser = user;
+    }
+
+    public String getBaseHarvestDir() {
+        return getCurrentProfile().getInputDirectory();
+    }
+
+    public void setBaseHarvestDir(String baseHarvestDir) {
+        getCurrentProfile().setInputDirectory(baseHarvestDir);
+    }
+
+    public String getXMLBaseURL() {
+        String st = baseXMLDir.getNodeValue();
+        try {
+            File f = new File(st);
+            return f.getAbsolutePath();
+        } catch (Exception ex) {
+            LogManager.getInstance().logMessage(ex);
+        }
+        return st;
+    }
+
+    public String getJarBaseURL() {
+        String st = baseJarDir.getNodeValue();
+        try {
+            File f = new File(st);
+            return f.getAbsolutePath();
+        } catch (Exception ex) {
+            LogManager.getInstance().logMessage(ex);
+        }
+        return st;
+    }
+
+    public void setXMLBaseURL(String url) {
+        baseXMLDir.setNodeValue(url);
+    }
+
+    public void setJarBaseURL(String url) {
+        baseJarDir.setNodeValue(url);
+    }
+
+    public String getApplicationName() {
+        return appName.getNodeValue();
+    }
+
+    public void setApplicationName(String name) {
+        appName.setNodeValue(name);
+    }
+
+    public String getCopyright() {
+        return copyright;
+    }
+
+    public void setLogDirectory(String logDirectory) {
+        instance.getCurrentProfile().setLogDirectory(logDirectory);
+    }
+
+    public String getLogDirectory() {
+        return instance.getCurrentProfile().getLogDirectory();
+    }
+
+    public void addMapping(String inputDTD, String outputDTD, String xsltFunction) {
+        configMapping.add(new ConfigMapEntry(inputDTD, outputDTD, xsltFunction));
+    }
+
+    public String createLogFileName() {
+        DateFormat formatter = new SimpleDateFormat("MMMdyyyy_Hmmss");
+        Date now = new Date();
+        String nowText = formatter.format(now);
+        return getLogDirectory() + "/nlnz_" + nowText + ".log";
+    }
+
+    public ConfigMapEntry getMapping(String inputDTD, String outputDTD) {
+        Iterator it = configMapping.iterator();
+        while (it.hasNext()) {
+            ConfigMapEntry entry = (ConfigMapEntry) it.next();
+            if (entry.getInputDTD().equals(inputDTD) && entry.getOutputDTD().equals(outputDTD)) {
+                return entry;
+            }
+        }
+        return null; // no function exists to do this transform...
+    }
+
+    public ConfigMapEntry[] getMappings() {
+        ConfigMapEntry[] maps = new ConfigMapEntry[configMapping.size()];
+        configMapping.toArray(maps);
+        return maps;
+    }
+
+    public void addMapping(ConfigMapEntry mapping) {
+        configMapping.add(mapping);
+    }
+
+    public void removeMapping(ConfigMapEntry mapping) {
+        configMapping.remove(mapping);
+    }
+
+    public void removeConfig(Configuration config) {
+        configs.remove(config);
+    }
+
+    public User[] getUsers() {
+        User[] u = new User[users.size()];
+        users.toArray(u);
+        return u;
+    }
+
+    public void writeNewConfig() throws IOException {
+        // find out where...
+        URL furl = classLoader.getResource("saveconfig.xml");
+        // remove spaces - if any...
+        String configPath = URLDecoder.decode(furl.getPath(), "UTF-8");
+        File configFile = new File(configPath);
+        File backup = new File(configFile.getPath() + ".bak");
+        // backup - if poss
+        boolean backedup = (backup.delete() && configFile.renameTo(backup));
+        if (!backedup) {
+            LogMessage msg = new LogMessage(
+                    LogMessage.INFO, configFile, "Config File not backed up", "check file system permissions etc");
+            LogManager.getInstance().logMessage(msg);
+        }
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+            // Prepare the DOM document for writing
+            Source source = new DOMSource(configDoc);
+
+            // Prepare the output file
+            Result result = new StreamResult(configFile);
+
+            // Write the DOM document to the file
+            Transformer xformer = TransformerFactory.newInstance().newTransformer();
+            xformer.transform(source, result);
+        } catch (TransformerException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public void writeConfig() throws IOException {
+
+        // find out where...
+        URL furl = classLoader.getResource("config.xml");
+        try {
+            writeProfiles();
+            writeAdapters();
+            writeUsers();
+            writeMaps();
+            writeConfigurations();
+        } catch (Exception e) {
+            LogManager.getInstance().logMessage(e);
+        }
+        // remove spaces - if any...
+        String configPath = URLDecoder.decode(furl.getPath(), "UTF-8");
+
+        File configFile = new File(configPath);
+        File backup = new File(configFile.getPath() + ".bak");
+        System.out.println(backup);
+
+        // backup - if poss
+        LogMessage msg = new LogMessage(
+                LogMessage.INFO,
+                configFile,
+                "Backing up config: " + configFile.getAbsolutePath(),
+                "Backing up to: " + backup.getAbsolutePath());
+        LogManager.getInstance().logMessage(msg);
+        LogMessage msg2 = new LogMessage(LogMessage.INFO, configFile, "Backup deleted: " + backup.delete(), "");
+        LogManager.getInstance().logMessage(msg2);
+        boolean backedup =
+                FileUtil.copy(configFile.getAbsolutePath(), backup.getAbsolutePath()); // fconfigFile.renameTo(backup));
+        if (!backedup) {
+            LogMessage msg3 = new LogMessage(
+                    LogMessage.INFO, configFile, "Config File not backed up", "check file system permissions etc");
+            LogManager.getInstance().logMessage(msg3);
+        }
+
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+            // Prepare the DOM document for writing
+            Source source = new DOMSource(configDoc);
+
+            // Prepare the output file
+            Result result = new StreamResult(configFile.getAbsolutePath());
+
+            // Write the DOM document to the file
+            Transformer xformer = TransformerFactory.newInstance().newTransformer();
+            System.out.println(source.getSystemId());
+            System.out.println(result.getSystemId());
+            xformer.transform(source, result);
+        } catch (TransformerException ex) {
+            ex.printStackTrace();
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /** The cool stuff that reads the config... * */
+    private void readConfig() {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setValidating(false);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+
+            // find the file...
+            InputStream cfgFile = null;
+            try {
+                cfgFile = classLoader.getResourceAsStream("config.xml");
+                configDoc = builder.parse(cfgFile);
+            } catch (Throwable t) {
+                throw new RuntimeException("Config file not found - make sure it is in the classpath", t);
+            } finally {
+                cfgFile.close();
+            }
+            // configDoc = builder.parse(configFile);
+
+            // find the <meta-config> tag
+            Node metaConfig = null;
+            for (int i = 0; i < configDoc.getChildNodes().getLength(); i++) {
+                if (ROOT_TAG.equalsIgnoreCase(configDoc.getChildNodes().item(i).getNodeName())) {
+                    metaConfig = configDoc.getChildNodes().item(i);
+                }
+            }
+            if (metaConfig == null) {
+                throw new RuntimeException("Root element <meta-config> not found in config.xml");
+            }
+
+            NodeList nodes = metaConfig.getChildNodes();
+            boolean app = false, adapters = false, maps = false, configs = false, profiles = false, users = false;
+            for (int i = 0; i < nodes.getLength(); i++) {
+                if (initApplication(nodes.item(i))) app = true;
+                if (initAdapters(nodes.item(i))) adapters = true;
+                if (initMaps(nodes.item(i))) maps = true;
+                if (initConfigs(nodes.item(i))) configs = true;
+                if (initProfiles(nodes.item(i))) profiles = true;
+                if (initUsers(nodes.item(i))) users = true;
+            }
+
+            if (!app) {
+                System.out.println("No application configuration information found in config.xml");
+            }
+            if (!adapters) {
+                System.out.println("No Adapters found in config.xml");
+            }
+            if (!maps) {
+                System.out.println("No Maps found in config.xml");
+            }
+            if (!configs) {
+                System.out.println("No processing configurations found in config.xml");
+            }
+            if (!profiles) {
+                System.out.println("No profiles found in config.xml");
+            }
+            if (!users) {
+                System.out.println("Incorrect users tag in config.xml");
+            }
+        } catch (Throwable ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    private boolean initApplication(Node node) {
+        boolean foundInit = false;
+        if (HARVESTER_TAG.equalsIgnoreCase(node.getNodeName())) {
+            NodeList nodes = node.getChildNodes();
+            for (int i = 0; i < nodes.getLength(); i++) {
+                Node appParam = nodes.item(i);
+                if (TITLE_TAG.equalsIgnoreCase(appParam.getNodeName())) {
+                    appName = appParam.getAttributes().getNamedItem(NAME_TAG);
+                }
+                if (INPUT_FILES_TAG.equalsIgnoreCase(appParam.getNodeName())) {
+                    baseHarvestDir = appParam.getAttributes().getNamedItem(DIR_NAME_TAG);
+                }
+                if (XML_BASE_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
+                    baseXMLDir = appParam.getAttributes().getNamedItem(URL_TAG);
+                    foundInit = true;
+                }
+                if (JAR_BASE_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
+                    baseJarDir = appParam.getAttributes().getNamedItem(URL_TAG);
+                    Loader.setJarDir(baseJarDir.getNodeValue());
+                }
+                if (ADMIN_PASSWORD_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
+                    // the value is in the tag - not an attribute...
+                    adminPasswordNode = appParam.getFirstChild();
+                    //					readAdminPassword(appParam.getFirstChild().getNodeValue());
+                }
+                if (LOG_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
+                    // the value is in the tag - not an attribute...
+                    logDirectory = appParam.getAttributes().getNamedItem(DIR_NAME_TAG);
+                }
+            }
+        }
+        return foundInit;
+    }
+
+    //	private void readAdminPassword(String hashedValue) {
+    //		// System.out.println(hashedValue);
+    //		BlowfishEasy bf = new BlowfishEasy(SEED.toCharArray());
+    //		// System.out.println(bf);
+    //		adminPassword = bf.decryptString(hashedValue);// .trim();
+    //		// System.out.println(adminPassword);
+    //	}
+
+    private boolean initAdapters(Node node)
+            throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+        boolean initAdapter = false;
+        if (ADAPTERS_TAG.equalsIgnoreCase(node.getNodeName())) {
+            adaptersNode = node;
+            NodeList nodes = node.getChildNodes();
+            for (int i = 0; i < nodes.getLength(); i++) {
+                if (ADAPTER_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
+                    Node adapterNode = nodes.item(i);
+                    NamedNodeMap map = adapterNode.getAttributes();
+                    String className = map.getNamedItem(CLASS_TAG).getNodeValue();
+                    // String outputDTD =
+                    // map.getNamedItem(OUTPUT_DTD_TAG).getNodeValue();
+                    // create it and set it up...
+                    DataAdapter adapter = null;
+                    try {
+                        adapter = (DataAdapter) Class.forName(className, true, classLoader)
+                                .getDeclaredConstructor()
+                                .newInstance();
+                        String jarName = map.getNamedItem(JAR_TAG).getNodeValue();
+                        setJarForAdapter(adapter, jarName);
+                    } catch (ClassCastException e) {
+                        LogManager.getInstance()
+                                .logMessage(
+                                        new LogMessage(
+                                                LogMessage.ERROR,
+                                                e,
+                                                "Adapter class " + className + " not found",
+                                                "Invalid adapter entry in config.xml file - check contents using admin tool or filesystem"));
+                    } catch (Exception e) {
+                        LogManager.getInstance()
+                                .logMessage(
+                                        new LogMessage(
+                                                LogMessage.ERROR,
+                                                e,
+                                                "Adapter class " + className + " not found",
+                                                "Invalid adapter entry in config.xml file - check contents using admin tool or filesystem"));
+                    }
+
+                    // are there any properties for the adapter.
+                    NodeList params = adapterNode.getChildNodes();
+                    for (int p = 0; p < params.getLength(); p++) {
+                        if (PARAMETER_TAG.equalsIgnoreCase(params.item(p).getNodeName())) {
+                            NamedNodeMap paramMap = params.item(p).getAttributes();
+                            String name = paramMap.getNamedItem(NAME_TAG).getNodeValue();
+                            String value = paramMap.getNamedItem(VALUE_TAG).getNodeValue();
+                            try {
+                                FXUtil.setProperty(adapter, name, value);
+                            } catch (Exception ex) {
+                                throw new RuntimeException("Invalid Adapter parameter");
+                            }
+                        }
+                    }
+
+                    // tell the directory about the adapter...
+                    if (adapter != null) {
+                        AdapterFactory.getInstance().addAdapter(adapter);
+                        initAdapter = true;
+                    }
+                }
+            }
+        }
+        return initAdapter;
+    }
+
+    private boolean initProfiles(Node node)
+            throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+        boolean initProfiles = false;
+        if (PROFILES_TAG.equalsIgnoreCase(node.getNodeName())) {
+            profileNode = node;
+            profiles = new ArrayList();
+            NamedNodeMap nodeMap = node.getAttributes();
+            String defaultProfileName =
+                    nodeMap.getNamedItem(PROFILE_DEFAULT_NAME_TAG).getNodeValue();
+            NodeList nodes = node.getChildNodes();
+            for (int i = 0; i < nodes.getLength(); i++) {
+                if (PROFILE_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
+                    Profile prof = new Profile();
+                    Node profileNode = nodes.item(i);
+                    NamedNodeMap map = profileNode.getAttributes();
+                    String profileName = map.getNamedItem(NAME_TAG).getNodeValue();
+                    prof.setName(profileName);
+                    if (profileName.equals(defaultProfileName)) {
+                        defaultProfile = prof;
+                        currentProfile = prof;
+                    }
+                    NodeList profileNodes = profileNode.getChildNodes();
+                    for (int elem = 0; elem < profileNodes.getLength(); elem++) {
+                        Node profileElement = profileNodes.item(elem);
+                        if (Config.LOG_TAG.equalsIgnoreCase(profileElement.getNodeName())) {
+                            prof.setLogDirectory(profileElement
+                                    .getAttributes()
+                                    .getNamedItem(DIR_NAME_TAG)
+                                    .getNodeValue());
+                        } else if (Config.INPUT_FILES_TAG.equalsIgnoreCase(profileElement.getNodeName())) {
+                            prof.setInputDirectory(profileElement
+                                    .getAttributes()
+                                    .getNamedItem(DIR_NAME_TAG)
+                                    .getNodeValue());
+                        } else if (Config.ADAPTER_TAG.equalsIgnoreCase(profileElement.getNodeName())) {
+                            NamedNodeMap adapterMap = profileElement.getAttributes();
+                            String adapterClass =
+                                    adapterMap.getNamedItem(CLASS_TAG).getNodeValue();
+                            prof.setAdapter(adapterClass, true);
+                        }
+                    }
+                    profiles.add(prof);
+                    initProfiles = true;
+                }
+            }
+        }
+        return initProfiles;
+    }
+
+    public void removeUser(User user) {
+        users.remove(user);
+        fireUserEvent(USER_REMOVED, user);
+    }
+
+    public User addUser(User user) {
+        users.add(user);
+        fireUserEvent(USER_ADDED, user);
+        return user;
+    }
+
+    public void addProfile(Profile p) {
+        if (!profiles.contains(p)) {
+            profiles.add(p);
+            fireProfileEvent(PROFILE_ADDED, p);
+        }
+    }
+
+    public boolean removeProfile(Profile p) {
+        if (profiles.size() > 1) {
+            if (profiles.contains(p)) {
+                profiles.remove(p);
+                if (p.equals(defaultProfile)) {
+                    defaultProfile = (Profile) profiles.get(0);
+                }
+                if (p.equals(currentProfile)) {
+                    currentProfile = (Profile) profiles.get(0);
+                }
+                fireProfileEvent(PROFILE_REMOVED, p);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void fireUserEvent(int type, User user) {
+        Iterator it = userListeners.iterator();
+        while (it.hasNext()) {
+            UserListener ul = (UserListener) it.next();
+            switch (type) {
+                case USER_ADDED:
+                    ul.userAdded(user);
+                    break;
+                case USER_REMOVED:
+                    ul.userRemoved(user);
+                    break;
+            }
+        }
+    }
+
+    private void fireProfileEvent(int type, Profile p) {
+        Iterator it = profileListeners.iterator();
+        while (it.hasNext()) {
+            ProfileListener pl = (ProfileListener) it.next();
+            switch (type) {
+                case PROFILE_ADDED:
+                    pl.profileAdded(p);
+                    break;
+                case PROFILE_REMOVED:
+                    pl.profileRemoved(p);
+                    break;
+                case PROFILE_CHANGED:
+                    pl.profileChanged(p);
+                    break;
+            }
+        }
+    }
+
+    private boolean initUsers(Node node) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+        boolean result = false;
+        if (USERS_TAG.equalsIgnoreCase(node.getNodeName())) {
+            String defaultUserName =
+                    node.getAttributes().getNamedItem(USER_DEFAULT_NAME_TAG).getNodeValue();
+            if (defaultUserName != null) {
+                result = true;
+            }
+            NodeList nodes = node.getChildNodes();
+            usersNode = node;
+            for (int i = 0; i < nodes.getLength(); i++) {
+                Node appParam = nodes.item(i);
+                if (USER_TAG.equalsIgnoreCase(appParam.getNodeName())) {
+                    Node name = appParam.getAttributes().getNamedItem(USER_NAME_TAG);
+                    User u = new User(name.getNodeValue());
+                    users.add(u);
+                    if (u.getName().equals(defaultUserName)) {
+                        defaultUser = u;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    private boolean initMaps(Node node) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+        boolean initMaps = false;
+        if (MAPS_TAG.equalsIgnoreCase(node.getNodeName())) {
+            mapNode = node;
+            NodeList nodes = node.getChildNodes();
+            for (int i = 0; i < nodes.getLength(); i++) {
+                if (MAP_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
+                    Node mapNode = nodes.item(i);
+                    NodeList map = mapNode.getChildNodes();
+                    String inDTD = null;
+                    String outDTD = null;
+                    String xsltDoc = null;
+                    for (int elem = 0; elem < map.getLength(); elem++) {
+                        Node mapElement = map.item(elem);
+                        if (INPUT_DTD_TAG.equalsIgnoreCase(mapElement.getNodeName())) {
+                            inDTD = mapElement
+                                    .getAttributes()
+                                    .getNamedItem(DOC_NAME_TAG)
+                                    .getNodeValue();
+                        }
+                        if (OUTPUT_DTD_TAG.equalsIgnoreCase(mapElement.getNodeName())) {
+                            outDTD = mapElement
+                                    .getAttributes()
+                                    .getNamedItem(DOC_NAME_TAG)
+                                    .getNodeValue();
+                        }
+                        if (XSLT_TAG.equalsIgnoreCase(mapElement.getNodeName())) {
+                            xsltDoc = mapElement
+                                    .getAttributes()
+                                    .getNamedItem(DOC_NAME_TAG)
+                                    .getNodeValue();
+                        }
+                    }
+
+                    // set up the mappings...
+                    addMapping(inDTD, outDTD, xsltDoc);
+                    initMaps = true;
+                }
+            }
+        }
+        return initMaps;
+    }
+
+    private boolean initConfigs(Node node)
+            throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+        boolean initConfigs = false;
+        if (CONFIGURATIONS_TAG.equalsIgnoreCase(node.getNodeName())) {
+            NodeList nodes = node.getChildNodes();
+            for (int i = 0; i < nodes.getLength(); i++) {
+                if (CONFIGURATION_TAG.equalsIgnoreCase(nodes.item(i).getNodeName())) {
+                    configNode = node;
+                    Node mapNode = nodes.item(i);
+                    NodeList map = mapNode.getChildNodes();
+                    String name = mapNode.getAttributes().getNamedItem(NAME_TAG).getNodeValue();
+                    String outputDir = null;
+                    String outputDTD = null;
+                    String className = null;
+                    for (int elem = 0; elem < map.getLength(); elem++) {
+                        Node mapElement = map.item(elem);
+                        if (OUTPUT_DIRECTORY_TAG.equalsIgnoreCase(mapElement.getNodeName())) {
+                            outputDir = mapElement
+                                    .getAttributes()
+                                    .getNamedItem(DIR_NAME_TAG)
+                                    .getNodeValue();
+                        }
+                        if (OUTPUT_DTD_TAG.equalsIgnoreCase(mapElement.getNodeName())) {
+                            // optional...
+                            outputDTD = mapElement
+                                    .getAttributes()
+                                    .getNamedItem(DOC_NAME_TAG)
+                                    .getNodeValue();
+                        }
+                        if (HARVESTER_TAG.equalsIgnoreCase(mapElement.getNodeName())) {
+                            // optional...
+                            className = mapElement
+                                    .getAttributes()
+                                    .getNamedItem(CLASS_TAG)
+                                    .getNodeValue();
+                        }
+                    }
+
+                    // set up the mappings...
+                    Configuration config = new Configuration(name, className, outputDir, outputDTD);
+                    addConfig(config);
+                    initConfigs = true;
+                }
+            }
+        }
+        return initConfigs;
+    }
+
+    private boolean writeUsers() {
+        while (usersNode.hasChildNodes()) {
+            usersNode.removeChild(usersNode.getFirstChild());
+        }
+        Element userEl = (Element) usersNode;
+        userEl.setAttribute("default", getDefaultUser().getName());
+        Iterator it = users.iterator();
+        while (it.hasNext()) {
+            User user = (User) it.next();
+            Element userNode = configDoc.createElement("user");
+            userNode.setAttribute("name", user.getName());
+            usersNode.appendChild(userNode);
+        }
+        return true;
+    }
+
+    private boolean writeProfiles() {
+        while (profileNode.hasChildNodes()) {
+            profileNode.removeChild(profileNode.getFirstChild());
+        }
+        Iterator it = profiles.iterator();
+        while (it.hasNext()) {
+            Profile prof = (Profile) it.next();
+            Element profNode = configDoc.createElement("profile");
+            profNode.setAttribute("name", prof.getName());
+            Element inpDirNode = configDoc.createElement(INPUT_FILES_TAG);
+            inpDirNode.setAttribute(DIR_NAME_TAG, prof.getInputDirectory());
+            Element logDirNode = configDoc.createElement(LOG_TAG);
+            logDirNode.setAttribute(DIR_NAME_TAG, prof.getLogDirectory());
+            profNode.appendChild(inpDirNode);
+            profNode.appendChild(logDirNode);
+            Iterator ad = prof.getAdapterClasses();
+            while (ad.hasNext()) {
+                String adClass = (String) ad.next();
+                Element adapNode = configDoc.createElement(ADAPTER_TAG);
+                adapNode.setAttribute(CLASS_TAG, adClass);
+                profNode.appendChild(adapNode);
+            }
+            profileNode.appendChild(profNode);
+        }
+        return true;
+    }
+
+    private boolean writeMaps() {
+        while (mapNode.hasChildNodes()) {
+            mapNode.removeChild(mapNode.getFirstChild());
+        }
+        Iterator it = this.configMapping.iterator();
+        while (it.hasNext()) {
+            ConfigMapEntry map = (ConfigMapEntry) it.next();
+            Element mapSubNode = configDoc.createElement("map");
+            Element inpDTDNode = configDoc.createElement(INPUT_DTD_TAG);
+            inpDTDNode.setAttribute(DOC_NAME_TAG, map.getInputDTD());
+            Element outDTDNode = configDoc.createElement(OUTPUT_DTD_TAG);
+            outDTDNode.setAttribute(DOC_NAME_TAG, map.getOutputDTD());
+            Element mapXSLTNode = configDoc.createElement(XSLT_TAG);
+            mapXSLTNode.setAttribute(DOC_NAME_TAG, map.getXsltFunction());
+            mapSubNode.appendChild(inpDTDNode);
+            mapSubNode.appendChild(outDTDNode);
+            mapSubNode.appendChild(mapXSLTNode);
+            mapNode.appendChild(mapSubNode);
+        }
+        return true;
+    }
+
+    private boolean writeAdapters() {
+        while (adaptersNode.hasChildNodes()) {
+            adaptersNode.removeChild(adaptersNode.getFirstChild());
+        }
+        DataAdapter[] ads = AdapterFactory.getInstance().getAdapters();
+        for (int i = 0; i < ads.length; i++) {
+            Element adSubNode = configDoc.createElement(ADAPTER_TAG);
+            adSubNode.setAttribute(CLASS_TAG, ads[i].getClass().getName());
+            String ot = ads[i].getOutputType();
+            if ((ot != null) && (ot.length() > 0)) {
+                adSubNode.setAttribute(OUTPUT_DTD_TAG, ads[i].getOutputType());
+            }
+            String jar = getJarForAdapter(ads[i]);
+            if ((jar != null) && (jar.length() > 0)) {
+                adSubNode.setAttribute(JAR_TAG, getJarForAdapter(ads[i]));
+            }
+            Element adParamNode = configDoc.createElement(PARAMETER_TAG);
+            // FXUtil.get
+            // ads[i].
+            // adParamNode.
+            adaptersNode.appendChild(adSubNode);
+        }
+        return true;
+    }
+
+    private boolean writeConfigurations() {
+        while (configNode.hasChildNodes()) {
+            configNode.removeChild(configNode.getFirstChild());
+        }
+        Iterator it = this.configs.iterator();
+        while (it.hasNext()) {
+            Configuration config = (Configuration) it.next();
+            Element configSubNode = configDoc.createElement("configuration");
+            configSubNode.setAttribute(NAME_TAG, config.getName());
+            Element outputDirNode = configDoc.createElement(OUTPUT_DIRECTORY_TAG);
+            outputDirNode.setAttribute(DIR_NAME_TAG, config.getOutputDirectory());
+            configSubNode.appendChild(outputDirNode);
+            Element harvesterNode = configDoc.createElement(HARVESTER_TAG);
+            harvesterNode.setAttribute(CLASS_TAG, config.getClassName());
+            configSubNode.appendChild(harvesterNode);
+            configNode.appendChild(configSubNode);
+        }
+        return true;
+    }
+
+    public void addUserListener(UserListener ul) {
+        userListeners.add(ul);
+    }
+
+    public void removeUserListener(UserListener ul) {
+        userListeners.remove(ul);
+    }
+
+    public void addProfileListener(ProfileListener pl) {
+        profileListeners.add(pl);
+    }
+
+    public void removeProfileListener(ProfileListener pl) {
+        profileListeners.remove(pl);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/EbuCoreNormalizedRatioTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/EbuCoreNormalizedRatioTest.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * Copyright 2014 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,60 +20,59 @@ package edu.harvard.hul.ois.fits;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-
 import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
+import org.junit.Test;
 
 public class EbuCoreNormalizedRatioTest extends AbstractLoggingTest {
 
-    @Test  
-	public void testNormalAspectRatioC() throws Exception {   
-    	String aspectRatio = "4:3";
-    	EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(aspectRatio);
-    	assertEquals(ratio.getNormalizedNumerator(), 4);
-    	assertEquals(ratio.getNormalizedDenominator(), 3);
-	}
-    
-    @Test  
-	public void testDecimalAspectRatioC() throws Exception {   
-    	String aspectRatio = "1.067";
-    	EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(aspectRatio);
-    	assertEquals(ratio.getNormalizedNumerator(), 1067);
-    	assertEquals(ratio.getNormalizedDenominator(), 1000);
-	}
-    
-    @Test  
-	public void testMixedAspectRatioC() throws Exception {   
-    	String aspectRatio = "2.22";
-    	EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(aspectRatio);
-    	assertEquals(ratio.getNormalizedNumerator(), 222);
-    	assertEquals(ratio.getNormalizedDenominator(), 100);
-	}    
-    
+    @Test
+    public void testNormalAspectRatioC() throws Exception {
+        String aspectRatio = "4:3";
+        EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(aspectRatio);
+        assertEquals(ratio.getNormalizedNumerator(), 4);
+        assertEquals(ratio.getNormalizedDenominator(), 3);
+    }
+
+    @Test
+    public void testDecimalAspectRatioC() throws Exception {
+        String aspectRatio = "1.067";
+        EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(aspectRatio);
+        assertEquals(ratio.getNormalizedNumerator(), 1067);
+        assertEquals(ratio.getNormalizedDenominator(), 1000);
+    }
+
+    @Test
+    public void testMixedAspectRatioC() throws Exception {
+        String aspectRatio = "2.22";
+        EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(aspectRatio);
+        assertEquals(ratio.getNormalizedNumerator(), 222);
+        assertEquals(ratio.getNormalizedDenominator(), 100);
+    }
+
     @Test
     public void testInvalidNullAspectRatio() {
-    	String aspectRatio = null;
-    	EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(aspectRatio);
-    	
-    	assertEquals(ratio.getNormalizedNumerator(), 0);
-    	assertEquals(ratio.getNormalizedDenominator(), 0);    	
+        String aspectRatio = null;
+        EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(aspectRatio);
+
+        assertEquals(ratio.getNormalizedNumerator(), 0);
+        assertEquals(ratio.getNormalizedDenominator(), 0);
     }
 
     @Test
     public void testInvalidRatio() {
-    	String aspectRatio = "abc123";
-    	EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(aspectRatio);
-    	
-    	assertEquals(ratio.getNormalizedNumerator(), 0);
-    	assertEquals(ratio.getNormalizedDenominator(), 0);    	
+        String aspectRatio = "abc123";
+        EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(aspectRatio);
+
+        assertEquals(ratio.getNormalizedNumerator(), 0);
+        assertEquals(ratio.getNormalizedDenominator(), 0);
     }
-    
+
     @Test
     public void testInvalidRatio_2() {
-    	String aspectRatio = "123:23.bc";
-    	EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(aspectRatio);
-    	
-    	assertEquals(ratio.getNormalizedNumerator(), 0);
-    	assertEquals(ratio.getNormalizedDenominator(), 0);    	
-    }    
+        String aspectRatio = "123:23.bc";
+        EbuCoreNormalizedRatio ratio = new EbuCoreNormalizedRatio(aspectRatio);
+
+        assertEquals(ratio.getNormalizedNumerator(), 0);
+        assertEquals(ratio.getNormalizedDenominator(), 0);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/FitsOutputVersionTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/FitsOutputVersionTest.java
@@ -4,42 +4,39 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
-
 import org.jdom2.Document;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.junit.Test;
-
-import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class FitsOutputVersionTest extends AbstractLoggingTest {
-	
-	private static Logger logger = LoggerFactory.getLogger(FitsOutputVersionTest.class);
 
-	/**
-	 * Test output of Fits version from the input file to FitsOutput.
-	 */
-	@Test
-	public void testFitsOutputVersion() {
+    private static Logger logger = LoggerFactory.getLogger(FitsOutputVersionTest.class);
 
-		try {
-			Reader in = new FileReader(new File("testfiles/FitsOutputTest.xml"));
-			SAXBuilder builder = new SAXBuilder();
-			Document fitsXml = builder.build(in);
-			FitsOutput fitsOutput = new FitsOutput(fitsXml);
-			assertNotNull(fitsOutput);
-			String inputVersion = fitsOutput.getFitsVersion();
-			assertNotNull(inputVersion);
-			assertEquals("FitsOutput version not the same as input file version", "1.1.0", inputVersion);
-		} catch (JDOMException | IOException e) {
-			fail("Could not parse input document: " + e.getClass().getSimpleName() + " -- " + e.getMessage());
-		}
-	}
-		
+    /**
+     * Test output of Fits version from the input file to FitsOutput.
+     */
+    @Test
+    public void testFitsOutputVersion() {
+
+        try {
+            Reader in = new FileReader(new File("testfiles/FitsOutputTest.xml"));
+            SAXBuilder builder = new SAXBuilder();
+            Document fitsXml = builder.build(in);
+            FitsOutput fitsOutput = new FitsOutput(fitsXml);
+            assertNotNull(fitsOutput);
+            String inputVersion = fitsOutput.getFitsVersion();
+            assertNotNull(inputVersion);
+            assertEquals("FitsOutput version not the same as input file version", "1.1.0", inputVersion);
+        } catch (JDOMException | IOException e) {
+            fail("Could not parse input document: " + e.getClass().getSimpleName() + " -- " + e.getMessage());
+        }
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/XmlContentConverterTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/XmlContentConverterTest.java
@@ -25,18 +25,10 @@
  * (617)495-3724
  * hulois@hulmail.harvard.edu
  **********************************************************************/
-
 package edu.harvard.hul.ois.fits;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
-import java.util.List;
-
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.Namespace;
-import org.junit.Test;
 
 import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import edu.harvard.hul.ois.ots.schemas.DocumentMD.DocumentMD;
@@ -59,86 +51,91 @@ import edu.harvard.hul.ois.ots.schemas.TextMD.CharacterInfo;
 import edu.harvard.hul.ois.ots.schemas.TextMD.MarkupBasis;
 import edu.harvard.hul.ois.ots.schemas.TextMD.MarkupLanguage;
 import edu.harvard.hul.ois.ots.schemas.TextMD.TextMD;
+import java.util.List;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class XmlContentConverterTest extends AbstractLoggingTest {
-	
-	private final static Namespace fitsNS = Namespace.getNamespace (Fits.XML_NAMESPACE);
-	
+
+    private static final Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
+
     private static final Logger logger = LoggerFactory.getLogger(XmlContentConverterTest.class);
 
-	@Test
-    public void testToMix () {
+    @Test
+    public void testToMix() {
         // Construct a document using JDOM
-        Document jdoc = new Document ();
-        Element imgElem = new Element ("image", fitsNS);
+        Document jdoc = new Document();
+        Element imgElem = new Element("image", fitsNS);
         jdoc.addContent(imgElem);
-        
-        Element elem = new Element ("byteOrder", fitsNS);
+
+        Element elem = new Element("byteOrder", fitsNS);
         elem.addContent("big endian");
-        imgElem.addContent (elem);
-        
-        elem = new Element ("gpsVersionID", fitsNS);
-        elem.addContent ("99.5");
-        imgElem.addContent (elem);
-        
-        elem = new Element ("gpsDestLatitude", fitsNS);
-        elem.addContent ("33 deg 24' 51.40\" N");
-        imgElem.addContent (elem);
-        
-        elem = new Element ("referenceBlackWhite", fitsNS);
-        elem.addContent ("0.0 255.0 0.0 255.0 0.0 255.0");
-        imgElem.addContent (elem);
-        
-        elem = new Element ("YCbCrCoefficients", fitsNS);
-        elem.addContent ("10.0 20.0 30.0");
-        imgElem.addContent (elem);
-        
-        XmlContentConverter conv = new XmlContentConverter ();
-        Mix mix = (Mix) conv.toMix (imgElem,null);
+        imgElem.addContent(elem);
+
+        elem = new Element("gpsVersionID", fitsNS);
+        elem.addContent("99.5");
+        imgElem.addContent(elem);
+
+        elem = new Element("gpsDestLatitude", fitsNS);
+        elem.addContent("33 deg 24' 51.40\" N");
+        imgElem.addContent(elem);
+
+        elem = new Element("referenceBlackWhite", fitsNS);
+        elem.addContent("0.0 255.0 0.0 255.0 0.0 255.0");
+        imgElem.addContent(elem);
+
+        elem = new Element("YCbCrCoefficients", fitsNS);
+        elem.addContent("10.0 20.0 30.0");
+        imgElem.addContent(elem);
+
+        XmlContentConverter conv = new XmlContentConverter();
+        Mix mix = (Mix) conv.toMix(imgElem, null);
         BasicDigitalObjectInformation bdoi = mix.getBasicDigitalObjectInformation();
-        String byteOrder = bdoi.getByteOrder().toString ();
-        assertEquals ("big endian", byteOrder);
-        
+        String byteOrder = bdoi.getByteOrder().toString();
+        assertEquals("big endian", byteOrder);
+
         ImageCaptureMetadata icm = mix.getImageCaptureMetadata();
         DigitalCameraCapture dcc = icm.getDigitalCameraCapture();
         CameraCaptureSettings ccs = dcc.getCameraCaptureSettings();
         GPSData gps = ccs.getGPSData();
         String gpsVersionID = gps.getGpsVersionID().toString();
-        assertEquals ("99.5", gpsVersionID);
-        
+        assertEquals("99.5", gpsVersionID);
+
         GPSDestLatitude dlat = gps.getGPSDestLatitude();
         double deg = dlat.getDegrees().toRational().getDouble();
         double min = dlat.getMinutes().toRational().getDouble();
         double sec = dlat.getSeconds().toRational().getDouble();
-        assertEquals (33.0, deg, 0.0);
-        assertEquals (24.0, min, 0.0);
-        assertEquals (51.0, sec, 0.4);
-        
+        assertEquals(33.0, deg, 0.0);
+        assertEquals(24.0, min, 0.0);
+        assertEquals(51.0, sec, 0.4);
+
         BasicImageInformation bii = mix.getBasicImageInformation();
         BasicImageCharacteristics bic = bii.getBasicImageCharacteristics();
         PhotometricInterpretation phi = bic.getPhotometricInterpretation();
         List<ReferenceBlackWhite> rbwList = phi.getReferenceBlackWhites();
         ReferenceBlackWhite rbw = rbwList.get(0);
         List<Component> compList = rbw.getComponents();
-        assertEquals (3, compList.size());
+        assertEquals(3, compList.size());
         Component comp = compList.get(0);
-        assertEquals ("Y", comp.getComponentPhotometricInterpretation().toString ());
+        assertEquals("Y", comp.getComponentPhotometricInterpretation().toString());
         double headroom = comp.getHeadroom().toRational().getDouble();
-        assertEquals (0.0, headroom, 0.0);
-        
+        assertEquals(0.0, headroom, 0.0);
+
         YCbCr ycbcr = phi.getYCbCr();
         YCbCrCoefficients ycbcrc = ycbcr.getYCbCrCoefficients();
-        double lumaRed = ycbcrc.getLumaRed().toRational().getDouble ();
-        assertEquals (10.0, lumaRed, 0.0);
-        double lumaGreen = ycbcrc.getLumaGreen().toRational().getDouble ();
-        assertEquals (20.0, lumaGreen, 0.0);
-        double lumaBlue = ycbcrc.getLumaBlue().toRational().getDouble ();
-        assertEquals (30.0, lumaBlue, 0.0);    
+        double lumaRed = ycbcrc.getLumaRed().toRational().getDouble();
+        assertEquals(10.0, lumaRed, 0.0);
+        double lumaGreen = ycbcrc.getLumaGreen().toRational().getDouble();
+        assertEquals(20.0, lumaGreen, 0.0);
+        double lumaBlue = ycbcrc.getLumaBlue().toRational().getDouble();
+        assertEquals(30.0, lumaBlue, 0.0);
     }
 
-	@Test
+    @Test
     public void testToDocumentMD() {
         // Construct a document using JDOM
         Document jdoc = new Document();
@@ -148,35 +145,35 @@ public class XmlContentConverterTest extends AbstractLoggingTest {
         Element elem = new Element("isTagged", fitsNS); // a feature
         elem.addContent("yes");
         docElem.addContent(elem);
-        
+
         elem = new Element("hasOutline", fitsNS); // a feature
         elem.addContent("yes");
         docElem.addContent(elem);
-        
+
         elem = new Element("hasAnnotations", fitsNS); // a feature
         elem.addContent("yes");
         docElem.addContent(elem);
-        
+
         elem = new Element("pageCount", fitsNS);
         elem.addContent("6");
         docElem.addContent(elem);
-        
+
         elem = new Element("isRightsManaged", fitsNS);
         elem.addContent("yes");
         docElem.addContent(elem);
-        
+
         elem = new Element("isProtected", fitsNS);
         elem.addContent("no");
         docElem.addContent(elem);
-        
+
         elem = new Element("hasForms", fitsNS); // a feature
         elem.addContent("yes");
         docElem.addContent(elem);
-        
+
         elem = new Element("hasHyperlinks", fitsNS);
         elem.addContent("yes");
         docElem.addContent(elem);
-        
+
         elem = new Element("hasEmbeddedResources", fitsNS);
         elem.addContent("yes");
         docElem.addContent(elem);
@@ -196,7 +193,7 @@ public class XmlContentConverterTest extends AbstractLoggingTest {
         docElem.addContent(fontElem2);
 
         XmlContentConverter conv = new XmlContentConverter();
-        DocumentMD dmd =(DocumentMD) conv.toDocumentMD(docElem);
+        DocumentMD dmd = (DocumentMD) conv.toDocumentMD(docElem);
         assertEquals(6, dmd.getPageCount());
         List<Feature> features = dmd.getFeatures();
         assertEquals(6, features.size());
@@ -204,59 +201,58 @@ public class XmlContentConverterTest extends AbstractLoggingTest {
         assertTrue(features.contains(Feature.hasOutline));
         assertTrue(features.contains(Feature.hasAnnotations));
         assertTrue(features.contains(Feature.isTagged));
-//        assertTrue(features.contains(Feature.hasHyperlinks));
-//        assertTrue(features.contains(Feature.hasEmbeddedResources));
-        
-        assertEquals(2, dmd.getFonts().size());
-	}
+        //        assertTrue(features.contains(Feature.hasHyperlinks));
+        //        assertTrue(features.contains(Feature.hasEmbeddedResources));
 
-	@Test
-    public void testToTextMD () {
+        assertEquals(2, dmd.getFonts().size());
+    }
+
+    @Test
+    public void testToTextMD() {
         final String mln = "http://www.loc.gov/standards/mets/mets.xsd";
         // Construct a document using JDOM
-        Document jdoc = new Document ();
-        Element textElem = new Element ("text", fitsNS);
+        Document jdoc = new Document();
+        Element textElem = new Element("text", fitsNS);
         jdoc.addContent(textElem);
-        
-        Element elem = new Element ("linebreak", fitsNS);
-        elem.addContent ("LF");
-        textElem.addContent (elem);
-        
-        elem = new Element ("charset", fitsNS);
-        elem.addContent ("US-ASCII");
-        textElem.addContent (elem);
 
-        elem = new Element ("markupBasis", fitsNS);
-        elem.addContent ("HTML");
-        textElem.addContent (elem);
-        
-        elem = new Element ("markupBasisVersion", fitsNS);
-        elem.addContent ("1.0");
-        textElem.addContent (elem);
-        
-        elem = new Element ("markupLanguage", fitsNS);
-        elem.addContent (mln);
-        textElem.addContent (elem);
-        
-        XmlContentConverter conv = new XmlContentConverter ();
-        TextMD tmd = (TextMD) conv.toTextMD (textElem);
-        
+        Element elem = new Element("linebreak", fitsNS);
+        elem.addContent("LF");
+        textElem.addContent(elem);
+
+        elem = new Element("charset", fitsNS);
+        elem.addContent("US-ASCII");
+        textElem.addContent(elem);
+
+        elem = new Element("markupBasis", fitsNS);
+        elem.addContent("HTML");
+        textElem.addContent(elem);
+
+        elem = new Element("markupBasisVersion", fitsNS);
+        elem.addContent("1.0");
+        textElem.addContent(elem);
+
+        elem = new Element("markupLanguage", fitsNS);
+        elem.addContent(mln);
+        textElem.addContent(elem);
+
+        XmlContentConverter conv = new XmlContentConverter();
+        TextMD tmd = (TextMD) conv.toTextMD(textElem);
+
         List<CharacterInfo> chinfos = tmd.getCharacterInfos();
         assertEquals(1, chinfos.size());
         CharacterInfo chinfo = chinfos.get(0);
         assertEquals("US-ASCII", chinfo.getCharset());
-        assertEquals("LF", chinfo.getLinebreak ());
-        
+        assertEquals("LF", chinfo.getLinebreak());
+
         List<MarkupBasis> mkbases = tmd.getMarkupBases();
         assertEquals(1, mkbases.size());
         MarkupBasis mkbas = mkbases.get(0);
-        assertEquals ("HTML", mkbas.getValue());
-        assertEquals ("1.0", mkbas.getVersion());
-        
+        assertEquals("HTML", mkbas.getValue());
+        assertEquals("1.0", mkbas.getVersion());
+
         List<MarkupLanguage> mklangs = tmd.getMarkupLanguages();
         assertEquals(1, mklangs.size());
         MarkupLanguage mklang = mklangs.get(0);
         assertEquals(mln, mklang.getValue());
     }
-
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/consolidation/OISConsolidatorTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/consolidation/OISConsolidatorTest.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * Copyright 2016 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,12 +20,6 @@ package edu.harvard.hul.ois.fits.consolidation;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.Test;
 
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.FitsOutput;
@@ -35,159 +29,162 @@ import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import edu.harvard.hul.ois.fits.tools.Tool;
 import edu.harvard.hul.ois.fits.tools.ToolBelt;
 import edu.harvard.hul.ois.fits.tools.ToolOutput;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * This test class is to verify output created by the OISConsolidator class.
- * 
+ *
  * @author dneiman
  */
 public class OISConsolidatorTest extends AbstractLoggingTest {
 
-	private static Logger logger = LoggerFactory.getLogger(OISConsolidatorTest.class);
-	
-	/**
-	 * This is a trivial test of passing a single ToolOutput from the Droid tool into the OISConsolidator
-	 * to verify its identity output.
-	 */
-	@Test
-	public void singleTool() throws Exception {
-		String inputFilename = "Winnie-the-Pooh-protected.epub";
-		File input = new File("testfiles/" + inputFilename);
-		File fitsConfigFile = new File("testfiles/properties/fits_droid_only.xml");
-		
-		// Make sure ToolOutput for each tool not reset after examine() so it can be reused for test.
-		Fits fits = new Fits(null, fitsConfigFile) {
-			
-			@Override
-			 public FitsOutput examine( File input ) throws FitsException {
-				resetToolOutputAfterExaminingInput(false);
-				return super.examine(input);
-			}
-		};
-		
-    	FitsOutput fitsOut = fits.examine(input);
-    	
-    	// output to file and console to view output if necessary, before running assertions
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + "_droid_only_Output.xml");
-    	fitsOut.addStandardCombinedFormat();
-    	
-    	ToolBelt toolBelt = fits.getToolbelt();
-    	assertEquals(1, toolBelt.getTools().size());
-    	Tool tool = toolBelt.getTools().get(0);
-    	ToolOutput toolOutput = tool.getOutput();
-    	assertNotNull(toolOutput);
-    	OISConsolidator consolidator = new OISConsolidator(fits);
-    	List<ToolOutput> results = new ArrayList<ToolOutput>();
-    	results.add(toolOutput);
-    	FitsOutput fitsOutput = consolidator.processResults(results);
-    	
-    	List<FitsIdentity> identities = fitsOutput.getIdentities();
-    	assertNotNull(identities);
-    	assertEquals(1, identities.size());
-    	FitsIdentity ident = identities.get(0);
-    	assertEquals("EPUB", ident.getFormat());
-    	assertEquals("application/epub+zip", ident.getMimetype());
-    	assertEquals(1, ident.getReportingTools().size());
-    	assertEquals("Droid", ident.getReportingTools().get(0).getName());
-    	assertEquals(1, ident.getExternalIdentifiers().size());
-	}
-	
-	/**
-	 * This tests that a less specific identity (jhove) will not appear with one that is more specific (droid)
-	 * when the tool with the MORE specific identity appears first in the fits.xml tool list.
-	 */
-	@Test
-	public void droidBeforeJhove() throws Exception {
-		String inputFilename = "image-vectorgraphic.svg";
-		File input = new File("testfiles/" + inputFilename);
-		File fitsConfigFile = new File("testfiles/properties/fits_droid_jhove.xml");
-		
-		// Make sure ToolOutput for each tool not reset after examine() so it can be reused for test.
-		Fits fits = new Fits(null, fitsConfigFile) {
-			
-			@Override
-			 public FitsOutput examine( File input ) throws FitsException {
-				resetToolOutputAfterExaminingInput(false);
-				return super.examine(input);
-			}
-		};
-		
-    	FitsOutput fitsOut = fits.examine(input);
-    	
-    	// output to file and console to view output if necessary, before running assertions
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + "_droid_tika_Output.xml");
-    	fitsOut.addStandardCombinedFormat();
-    	
-    	ToolBelt toolBelt = fits.getToolbelt();
-    	assertEquals(2, toolBelt.getTools().size());
-    	OISConsolidator consolidator = new OISConsolidator(fits);
-    	List<ToolOutput> results = new ArrayList<ToolOutput>();
-    	for (Tool tool : toolBelt.getTools()) {
-    		ToolOutput toolOutput = tool.getOutput();
-    		assertNotNull(toolOutput);
-    		results.add(toolOutput);
-    	}
-    	FitsOutput fitsOutput = consolidator.processResults(results);
-    	
-    	List<FitsIdentity> identities = fitsOutput.getIdentities();
-    	assertNotNull(identities);
-    	assertEquals(1, identities.size());
-    	FitsIdentity ident = identities.get(0);
-    	assertEquals("Scalable Vector Graphics (SVG)", ident.getFormat());
-    	assertEquals("image/svg+xml", ident.getMimetype());
-    	assertEquals(1, ident.getReportingTools().size());
-    	assertEquals("Droid", ident.getReportingTools().get(0).getName());
-    	assertEquals(1, ident.getExternalIdentifiers().size());
-	}
-	
-	/**
-	 * This tests that a less specific identity (jhove) will not appear with one that is more specific (droid)
-	 * when the tool with the LESS specific identity appears first in the fits.xml tool list.
-	 */
-	@Test
-	public void jhoveBeforeDroid() throws Exception {
-		String inputFilename = "image-vectorgraphic.svg";
-		File input = new File("testfiles/" + inputFilename);
-		File fitsConfigFile = new File("testfiles/properties/fits_jhove_droid.xml");
-		
-		// Make sure ToolOutput for each tool not reset after examine() so it can be reused for test.
-		Fits fits = new Fits(null, fitsConfigFile) {
-			
-			@Override
-			 public FitsOutput examine( File input ) throws FitsException {
-				resetToolOutputAfterExaminingInput(false);
-				return super.examine(input);
-			}
-		};
-		
-    	FitsOutput fitsOut = fits.examine(input);
-    	
-    	// output to file and console to view output if necessary, before running assertions
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + "_jhove_droid_Output.xml");
-    	fitsOut.addStandardCombinedFormat();
-    	
-    	ToolBelt toolBelt = fits.getToolbelt();
-    	assertEquals(2, toolBelt.getTools().size());
-    	OISConsolidator consolidator = new OISConsolidator(fits);
-    	List<ToolOutput> results = new ArrayList<ToolOutput>();
-    	for (Tool tool : toolBelt.getTools()) {
-    		ToolOutput toolOutput = tool.getOutput();
-    		assertNotNull(toolOutput);
-    		results.add(toolOutput);
-    	}
-    	FitsOutput fitsOutput = consolidator.processResults(results);
-    	
-    	List<FitsIdentity> identities = fitsOutput.getIdentities();
-    	assertNotNull(identities);
-    	assertEquals(1, identities.size());
-    	FitsIdentity ident = identities.get(0);
-    	assertEquals("Scalable Vector Graphics (SVG)", ident.getFormat());
-    	assertEquals("image/svg+xml", ident.getMimetype());
-    	assertEquals(1, ident.getReportingTools().size());
-    	assertEquals("Droid", ident.getReportingTools().get(0).getName());
-    	assertEquals(1, ident.getExternalIdentifiers().size());
-	}
+    private static Logger logger = LoggerFactory.getLogger(OISConsolidatorTest.class);
 
+    /**
+     * This is a trivial test of passing a single ToolOutput from the Droid tool into the OISConsolidator
+     * to verify its identity output.
+     */
+    @Test
+    public void singleTool() throws Exception {
+        String inputFilename = "Winnie-the-Pooh-protected.epub";
+        File input = new File("testfiles/" + inputFilename);
+        File fitsConfigFile = new File("testfiles/properties/fits_droid_only.xml");
+
+        // Make sure ToolOutput for each tool not reset after examine() so it can be reused for test.
+        Fits fits = new Fits(null, fitsConfigFile) {
+
+            @Override
+            public FitsOutput examine(File input) throws FitsException {
+                resetToolOutputAfterExaminingInput(false);
+                return super.examine(input);
+            }
+        };
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        // output to file and console to view output if necessary, before running assertions
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + "_droid_only_Output.xml");
+        fitsOut.addStandardCombinedFormat();
+
+        ToolBelt toolBelt = fits.getToolbelt();
+        assertEquals(1, toolBelt.getTools().size());
+        Tool tool = toolBelt.getTools().get(0);
+        ToolOutput toolOutput = tool.getOutput();
+        assertNotNull(toolOutput);
+        OISConsolidator consolidator = new OISConsolidator(fits);
+        List<ToolOutput> results = new ArrayList<ToolOutput>();
+        results.add(toolOutput);
+        FitsOutput fitsOutput = consolidator.processResults(results);
+
+        List<FitsIdentity> identities = fitsOutput.getIdentities();
+        assertNotNull(identities);
+        assertEquals(1, identities.size());
+        FitsIdentity ident = identities.get(0);
+        assertEquals("EPUB", ident.getFormat());
+        assertEquals("application/epub+zip", ident.getMimetype());
+        assertEquals(1, ident.getReportingTools().size());
+        assertEquals("Droid", ident.getReportingTools().get(0).getName());
+        assertEquals(1, ident.getExternalIdentifiers().size());
+    }
+
+    /**
+     * This tests that a less specific identity (jhove) will not appear with one that is more specific (droid)
+     * when the tool with the MORE specific identity appears first in the fits.xml tool list.
+     */
+    @Test
+    public void droidBeforeJhove() throws Exception {
+        String inputFilename = "image-vectorgraphic.svg";
+        File input = new File("testfiles/" + inputFilename);
+        File fitsConfigFile = new File("testfiles/properties/fits_droid_jhove.xml");
+
+        // Make sure ToolOutput for each tool not reset after examine() so it can be reused for test.
+        Fits fits = new Fits(null, fitsConfigFile) {
+
+            @Override
+            public FitsOutput examine(File input) throws FitsException {
+                resetToolOutputAfterExaminingInput(false);
+                return super.examine(input);
+            }
+        };
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        // output to file and console to view output if necessary, before running assertions
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + "_droid_tika_Output.xml");
+        fitsOut.addStandardCombinedFormat();
+
+        ToolBelt toolBelt = fits.getToolbelt();
+        assertEquals(2, toolBelt.getTools().size());
+        OISConsolidator consolidator = new OISConsolidator(fits);
+        List<ToolOutput> results = new ArrayList<ToolOutput>();
+        for (Tool tool : toolBelt.getTools()) {
+            ToolOutput toolOutput = tool.getOutput();
+            assertNotNull(toolOutput);
+            results.add(toolOutput);
+        }
+        FitsOutput fitsOutput = consolidator.processResults(results);
+
+        List<FitsIdentity> identities = fitsOutput.getIdentities();
+        assertNotNull(identities);
+        assertEquals(1, identities.size());
+        FitsIdentity ident = identities.get(0);
+        assertEquals("Scalable Vector Graphics (SVG)", ident.getFormat());
+        assertEquals("image/svg+xml", ident.getMimetype());
+        assertEquals(1, ident.getReportingTools().size());
+        assertEquals("Droid", ident.getReportingTools().get(0).getName());
+        assertEquals(1, ident.getExternalIdentifiers().size());
+    }
+
+    /**
+     * This tests that a less specific identity (jhove) will not appear with one that is more specific (droid)
+     * when the tool with the LESS specific identity appears first in the fits.xml tool list.
+     */
+    @Test
+    public void jhoveBeforeDroid() throws Exception {
+        String inputFilename = "image-vectorgraphic.svg";
+        File input = new File("testfiles/" + inputFilename);
+        File fitsConfigFile = new File("testfiles/properties/fits_jhove_droid.xml");
+
+        // Make sure ToolOutput for each tool not reset after examine() so it can be reused for test.
+        Fits fits = new Fits(null, fitsConfigFile) {
+
+            @Override
+            public FitsOutput examine(File input) throws FitsException {
+                resetToolOutputAfterExaminingInput(false);
+                return super.examine(input);
+            }
+        };
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        // output to file and console to view output if necessary, before running assertions
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + "_jhove_droid_Output.xml");
+        fitsOut.addStandardCombinedFormat();
+
+        ToolBelt toolBelt = fits.getToolbelt();
+        assertEquals(2, toolBelt.getTools().size());
+        OISConsolidator consolidator = new OISConsolidator(fits);
+        List<ToolOutput> results = new ArrayList<ToolOutput>();
+        for (Tool tool : toolBelt.getTools()) {
+            ToolOutput toolOutput = tool.getOutput();
+            assertNotNull(toolOutput);
+            results.add(toolOutput);
+        }
+        FitsOutput fitsOutput = consolidator.processResults(results);
+
+        List<FitsIdentity> identities = fitsOutput.getIdentities();
+        assertNotNull(identities);
+        assertEquals(1, identities.size());
+        FitsIdentity ident = identities.get(0);
+        assertEquals("Scalable Vector Graphics (SVG)", ident.getFormat());
+        assertEquals("image/svg+xml", ident.getMimetype());
+        assertEquals(1, ident.getReportingTools().size());
+        assertEquals("Droid", ident.getReportingTools().get(0).getName());
+        assertEquals(1, ident.getExternalIdentifiers().size());
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/ADLTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/ADLTest.java
@@ -1,62 +1,58 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import java.io.File;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
-
-
 public class ADLTest extends AbstractLoggingTest {
-    
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
-		fits = new Fits(null, fitsConfigFile);
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@Test
-	public void testADL() throws Exception {	
-		
-		String inputFilename = "T-350_036_Archival_Side_1.adl";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
+        fits = new Fits(null, fitsConfigFile);
+    }
 
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
+
+    @Test
+    public void testADL() throws Exception {
+
+        String inputFilename = "T-350_036_Archival_Side_1.adl";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/ADLXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/ADLXmlUnitTest.java
@@ -1,76 +1,70 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
-
 public class ADLXmlUnitTest extends AbstractXmlUnitTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-    
-	@Test
-	public void testADL() throws Exception {	
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-		String inputFilename = "T-350_036_Archival_Side_1.adl";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
+    @Test
+    public void testADL() throws Exception {
+
+        String inputFilename = "T-350_036_Archival_Side_1.adl";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/AdobeIllustratorTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/AdobeIllustratorTest.java
@@ -1,67 +1,64 @@
-/* 
+/*
  * Copyright 2016 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These generated FITS output with tool output on the given Adobe Illustrator files.
  * These tests should be run with &lt;display-tool-output&gt;false&lt;/display-tool-output&gt; in fits.xml.
- * 
+ *
  * @author dan179
  */
 public class AdobeIllustratorTest extends AbstractXmlUnitTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
-		fits = new Fits(null, fitsConfigFile);
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-	
-	@Test
-	public void testtestAdobeIllustratorFile() throws Exception {
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-    	String inputFilename = "MMS-82A.08.12.02.ai";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
+        fits = new Fits(null, fitsConfigFile);
+    }
 
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
+
+    @Test
+    public void testtestAdobeIllustratorFile() throws Exception {
+
+        String inputFilename = "MMS-82A.08.12.02.ai";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/AdobeIllustratorXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/AdobeIllustratorXmlUnitTest.java
@@ -1,79 +1,74 @@
-/* 
+/*
  * Copyright 2016 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These tests compare actual FITS output with expected output on Adobe Illustrator files.
- * 
+ *
  * @author dan179
  */
 public class AdobeIllustratorXmlUnitTest extends AbstractXmlUnitTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-	
-	@Test
-	public void testAdobeIllustratorFile() throws Exception {
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-    	String inputFilename = "MMS-82A.08.12.02.ai";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+    @Test
+    public void testAdobeIllustratorFile() throws Exception {
 
+        String inputFilename = "MMS-82A.08.12.02.ai";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/AudioStdSchemaTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/AudioStdSchemaTest.java
@@ -1,72 +1,70 @@
-/* 
+/*
  * Copyright 2019 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 public class AudioStdSchemaTest extends AbstractXmlUnitTest {
 
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
-		fits = new Fits(null, fitsConfigFile);
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-    
-    @Test  
-	public void testAudioChunk() throws Exception {   
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
+        fits = new Fits(null, fitsConfigFile);
+    }
 
-		String inputFilename = "testchunk.wav";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-				
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test  
-	public void testAudioMD_() throws Exception {
-		
-		String inputFilename = "test.wav";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
+    @Test
+    public void testAudioChunk() throws Exception {
+
+        String inputFilename = "testchunk.wav";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testAudioMD_() throws Exception {
+
+        String inputFilename = "test.wav";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/AudioStdSchemaXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/AudioStdSchemaXmlUnitTest.java
@@ -1,99 +1,93 @@
-/* 
+/*
  * Copyright 2015 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 public class AudioStdSchemaXmlUnitTest extends AbstractXmlUnitTest {
 
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-    
-    @Test  
-	public void testAudioChunk() throws Exception {   
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-		String inputFilename = "testchunk.wav";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testAudioChunk() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        String inputFilename = "testchunk.wav";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-	@Test  
-	public void testAudioMD_noMD5() throws Exception {
-		
-		// use an alternate fits.xml file where a MD5 checksum is not generated
-		File fitsConfigFile = new File("testfiles/properties/fits_no_md5_audio.xml");
-    	Fits fits = new Fits(null, fitsConfigFile);
-		
-		// First generate the FITS output
-		String inputFilename = "test.wav";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+    @Test
+    public void testAudioMD_noMD5() throws Exception {
+
+        // use an alternate fits.xml file where a MD5 checksum is not generated
+        File fitsConfigFile = new File("testfiles/properties/fits_no_md5_audio.xml");
+        Fits fits = new Fits(null, fitsConfigFile);
+
+        // First generate the FITS output
+        String inputFilename = "test.wav";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/BulkDirectoryTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/BulkDirectoryTest.java
@@ -1,33 +1,31 @@
-/* 
+/*
  * Copyright 2019 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import java.io.File;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,59 +36,58 @@ import org.slf4j.LoggerFactory;
  */
 @Ignore // The class should be configured with @Ignore by default.
 public class BulkDirectoryTest extends AbstractLoggingTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
-	
-	private static final String FITS_CONFIG_FILE = "<some_directory>/some-fits.xml";
-	private static final String FITS_INPUT_DIRECTORY = "<some_directory_for_input_files>";
-	private static final String FITS_OUTPUT_DIRECTORY = "test-generated-output";
 
-	private static Logger logger = LoggerFactory.getLogger(BulkDirectoryTest.class);
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		
-		// The following uses the standard FITS config file, fits.xml
-//		fits = new Fits();
-// Use the following two lines to use a custom config file
-		File fitsConfigFile = new File(FITS_CONFIG_FILE);
-		fits = new Fits(null, fitsConfigFile);
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-    
-    @Test  
-	public void testDirectory() throws Exception {   
+    private static final String FITS_CONFIG_FILE = "<some_directory>/some-fits.xml";
+    private static final String FITS_INPUT_DIRECTORY = "<some_directory_for_input_files>";
+    private static final String FITS_OUTPUT_DIRECTORY = "test-generated-output";
 
-		File inputDir = new File(FITS_INPUT_DIRECTORY);
-		File[] inputFiles = inputDir.listFiles();
-		logger.info("Processing this many files: " + inputFiles.length);
-		for (File input : inputFiles) {
-			String fileName = input.getName();
-			logger.info("processsing file: " + fileName);
-			FitsOutput fitsOut = fits.examine(input);
-			fitsOut.addStandardCombinedFormat();
-			fitsOut.saveToDisk(FITS_OUTPUT_DIRECTORY + File.separator + fileName + OUTPUT_FILE_SUFFIX);
-		}
-	}    
-    
-    @Test  
-	public void testSingleFile() throws Exception {   
+    private static Logger logger = LoggerFactory.getLogger(BulkDirectoryTest.class);
 
-    	String fileName = "T-350_036_Archival_Side_1.adl";
-    	File input = new File(FITS_INPUT_DIRECTORY + File.separator + fileName);
-		FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk(FITS_OUTPUT_DIRECTORY + File.separator + fileName + OUTPUT_FILE_SUFFIX);
-		fits.getToolbelt().printToolInfo(true);
-	}    
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
 
+        // The following uses the standard FITS config file, fits.xml
+        //		fits = new Fits();
+        // Use the following two lines to use a custom config file
+        File fitsConfigFile = new File(FITS_CONFIG_FILE);
+        fits = new Fits(null, fitsConfigFile);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
+
+    @Test
+    public void testDirectory() throws Exception {
+
+        File inputDir = new File(FITS_INPUT_DIRECTORY);
+        File[] inputFiles = inputDir.listFiles();
+        logger.info("Processing this many files: " + inputFiles.length);
+        for (File input : inputFiles) {
+            String fileName = input.getName();
+            logger.info("processsing file: " + fileName);
+            FitsOutput fitsOut = fits.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk(FITS_OUTPUT_DIRECTORY + File.separator + fileName + OUTPUT_FILE_SUFFIX);
+        }
+    }
+
+    @Test
+    public void testSingleFile() throws Exception {
+
+        String fileName = "T-350_036_Archival_Side_1.adl";
+        File input = new File(FITS_INPUT_DIRECTORY + File.separator + fileName);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk(FITS_OUTPUT_DIRECTORY + File.separator + fileName + OUTPUT_FILE_SUFFIX);
+        fits.getToolbelt().printToolInfo(true);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/DocMDTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/DocMDTest.java
@@ -1,319 +1,318 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import java.io.File;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
-
 /**
  * This class generates FITS and Standard output for inspection during development.
  * It does not actually perform any JUnit test assertions.
- * 
+ *
  * @author dan179
  */
 public class DocMDTest extends AbstractLoggingTest {
 
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
-		fits = new Fits(null, fitsConfigFile);
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-    
-	@Test
-	public void testWordDocUrlEmbeddedResources() throws Exception {	
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
+        fits = new Fits(null, fitsConfigFile);
+    }
 
-    	String inputFilename = "Word2003_has_URLs_has_embedded_resources.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testWordDocGraphics() throws Exception {	
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-    	String inputFilename = "Word2003_many_graphics.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testWordDocPasswordProtected() throws Exception {	
+    @Test
+    public void testWordDocUrlEmbeddedResources() throws Exception {
 
-    	String inputFilename = "Word2003PasswordProtected.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testWordDoc2011() throws Exception {	
+        String inputFilename = "Word2003_has_URLs_has_embedded_resources.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-    	String inputFilename = "Word2011_Has_Outline.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();		
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testWordDocLibreOffice() throws Exception {	
+    @Test
+    public void testWordDocGraphics() throws Exception {
 
-    	String inputFilename = "LibreOffice.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testWordDocHyperlinks() throws Exception {	
+        String inputFilename = "Word2003_many_graphics.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-    	String inputFilename = "Word2003_has_table_of_contents.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testWordDocPasswordAndEncrypted() throws Exception {	
+    @Test
+    public void testWordDocPasswordProtected() throws Exception {
 
-    	String inputFilename = "Word_protected_encrypted.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testWordDocV2() throws Exception {
+        String inputFilename = "Word2003PasswordProtected.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-    	String inputFilename = "NEWSSLID_Word2_0.DOC";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testOpenOfficeDoc() throws Exception {	
+    @Test
+    public void testWordDoc2011() throws Exception {
 
-    	String inputFilename = "LibreODT-Ur-doc.odt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testOpenOfficeDocEmbeddedResources() throws Exception {	
+        String inputFilename = "Word2011_Has_Outline.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-    	String inputFilename = "LibreODTwFormulas.odt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testOpenOfficeDocHasTables() throws Exception {	
+    @Test
+    public void testWordDocLibreOffice() throws Exception {
 
-    	String inputFilename = "LibreODT-hasTables.odt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testOpenOfficeDocUnparseableDate() throws Exception {	
+        String inputFilename = "LibreOffice.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-    	String inputFilename = "UnparseableDate.odt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-	
-	@Test
-	public void testWordDocxOutput() throws Exception {
+    @Test
+    public void testWordDocHyperlinks() throws Exception {
 
-    	String inputFilename = "Word_has_index.docx";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-	
-	@Test
-	public void testWordDocxPasswordProtected() throws Exception {
+        String inputFilename = "Word2003_has_table_of_contents.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-    	String inputFilename = "WordPasswordProtected.docx";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-	
-	@Test
-	public void testWordDocmOutput() throws Exception {
+    @Test
+    public void testWordDocPasswordAndEncrypted() throws Exception {
 
-    	String inputFilename = "Document_Has_Form_Controls.docm";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-	
-	@Test
-	public void testEpubOutput() throws Exception {
+        String inputFilename = "Word_protected_encrypted.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-    	// process multiple files to examine different types of output
-    	String[] inputFilenames = {"Winnie-the-Pooh-protected.epub",
-    			"GeographyofBliss_oneChapter.epub",
-    			"aliceDynamic_images_metadata_tableOfContents.epub",
-    			"epub30-test-font-embedding-obfuscation.epub",
-    			"Calibre_hasTable_of_Contents.epub"};
+    @Test
+    public void testWordDocV2() throws Exception {
 
-    	for (String inputFilename : inputFilenames) {
-    		
-    		String outputFilename = "test-generated-output/"+ inputFilename + OUTPUT_FILE_SUFFIX;
-    		File input = new File("testfiles/" + inputFilename);
-    		FitsOutput fitsOut = fits.examine(input);
-    		fitsOut.addStandardCombinedFormat();
-    		fitsOut.saveToDisk(outputFilename);
-    	}
-	}
-	
-	@Test
-	public void testWPDOutput() throws Exception {
-    	
-    	// process multiple files to examine different types of output
-    	String[] inputFilenames = { "WordPerfect6-7.wpd",
-    			"WordPerfect4_2.wp",
-    			"WordPerfect5_0.wp",
-    			"WordPerfect5_2.wp" };
-//    			"WordPerfectCompoundFile.wpd"};  // (not identified as a WordPerfect document)
+        String inputFilename = "NEWSSLID_Word2_0.DOC";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-    	for (String inputFilename : inputFilenames) {
-    		String outputFilename = "test-generated-output/"+ inputFilename + OUTPUT_FILE_SUFFIX;
-    		File input = new File("testfiles/" + inputFilename);
-    		FitsOutput fitsOut = fits.examine(input);
-    		fitsOut.addStandardCombinedFormat();
-    		fitsOut.saveToDisk(outputFilename);
-    	}
-	}
-	
-	@Test
-	public void testRtfOutput() throws Exception {
+    @Test
+    public void testOpenOfficeDoc() throws Exception {
 
-    	String inputFilename = "TestDoc.rtf";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-	
-	@Test
-	public void testRtfWithCompanyOutput() throws Exception {
+        String inputFilename = "LibreODT-Ur-doc.odt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-    	String inputFilename = "Doc2.rtf";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testPdf() throws Exception {
-		
-    	String[] inputFilenames = {"PDF_embedded_resources.pdf",
-    			"HasChangeHistory.pdf",
-    			"PDF_eng.pdf",
-    			"HasAnnotations.pdf"};
+    @Test
+    public void testOpenOfficeDocEmbeddedResources() throws Exception {
 
-    	for (String inputFilename : inputFilenames) {
-    		String outputFilename = "test-generated-output/"+ inputFilename + OUTPUT_FILE_SUFFIX;
-    		File input = new File("testfiles/" + inputFilename);
-    		FitsOutput fitsOut = fits.examine(input);
-        	fitsOut.addStandardCombinedFormat();
-    		fitsOut.saveToDisk(outputFilename);
-    	}
-	}
-    
-	@Test
-	public void testPdfA() throws Exception {
-		
-    	String[] inputFilenames = {"PDFa_equations.pdf",
-    			"PDFa_multiplefonts.pdf",
-    			"PDFa_has_form.pdf",
-    			"PDFa_has_table_of_contents.pdf",
-    			"PDFa_has_tables.pdf",
-    			"PDFA_Document with tables.pdf",
-    			"PDFa_embedded_resources.pdf"};
+        String inputFilename = "LibreODTwFormulas.odt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-    	for (String inputFilename : inputFilenames) {
-    		String outputFilename = "test-generated-output/"+ inputFilename + OUTPUT_FILE_SUFFIX;
-    		File input = new File("testfiles/" + inputFilename);
-    		FitsOutput fitsOut = fits.examine(input);
-        	fitsOut.addStandardCombinedFormat();
-    		fitsOut.saveToDisk(outputFilename);
-    	}
-	}
-    
-	@Test
-	public void testPdfX() throws Exception {
-		
-    	String[] inputFilenames = {"altona_technical_1v2_x3_has_annotations.pdf",
-    			"Book_pdfx1a.pdf", // converts to PDF/A
-    			"PDFx3.pdf"}; // converts to PDF/A
+    @Test
+    public void testOpenOfficeDocHasTables() throws Exception {
 
-    	for (String inputFilename : inputFilenames) {
-    		String outputFilename = "test-generated-output/"+ inputFilename + OUTPUT_FILE_SUFFIX;
-    		File input = new File("testfiles/" + inputFilename);
-    		FitsOutput fitsOut = fits.examine(input);
-        	fitsOut.addStandardCombinedFormat();
-    		fitsOut.saveToDisk(outputFilename);
-    	}
-	}
+        String inputFilename = "LibreODT-hasTables.odt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
+    @Test
+    public void testOpenOfficeDocUnparseableDate() throws Exception {
+
+        String inputFilename = "UnparseableDate.odt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testWordDocxOutput() throws Exception {
+
+        String inputFilename = "Word_has_index.docx";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testWordDocxPasswordProtected() throws Exception {
+
+        String inputFilename = "WordPasswordProtected.docx";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testWordDocmOutput() throws Exception {
+
+        String inputFilename = "Document_Has_Form_Controls.docm";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testEpubOutput() throws Exception {
+
+        // process multiple files to examine different types of output
+        String[] inputFilenames = {
+            "Winnie-the-Pooh-protected.epub",
+            "GeographyofBliss_oneChapter.epub",
+            "aliceDynamic_images_metadata_tableOfContents.epub",
+            "epub30-test-font-embedding-obfuscation.epub",
+            "Calibre_hasTable_of_Contents.epub"
+        };
+
+        for (String inputFilename : inputFilenames) {
+
+            String outputFilename = "test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX;
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = fits.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk(outputFilename);
+        }
+    }
+
+    @Test
+    public void testWPDOutput() throws Exception {
+
+        // process multiple files to examine different types of output
+        String[] inputFilenames = {"WordPerfect6-7.wpd", "WordPerfect4_2.wp", "WordPerfect5_0.wp", "WordPerfect5_2.wp"};
+        //    			"WordPerfectCompoundFile.wpd"};  // (not identified as a WordPerfect document)
+
+        for (String inputFilename : inputFilenames) {
+            String outputFilename = "test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX;
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = fits.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk(outputFilename);
+        }
+    }
+
+    @Test
+    public void testRtfOutput() throws Exception {
+
+        String inputFilename = "TestDoc.rtf";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testRtfWithCompanyOutput() throws Exception {
+
+        String inputFilename = "Doc2.rtf";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testPdf() throws Exception {
+
+        String[] inputFilenames = {
+            "PDF_embedded_resources.pdf", "HasChangeHistory.pdf", "PDF_eng.pdf", "HasAnnotations.pdf"
+        };
+
+        for (String inputFilename : inputFilenames) {
+            String outputFilename = "test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX;
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = fits.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk(outputFilename);
+        }
+    }
+
+    @Test
+    public void testPdfA() throws Exception {
+
+        String[] inputFilenames = {
+            "PDFa_equations.pdf",
+            "PDFa_multiplefonts.pdf",
+            "PDFa_has_form.pdf",
+            "PDFa_has_table_of_contents.pdf",
+            "PDFa_has_tables.pdf",
+            "PDFA_Document with tables.pdf",
+            "PDFa_embedded_resources.pdf"
+        };
+
+        for (String inputFilename : inputFilenames) {
+            String outputFilename = "test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX;
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = fits.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk(outputFilename);
+        }
+    }
+
+    @Test
+    public void testPdfX() throws Exception {
+
+        String[] inputFilenames = {
+            "altona_technical_1v2_x3_has_annotations.pdf",
+            "Book_pdfx1a.pdf", // converts to PDF/A
+            "PDFx3.pdf"
+        }; // converts to PDF/A
+
+        for (String inputFilename : inputFilenames) {
+            String outputFilename = "test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX;
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = fits.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk(outputFilename);
+        }
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/DocMDXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/DocMDXmlUnitTest.java
@@ -1,715 +1,655 @@
-/* 
+/*
  * Copyright 2016 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These tests compare actual FITS output with expected output on various word processing documents.
  * These tests should be run with &lt;display-tool-output&gt;false&lt;/display-tool-output&gt; in fits.xml.
- * 
+ *
  * @author dan179
  */
 public class DocMDXmlUnitTest extends AbstractXmlUnitTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
-
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-	
-	@Test
-	public void testWordDocUrlEmbeddedResources() throws Exception {
-
-    	String inputFilename = "Word2003_has_URLs_has_embedded_resources.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocGraphics() throws Exception {
-
-    	String inputFilename = "Word2003_many_graphics.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocPasswordProtected() throws Exception {
-
-    	String inputFilename = "Word2003PasswordProtected.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDoc2011() throws Exception {
-
-    	String inputFilename = "Word2011_Has_Outline.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocLibreOffice() throws Exception {
-
-    	String inputFilename = "LibreOffice.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocHyperlinks() throws Exception {
-
-    	String inputFilename = "Word2003_has_table_of_contents.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocPasswordAndEncrypted() throws Exception {
-
-    	String inputFilename = "Word_protected_encrypted.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocMacMSWord() throws Exception {
-
-    	String inputFilename = "MacMSWORD_4-5.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocV2() throws Exception {
-
-    	String inputFilename = "NEWSSLID_Word2_0.DOC";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testOpenOfficeDoc() throws Exception {
-
-    	String inputFilename = "LibreODT-Ur-doc.odt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testOpenOfficeDocEmbeddedResources() throws Exception {
-
-    	String inputFilename = "LibreODTwFormulas.odt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testOpenOfficeDocHasTables() throws Exception {
-
-    	String inputFilename = "LibreODT-hasTables.odt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testOpenOfficeDocUnparseableDate() throws Exception {
-
-    	String inputFilename = "UnparseableDate.odt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testWordDocxOutput() throws Exception {
-
-    	String inputFilename = "Word_has_index.docx";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-
-	@Test
-	public void testXlsxOutput() throws Exception {
-		String inputFilename = "DH43D5TQESXBZ8W.xlsx";
-		File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-
-	@Test
-	public void testXlsOutput() throws Exception {
-		String inputFilename = "valid.xls";
-		File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-
-	@Test
-	public void testPptxOutput() throws Exception {
-		String inputFilename = "samplepptx.pptx";
-		File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-
-	@Test
-	public void testPptOutput() throws Exception {
-		String inputFilename = "ConleyPPLec.ppt";
-		File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	/*
-	 * This output of this document produces what looks to be invalid output.
-	 */
-	@Test
-	public void testWordDocxPasswordProtected() throws Exception {
-
-    	String inputFilename = "WordPasswordProtected.docx";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testWordDocmOutput() throws Exception {
-
-    	String inputFilename = "Document_Has_Form_Controls.docm";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testEpubOutput() throws Exception {
-
-    	// process multiple files to examine different types of output
-    	String[] inputFilenames = {"Winnie-the-Pooh-protected.epub", // not properly identified as epub mimetype
-    			"GeographyofBliss_oneChapter.epub",
-    			"aliceDynamic_images_metadata_tableOfContents.epub", // not properly identified as epub mimetype
-    			"epub30-test-font-embedding-obfuscation.epub",
-    			"Calibre_hasTable_of_Contents.epub"};
-
-    	for (String inputFilename : inputFilenames) {
-    		
-        	File input = new File("testfiles/" + inputFilename);
-        	FitsOutput fitsOut = fits.examine(input);
-        	fitsOut.addStandardCombinedFormat();
-        	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-        	
-    		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-    		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-    		// Read in the expected XML file
-    		Scanner scan = new Scanner(new File(
-    				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-    		String expectedXmlStr = scan.
-    				useDelimiter("\\Z").next();
-    		scan.close();
-
-    		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-    	}
-	}
-	
-	@Test
-	public void testWPDOutput() throws Exception {
-    	
-    	// process multiple files to examine different types of output
-    	String[] inputFilenames = { //"WordPerfect6-7.wpd",
-    			"WordPerfect4_2.wp",
-    			"WordPerfect5_0.wp",
-    			"WordPerfect5_2.wp" };
-//    			"WordPerfectCompoundFile.wpd"};  // (not identified as a WordPerfect document)
-
-    	for (String inputFilename : inputFilenames) {
-        	File input = new File("testfiles/" + inputFilename);
-        	FitsOutput fitsOut = fits.examine(input);
-        	fitsOut.addStandardCombinedFormat();
-        	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-        	
-    		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-    		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-    		// Read in the expected XML file
-    		Scanner scan = new Scanner(new File(
-    				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-    		String expectedXmlStr = scan.
-    				useDelimiter("\\Z").next();
-    		scan.close();
-
-    		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-    	}
-	}
-	
-	@Test
-	public void testRtfOutput() throws Exception {
-
-    	String inputFilename = "TestDoc.rtf";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testRtfWithCompanyOutput() throws Exception {
-
-    	String inputFilename = "Doc2.rtf";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testPdf() throws Exception {
-		
-    	String[] inputFilenames = {"PDF_embedded_resources.pdf",
-    			"HasChangeHistory.pdf",
-    			"PDF_eng.pdf",
-    			"HasAnnotations.pdf"};
-
-    	for (String inputFilename : inputFilenames) {
-    		File input = new File("testfiles/" + inputFilename);
-	    	FitsOutput fitsOut = fits.examine(input);
-	    	fitsOut.addStandardCombinedFormat();
-	    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-	    	
-			XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-			String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-	
-			// Read in the expected XML file
-			Scanner scan = new Scanner(new File(
-					"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-			String expectedXmlStr = scan.
-					useDelimiter("\\Z").next();
-			scan.close();
-	
-			testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-    	}
-	}
-    
-	@Test
-	public void testPdfA() throws Exception {
-		
-    	String[] inputFilenames = {"PDFa_equations.pdf",
-    			"PDFa_multiplefonts.pdf",
-    			"PDFa_has_form.pdf",
-    			"PDFa_has_table_of_contents.pdf",
-    			"PDFa_has_tables.pdf",
-    			"PDFA_Document with tables.pdf",
-    			"PDFa_embedded_resources.pdf"};
-
-    	for (String inputFilename : inputFilenames) {
-    		File input = new File("testfiles/" + inputFilename);
-	    	FitsOutput fitsOut = fits.examine(input);
-	    	fitsOut.addStandardCombinedFormat();
-	    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-	    	
-			XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-			String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-	
-			// Read in the expected XML file
-			Scanner scan = new Scanner(new File(
-					"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-			String expectedXmlStr = scan.
-					useDelimiter("\\Z").next();
-			scan.close();
-	
-			testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-    	}
-	}
-    
-	@Test
-	public void testPdfX() throws Exception {
-		
-    	String[] inputFilenames = {
-    			"altona_technical_1v2_x3_has_annotations.pdf",
-    			"Book_pdfx1a.pdf",
-    			"PDFx3.pdf"
-    			};
-
-    	for (String inputFilename : inputFilenames) {
-    		File input = new File("testfiles/" + inputFilename);
-	    	FitsOutput fitsOut = fits.examine(input);
-        	fitsOut.addStandardCombinedFormat();
-	    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-	    	
-			XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-			String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-	
-			// Read in the expected XML file
-			Scanner scan = new Scanner(new File(
-					"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-			String expectedXmlStr = scan.
-					useDelimiter("\\Z").next();
-			scan.close();
-	
-			testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-    	}
-	}
-
-	@Test
-	public void includeAllToolOutputWhenConsolidationDisabled() throws Exception {
-		String inputFilename = "PDFa_has_table_of_contents.pdf";
-		File input = new File("testfiles/" + inputFilename);
-		File fitsConfigFile = new File("testfiles/properties/fits-no-consolidation.xml");
-
-		Fits fits = new Fits(null, fitsConfigFile);
-		FitsOutput fitsOut = fits.examine(input);
-
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + "_no_consolidation_ActualOutput.xml");
-
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + "_no_consolidation_ExpectedOutput.xml"));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
 
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
+
+    @Test
+    public void testWordDocUrlEmbeddedResources() throws Exception {
+
+        String inputFilename = "Word2003_has_URLs_has_embedded_resources.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocGraphics() throws Exception {
+
+        String inputFilename = "Word2003_many_graphics.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocPasswordProtected() throws Exception {
+
+        String inputFilename = "Word2003PasswordProtected.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDoc2011() throws Exception {
+
+        String inputFilename = "Word2011_Has_Outline.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocLibreOffice() throws Exception {
+
+        String inputFilename = "LibreOffice.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocHyperlinks() throws Exception {
+
+        String inputFilename = "Word2003_has_table_of_contents.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocPasswordAndEncrypted() throws Exception {
+
+        String inputFilename = "Word_protected_encrypted.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocMacMSWord() throws Exception {
+
+        String inputFilename = "MacMSWORD_4-5.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocV2() throws Exception {
+
+        String inputFilename = "NEWSSLID_Word2_0.DOC";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testOpenOfficeDoc() throws Exception {
+
+        String inputFilename = "LibreODT-Ur-doc.odt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testOpenOfficeDocEmbeddedResources() throws Exception {
+
+        String inputFilename = "LibreODTwFormulas.odt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testOpenOfficeDocHasTables() throws Exception {
+
+        String inputFilename = "LibreODT-hasTables.odt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testOpenOfficeDocUnparseableDate() throws Exception {
+
+        String inputFilename = "UnparseableDate.odt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocxOutput() throws Exception {
+
+        String inputFilename = "Word_has_index.docx";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testXlsxOutput() throws Exception {
+        String inputFilename = "DH43D5TQESXBZ8W.xlsx";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testXlsOutput() throws Exception {
+        String inputFilename = "valid.xls";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testPptxOutput() throws Exception {
+        String inputFilename = "samplepptx.pptx";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testPptOutput() throws Exception {
+        String inputFilename = "ConleyPPLec.ppt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    /*
+     * This output of this document produces what looks to be invalid output.
+     */
+    @Test
+    public void testWordDocxPasswordProtected() throws Exception {
+
+        String inputFilename = "WordPasswordProtected.docx";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocmOutput() throws Exception {
+
+        String inputFilename = "Document_Has_Form_Controls.docm";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testEpubOutput() throws Exception {
+
+        // process multiple files to examine different types of output
+        String[] inputFilenames = {
+            "Winnie-the-Pooh-protected.epub", // not properly identified as epub mimetype
+            "GeographyofBliss_oneChapter.epub",
+            "aliceDynamic_images_metadata_tableOfContents.epub", // not properly identified as epub mimetype
+            "epub30-test-font-embedding-obfuscation.epub",
+            "Calibre_hasTable_of_Contents.epub"
+        };
+
+        for (String inputFilename : inputFilenames) {
+
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = fits.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+            XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+            String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+            // Read in the expected XML file
+            Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+            String expectedXmlStr = scan.useDelimiter("\\Z").next();
+            scan.close();
+
+            testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+        }
+    }
+
+    @Test
+    public void testWPDOutput() throws Exception {
+
+        // process multiple files to examine different types of output
+        String[] inputFilenames = { // "WordPerfect6-7.wpd",
+            "WordPerfect4_2.wp", "WordPerfect5_0.wp", "WordPerfect5_2.wp"
+        };
+        //    			"WordPerfectCompoundFile.wpd"};  // (not identified as a WordPerfect document)
+
+        for (String inputFilename : inputFilenames) {
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = fits.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+            XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+            String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+            // Read in the expected XML file
+            Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+            String expectedXmlStr = scan.useDelimiter("\\Z").next();
+            scan.close();
+
+            testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+        }
+    }
+
+    @Test
+    public void testRtfOutput() throws Exception {
+
+        String inputFilename = "TestDoc.rtf";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testRtfWithCompanyOutput() throws Exception {
+
+        String inputFilename = "Doc2.rtf";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testPdf() throws Exception {
+
+        String[] inputFilenames = {
+            "PDF_embedded_resources.pdf", "HasChangeHistory.pdf", "PDF_eng.pdf", "HasAnnotations.pdf"
+        };
+
+        for (String inputFilename : inputFilenames) {
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = fits.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+            XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+            String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+            // Read in the expected XML file
+            Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+            String expectedXmlStr = scan.useDelimiter("\\Z").next();
+            scan.close();
+
+            testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+        }
+    }
+
+    @Test
+    public void testPdfA() throws Exception {
+
+        String[] inputFilenames = {
+            "PDFa_equations.pdf",
+            "PDFa_multiplefonts.pdf",
+            "PDFa_has_form.pdf",
+            "PDFa_has_table_of_contents.pdf",
+            "PDFa_has_tables.pdf",
+            "PDFA_Document with tables.pdf",
+            "PDFa_embedded_resources.pdf"
+        };
+
+        for (String inputFilename : inputFilenames) {
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = fits.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+            XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+            String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+            // Read in the expected XML file
+            Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+            String expectedXmlStr = scan.useDelimiter("\\Z").next();
+            scan.close();
+
+            testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+        }
+    }
+
+    @Test
+    public void testPdfX() throws Exception {
+
+        String[] inputFilenames = {"altona_technical_1v2_x3_has_annotations.pdf", "Book_pdfx1a.pdf", "PDFx3.pdf"};
+
+        for (String inputFilename : inputFilenames) {
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = fits.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+            XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+            String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+            // Read in the expected XML file
+            Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+            String expectedXmlStr = scan.useDelimiter("\\Z").next();
+            scan.close();
+
+            testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+        }
+    }
+
+    @Test
+    public void includeAllToolOutputWhenConsolidationDisabled() throws Exception {
+        String inputFilename = "PDFa_has_table_of_contents.pdf";
+        File input = new File("testfiles/" + inputFilename);
+        File fitsConfigFile = new File("testfiles/properties/fits-no-consolidation.xml");
+
+        Fits fits = new Fits(null, fitsConfigFile);
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + "_no_consolidation_ActualOutput.xml");
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan =
+                new Scanner(new File("testfiles/output/" + inputFilename + "_no_consolidation_ExpectedOutput.xml"));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/DpxTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/DpxTest.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * Copyright 2022 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,52 +20,48 @@ package edu.harvard.hul.ois.fits.junit;
 
 import static org.junit.Assert.fail;
 
-import java.io.File;
-import java.util.List;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.FitsOutput;
 import edu.harvard.hul.ois.fits.identity.FitsIdentity;
 import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
-
+import java.io.File;
+import java.util.List;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class DpxTest extends AbstractLoggingTest {
 
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-	@Test
-	public void testDpxFormatDetection() throws Exception {
-		String inputFilename = "00266.dpx";
-		File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    @Test
+    public void testDpxFormatDetection() throws Exception {
+        String inputFilename = "00266.dpx";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
 
-		List <FitsIdentity> identities = fitsOut.getIdentities();
+        List<FitsIdentity> identities = fitsOut.getIdentities();
 
-		for (FitsIdentity identity : identities) {
-			if (!identity.getMimetype().contains("image/x-dpx")) {
-				fail(inputFilename + " should be identified as a DPX file with mimetype of image/x-dpx");
-			}
-		}
-	}
-
+        for (FitsIdentity identity : identities) {
+            if (!identity.getMimetype().contains("image/x-dpx")) {
+                fail(inputFilename + " should be identified as a DPX file with mimetype of image/x-dpx");
+            }
+        }
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/DpxXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/DpxXmlUnitTest.java
@@ -1,119 +1,111 @@
-/* 
+/*
  * Copyright 2022 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
-
 public class DpxXmlUnitTest extends AbstractXmlUnitTest {
 
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-	@Test
-	public void testDpxOutput() throws Exception {
-		String inputFilename = "00266.dpx";
-		File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+    @Test
+    public void testDpxOutput() throws Exception {
+        String inputFilename = "00266.dpx";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-	@Test
-	public void testDpxStandardCombinedOutput() throws Exception {
-		String inputFilename = "00266.dpx";
-		File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + "-standard-combined" + ACTUAL_OUTPUT_FILE_SUFFIX);
+    @Test
+    public void testDpxStandardCombinedOutput() throws Exception {
+        String inputFilename = "00266.dpx";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + "-standard-combined" + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + "-standard-combined" + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        // Read in the expected XML file
+        Scanner scan = new Scanner(
+                new File("testfiles/output/" + inputFilename + "-standard-combined" + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-	@Test
-	public void testDpxStandardOnlyOutput() throws Exception {
-		String inputFilename = "00266.dpx";
-		File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
+    @Test
+    public void testDpxStandardOnlyOutput() throws Exception {
+        String inputFilename = "00266.dpx";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
 
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-		Fits.outputStandardSchemaXml(fitsOut, out);
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + "-standard-only" + ACTUAL_OUTPUT_FILE_SUFFIX);
+        Fits.outputStandardSchemaXml(fitsOut, out);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + "-standard-only" + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		String actualXmlStr = new String(out.toByteArray(),"UTF-8");
+        String actualXmlStr = new String(out.toByteArray(), "UTF-8");
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + "-standard-only" + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        // Read in the expected XML file
+        Scanner scan = new Scanner(
+                new File("testfiles/output/" + inputFilename + "-standard-only" + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/EbucoreParseChannelPositionTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/EbucoreParseChannelPositionTest.java
@@ -30,253 +30,239 @@ package edu.harvard.hul.ois.fits.junit;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
 
-import java.util.List;
-
-import org.junit.Test;
-
 import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import edu.harvard.hul.ois.fits.tools.mediainfo.ChannelPositionParser;
 import edu.harvard.hul.ois.fits.tools.mediainfo.ChannelPositionWrapper;
 import edu.harvard.hul.ois.ots.schemas.XmlContent.XmlContentException;
+import java.util.List;
+import org.junit.Test;
 
 public class EbucoreParseChannelPositionTest extends AbstractLoggingTest {
-	
-	// Taken and revised from a MediaInfo header file
-	private static final String[] DTS_ChannelPositions =
-	{
-	    "Front: C",
-	    "Front: C C",
-	    "Front: L R",
-	    "Front: L R",
-	    "Front: L R",
-	    "Front: L C R",
-	    "Front: L R, Back: C",
-	    "Front: L C R, Back: C",
-	    "Front: L R, Side: L R",
-	    "Front: L C R, Side: L R",
-	    "Front: L C C R, Side: L R",
-	    "Front: L C R, Side: L R",
-	    "Front: L R, Side: L R, Back: L R",
-	    "Front: L C R, Side: L R, Back: L R",
-	    "Front: L R, Side: L R, Back: L C C R",
-	    "Front: L C R, Side: L R, Back: L C R"
-	};
-	
-	// Taken and revised from a MediaInfo header file	
-	private static final String[] MpegTs_DtsNeural_ChannelPositions_2 =
-	{
-		"Front: L R, LFE",
-		"Front: L C R, LFE",
-		"Front: L R, Side: L R, LFE",
-		"Front: L C R, Side: L R, LFE",
-		"Front: L C R, Side: L R, Back: C, LFE",
-		"Front: L C R, Side: L R, Back: L R, LFE",
-		"Front: L R, Side: L R, Back: C, LFE",
-		"Front: L R, Side: L R, Back: L R, LFE",
-	};
-	
-	@Test
-	public void testParse() throws Exception {
-		
-		ChannelPositionParser app = new ChannelPositionParser();
-		
-		String channelsStr = "Front: L C R, Side: L R, LFE";
 
-		List <ChannelPositionWrapper>channelList = app.getChannelsFromString(channelsStr);
-		
-		// Verify we have 6 channels
-		assertEquals(channelList.size(), 6);
-		
-		// Channel number 1 Left Front	 	X: -100		Y: 0
-		// Channel number 2 Center Front	X: 0 	  	Y: 0
-		// Channel number 3 Right Front	 	X: 100 	  	Y: 0
-		// Channel number 4 Left Side	 	X: -100 	Y: 100
-		// Channel number 5 Right Side	 	X: 100 	  	Y: 100
-		// Channel number 6  LFE	 		X: 0 	  	Y: 0
-		ChannelPositionWrapper pos_1 = channelList.get(0);
-		ChannelPositionWrapper pos_2 = channelList.get(1);
-		ChannelPositionWrapper pos_3 = channelList.get(2);
-		ChannelPositionWrapper pos_4 = channelList.get(3);
-		ChannelPositionWrapper pos_5 = channelList.get(4);
-		ChannelPositionWrapper pos_6 = channelList.get(5);
-		
-		assertEquals(pos_1.getXpos(), -100);
-		assertEquals(pos_1.getYpos(), 0);
-		
-		assertEquals(pos_2.getXpos(), 0);
-		assertEquals(pos_2.getYpos(), 0);
-		
-		assertEquals(pos_3.getXpos(), 100);
-		assertEquals(pos_3.getYpos(), 0);
-		
-		assertEquals(pos_4.getXpos(), -100);
-		assertEquals(pos_4.getYpos(), 100);
-		
-		assertEquals(pos_5.getXpos(), 100);
-		assertEquals(pos_5.getYpos(), 100);
-		
-		assertEquals(pos_6.getXpos(), 0);
-		assertEquals(pos_6.getYpos(), 0);
-		
-		
-//		for(ChannelPositionWrapper channel : channelList) {
-//			System.out.println("Channel number " + 
-//					(channelList.indexOf(channel) +1) + " " + 
-//					channel.getName() + "\t" +
-//					" X: " + channel.getXpos() + " \t " +
-//					" Y: " + channel.getYpos() );
-//		}
+    // Taken and revised from a MediaInfo header file
+    private static final String[] DTS_ChannelPositions = {
+        "Front: C",
+        "Front: C C",
+        "Front: L R",
+        "Front: L R",
+        "Front: L R",
+        "Front: L C R",
+        "Front: L R, Back: C",
+        "Front: L C R, Back: C",
+        "Front: L R, Side: L R",
+        "Front: L C R, Side: L R",
+        "Front: L C C R, Side: L R",
+        "Front: L C R, Side: L R",
+        "Front: L R, Side: L R, Back: L R",
+        "Front: L C R, Side: L R, Back: L R",
+        "Front: L R, Side: L R, Back: L C C R",
+        "Front: L C R, Side: L R, Back: L C R"
+    };
 
-	}
-	
-	@Test
-	public void testParse_2() throws Exception {
-		
-		ChannelPositionParser app = new ChannelPositionParser();
-		
-		String channelsStr = "Front: L R";
+    // Taken and revised from a MediaInfo header file
+    private static final String[] MpegTs_DtsNeural_ChannelPositions_2 = {
+        "Front: L R, LFE",
+        "Front: L C R, LFE",
+        "Front: L R, Side: L R, LFE",
+        "Front: L C R, Side: L R, LFE",
+        "Front: L C R, Side: L R, Back: C, LFE",
+        "Front: L C R, Side: L R, Back: L R, LFE",
+        "Front: L R, Side: L R, Back: C, LFE",
+        "Front: L R, Side: L R, Back: L R, LFE",
+    };
 
-		List <ChannelPositionWrapper>channelList = app.getChannelsFromString(channelsStr);
+    @Test
+    public void testParse() throws Exception {
 
-		// Verify we have 2 channels
-		assertEquals(channelList.size(), 2);
-		
-		//Channel number 1 Left Front	 X: -100 	  Y: 0
-		//Channel number 2 Right Front	 X: 100 	  Y: 0
-		ChannelPositionWrapper pos_1 = channelList.get(0);
-		ChannelPositionWrapper pos_2 = channelList.get(1);	
-		
-		assertEquals(pos_1.getXpos(), -100);
-		assertEquals(pos_1.getYpos(), 0);
-		
-		assertEquals(pos_2.getXpos(), 100);
-		assertEquals(pos_2.getYpos(), 0);		
-		
+        ChannelPositionParser app = new ChannelPositionParser();
 
-//		for(ChannelPositionWrapper channel : channelList) {
-//			System.out.println("Channel number " + 
-//					(channelList.indexOf(channel) +1) + " " + 
-//					channel.getName() + "\t" +
-//					" X: " + channel.getXpos() + " \t " +
-//					" Y: " + channel.getYpos() );
-//		}
+        String channelsStr = "Front: L C R, Side: L R, LFE";
 
-	}	
-	
-	@Test  
-	public void testParseMediaInfoList() throws Exception {
+        List<ChannelPositionWrapper> channelList = app.getChannelsFromString(channelsStr);
 
-		ChannelPositionParser app = new ChannelPositionParser();
-		
-//		System.out.println("\n\nDTS_ChannelPositions");
-//		System.out.println("========================");		
+        // Verify we have 6 channels
+        assertEquals(channelList.size(), 6);
 
-		for (String position : DTS_ChannelPositions) {
+        // Channel number 1 Left Front	 	X: -100		Y: 0
+        // Channel number 2 Center Front	X: 0 	  	Y: 0
+        // Channel number 3 Right Front	 	X: 100 	  	Y: 0
+        // Channel number 4 Left Side	 	X: -100 	Y: 100
+        // Channel number 5 Right Side	 	X: 100 	  	Y: 100
+        // Channel number 6  LFE	 		X: 0 	  	Y: 0
+        ChannelPositionWrapper pos_1 = channelList.get(0);
+        ChannelPositionWrapper pos_2 = channelList.get(1);
+        ChannelPositionWrapper pos_3 = channelList.get(2);
+        ChannelPositionWrapper pos_4 = channelList.get(3);
+        ChannelPositionWrapper pos_5 = channelList.get(4);
+        ChannelPositionWrapper pos_6 = channelList.get(5);
 
-//			System.out.println("\n-- " + position + " -- ");
+        assertEquals(pos_1.getXpos(), -100);
+        assertEquals(pos_1.getYpos(), 0);
 
-			List <ChannelPositionWrapper>channelList = app.getChannelsFromString(position);
-			for(ChannelPositionWrapper channel : channelList) {
-//				System.out.println("Channel number " + 
-//						(channelList.indexOf(channel) +1) + " " + 
-//						channel.getName() + "\t" +
-//						" X: " + channel.getXpos() + " \t " +
-//						" Y: " + channel.getYpos() );
-			}		
+        assertEquals(pos_2.getXpos(), 0);
+        assertEquals(pos_2.getYpos(), 0);
 
-		}
+        assertEquals(pos_3.getXpos(), 100);
+        assertEquals(pos_3.getYpos(), 0);
 
-	}
-	
-	@Test
-	public void testParseMediaInfoList_2() throws Exception {
-		
-		ChannelPositionParser app = new ChannelPositionParser();
-		
-//		System.out.println("\n\nMpegTs_DtsNeural_ChannelPositions_2");
-//		System.out.println("=======================================");			
-		
-		// MpegTs_DtsNeural_ChannelPositions_2
-		for (String position : MpegTs_DtsNeural_ChannelPositions_2) {
+        assertEquals(pos_4.getXpos(), -100);
+        assertEquals(pos_4.getYpos(), 100);
 
-//			System.out.println("\n-- " + position + " -- ");
+        assertEquals(pos_5.getXpos(), 100);
+        assertEquals(pos_5.getYpos(), 100);
 
-			List <ChannelPositionWrapper>channelList = app.getChannelsFromString(position);
-			for(ChannelPositionWrapper channel : channelList) {
-//				System.out.println("Channel number " + 
-//						(channelList.indexOf(channel) +1) + " " + 
-//						channel.getName() + "\t" +
-//						" X: " + channel.getXpos() + " \t " +
-//						" Y: " + channel.getYpos() );
-			}		
+        assertEquals(pos_6.getXpos(), 0);
+        assertEquals(pos_6.getYpos(), 0);
 
-		}
-	}
+        //		for(ChannelPositionWrapper channel : channelList) {
+        //			System.out.println("Channel number " +
+        //					(channelList.indexOf(channel) +1) + " " +
+        //					channel.getName() + "\t" +
+        //					" X: " + channel.getXpos() + " \t " +
+        //					" Y: " + channel.getYpos() );
+        //		}
 
+    }
 
-	@Test  
-	public void testParseInvalidChannelPosition() throws Exception {
+    @Test
+    public void testParse_2() throws Exception {
 
-		ChannelPositionParser app = new ChannelPositionParser();
+        ChannelPositionParser app = new ChannelPositionParser();
 
-		// --------------------------------------------------------------------
-		// Invalid Channel Positions
-		// --------------------------------------------------------------------
+        String channelsStr = "Front: L R";
 
-		// TODO:
-		// NOTE: Front A and Front B is invalid, but Front C is Valid ...
-		// What should I do?
-		String channelsStr = "Front: A B C, Side: L R, LFE";		
-//		System.out.println("\n\n-- " + channelsStr + " -- ");	
-		List<ChannelPositionWrapper> channelList;
-		try {
-			channelList = app.getChannelsFromString(channelsStr);
-			for(ChannelPositionWrapper channel : channelList ) {
-//				System.out.println("Channel number " + 
-//						(channelList.indexOf(channel) +1) + " " + 
-//						channel.getName() + "\t" +
-//						" X: " + channel.getXpos() + " \t " +
-//						" Y: " + channel.getYpos() );
-			}
-			fail("An exception should have occurred.");
-		} catch ( XmlContentException e) {
-			//e.printStackTrace();
-			assertEquals( "A is not a valid position ", e.getMessage() );
-		}
+        List<ChannelPositionWrapper> channelList = app.getChannelsFromString(channelsStr);
 
+        // Verify we have 2 channels
+        assertEquals(channelList.size(), 2);
 
-		// Bogus: is an invalid location, so the below throws an exception
-		channelsStr = "Front: L C R, Bogus: L R, LFE";		
-//		System.out.println("\n\n-- " + channelsStr + " -- ");	
-		try {
-			channelList = app.getChannelsFromString(channelsStr);
-			fail("An exception should have occurred.");
-		} catch ( XmlContentException e) {
-			//e.printStackTrace();
-			assertEquals(" Bogus: L R Contains an invalid position identifier", e.getMessage());
-		}
+        // Channel number 1 Left Front	 X: -100 	  Y: 0
+        // Channel number 2 Right Front	 X: 100 	  Y: 0
+        ChannelPositionWrapper pos_1 = channelList.get(0);
+        ChannelPositionWrapper pos_2 = channelList.get(1);
 
-		//
-		//
-		// TODO: The below creates X/Y Position of 0, 0
-		//
-		// These are default values, should we detect an error ???
+        assertEquals(pos_1.getXpos(), -100);
+        assertEquals(pos_1.getYpos(), 0);
 
-		// Invalid Channel String, so the below throws an exception
-		channelsStr = "A Bogus Channel Position";		
-//		System.out.println("\n\n-- " + channelsStr + " -- ");
-		channelList = null;
-		try {
-			channelList = app.getChannelsFromString(channelsStr);
-		} catch ( XmlContentException e) {
-			fail("No Exception should occur. Default values will be set.");
-		}
-		if (channelList == null || channelList.isEmpty()) {
-			//System.out.println(channelsStr + " produces an empty channel list");
-			fail("Default values should be be set.");			
-		} 	
+        assertEquals(pos_2.getXpos(), 100);
+        assertEquals(pos_2.getYpos(), 0);
 
-	}
+        //		for(ChannelPositionWrapper channel : channelList) {
+        //			System.out.println("Channel number " +
+        //					(channelList.indexOf(channel) +1) + " " +
+        //					channel.getName() + "\t" +
+        //					" X: " + channel.getXpos() + " \t " +
+        //					" Y: " + channel.getYpos() );
+        //		}
 
+    }
 
+    @Test
+    public void testParseMediaInfoList() throws Exception {
+
+        ChannelPositionParser app = new ChannelPositionParser();
+
+        //		System.out.println("\n\nDTS_ChannelPositions");
+        //		System.out.println("========================");
+
+        for (String position : DTS_ChannelPositions) {
+
+            //			System.out.println("\n-- " + position + " -- ");
+
+            List<ChannelPositionWrapper> channelList = app.getChannelsFromString(position);
+            for (ChannelPositionWrapper channel : channelList) {
+                //				System.out.println("Channel number " +
+                //						(channelList.indexOf(channel) +1) + " " +
+                //						channel.getName() + "\t" +
+                //						" X: " + channel.getXpos() + " \t " +
+                //						" Y: " + channel.getYpos() );
+            }
+        }
+    }
+
+    @Test
+    public void testParseMediaInfoList_2() throws Exception {
+
+        ChannelPositionParser app = new ChannelPositionParser();
+
+        //		System.out.println("\n\nMpegTs_DtsNeural_ChannelPositions_2");
+        //		System.out.println("=======================================");
+
+        // MpegTs_DtsNeural_ChannelPositions_2
+        for (String position : MpegTs_DtsNeural_ChannelPositions_2) {
+
+            //			System.out.println("\n-- " + position + " -- ");
+
+            List<ChannelPositionWrapper> channelList = app.getChannelsFromString(position);
+            for (ChannelPositionWrapper channel : channelList) {
+                //				System.out.println("Channel number " +
+                //						(channelList.indexOf(channel) +1) + " " +
+                //						channel.getName() + "\t" +
+                //						" X: " + channel.getXpos() + " \t " +
+                //						" Y: " + channel.getYpos() );
+            }
+        }
+    }
+
+    @Test
+    public void testParseInvalidChannelPosition() throws Exception {
+
+        ChannelPositionParser app = new ChannelPositionParser();
+
+        // --------------------------------------------------------------------
+        // Invalid Channel Positions
+        // --------------------------------------------------------------------
+
+        // TODO:
+        // NOTE: Front A and Front B is invalid, but Front C is Valid ...
+        // What should I do?
+        String channelsStr = "Front: A B C, Side: L R, LFE";
+        //		System.out.println("\n\n-- " + channelsStr + " -- ");
+        List<ChannelPositionWrapper> channelList;
+        try {
+            channelList = app.getChannelsFromString(channelsStr);
+            for (ChannelPositionWrapper channel : channelList) {
+                //				System.out.println("Channel number " +
+                //						(channelList.indexOf(channel) +1) + " " +
+                //						channel.getName() + "\t" +
+                //						" X: " + channel.getXpos() + " \t " +
+                //						" Y: " + channel.getYpos() );
+            }
+            fail("An exception should have occurred.");
+        } catch (XmlContentException e) {
+            // e.printStackTrace();
+            assertEquals("A is not a valid position ", e.getMessage());
+        }
+
+        // Bogus: is an invalid location, so the below throws an exception
+        channelsStr = "Front: L C R, Bogus: L R, LFE";
+        //		System.out.println("\n\n-- " + channelsStr + " -- ");
+        try {
+            channelList = app.getChannelsFromString(channelsStr);
+            fail("An exception should have occurred.");
+        } catch (XmlContentException e) {
+            // e.printStackTrace();
+            assertEquals(" Bogus: L R Contains an invalid position identifier", e.getMessage());
+        }
+
+        //
+        //
+        // TODO: The below creates X/Y Position of 0, 0
+        //
+        // These are default values, should we detect an error ???
+
+        // Invalid Channel String, so the below throws an exception
+        channelsStr = "A Bogus Channel Position";
+        //		System.out.println("\n\n-- " + channelsStr + " -- ");
+        channelList = null;
+        try {
+            channelList = app.getChannelsFromString(channelsStr);
+        } catch (XmlContentException e) {
+            fail("No Exception should occur. Default values will be set.");
+        }
+        if (channelList == null || channelList.isEmpty()) {
+            // System.out.println(channelsStr + " produces an empty channel list");
+            fail("Default values should be be set.");
+        }
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/FitsBasicAudioTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/FitsBasicAudioTest.java
@@ -1,51 +1,47 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
-import java.io.File;
-
-import org.junit.Test;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.FitsOutput;
 import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import edu.harvard.hul.ois.fits.tools.Tool;
+import java.io.File;
+import org.junit.Test;
 
 public class FitsBasicAudioTest extends AbstractLoggingTest {
-    
-	@Test
-	public void testFitsAudio () throws Exception {	
-    	Fits fits = new Fits("");
-    	File input = new File("testfiles/test.wav");
-    	
-    	for(Tool t : fits.getToolbelt().getTools()) {
-    		if(t.getToolInfo().getName().equals("Jhove")) {
-    			//t.setEnabled(false);
-    		}
-    		if(t.getToolInfo().getName().equals("Exiftool")) {
-    			//t.setEnabled(false);
-    		}
-    	}
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/fitsBasicAudioTestOutput.xml");
-    	
-	}
 
+    @Test
+    public void testFitsAudio() throws Exception {
+        Fits fits = new Fits("");
+        File input = new File("testfiles/test.wav");
+
+        for (Tool t : fits.getToolbelt().getTools()) {
+            if (t.getToolInfo().getName().equals("Jhove")) {
+                // t.setEnabled(false);
+            }
+            if (t.getToolInfo().getName().equals("Exiftool")) {
+                // t.setEnabled(false);
+            }
+        }
+
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/fitsBasicAudioTestOutput.xml");
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/FitsBasicTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/FitsBasicTest.java
@@ -1,51 +1,47 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
-import java.io.File;
-
-import org.junit.Test;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.FitsOutput;
 import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import edu.harvard.hul.ois.fits.tools.Tool;
+import java.io.File;
+import org.junit.Test;
 
 public class FitsBasicTest extends AbstractLoggingTest {
-    
-	@Test
-	public void testFits() throws Exception {	
-    	Fits fits = new Fits("");
-    	File input = new File("testfiles/test.jp2");
-    	
-    	for(Tool t : fits.getToolbelt().getTools()) {
-    		if(t.getToolInfo().getName().equals("Jhove")) {
-    			//t.setEnabled(false);
-    		}
-    		if(t.getToolInfo().getName().equals("Exiftool")) {
-    			//t.setEnabled(false);
-    		}
-    	}
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/fitsBasicTestOutput.xml");
-    	
-	}
 
+    @Test
+    public void testFits() throws Exception {
+        Fits fits = new Fits("");
+        File input = new File("testfiles/test.jp2");
+
+        for (Tool t : fits.getToolbelt().getTools()) {
+            if (t.getToolInfo().getName().equals("Jhove")) {
+                // t.setEnabled(false);
+            }
+            if (t.getToolInfo().getName().equals("Exiftool")) {
+                // t.setEnabled(false);
+            }
+        }
+
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/fitsBasicTestOutput.xml");
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/FitsBasicVideoTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/FitsBasicVideoTest.java
@@ -1,89 +1,84 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
-import java.io.File;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.FitsOutput;
 import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import edu.harvard.hul.ois.fits.tools.Tool;
+import java.io.File;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class FitsBasicVideoTest extends AbstractLoggingTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-    
-	@Test
-	public void testFitsVideo_AVC() throws Exception {	
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-    	File input = new File("testfiles/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4");
-    	
-    	for(Tool t : fits.getToolbelt().getTools()) {
-    		if(t.getToolInfo().getName().equals("Jhove")) {
-    			//t.setEnabled(false);
-    		}
-    		if(t.getToolInfo().getName().equals("Exiftool")) {
-    			//t.setEnabled(false);
-    		}
-    	}
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/fitsBasicVideoTestOutput.xml");
-    	
-	}
-	
-	@Test
-	public void testFitsVideo_DV() throws Exception {	
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-    	File input = new File("testfiles/FITS-SAMPLE-26.mov");
-    	
-    	for(Tool t : fits.getToolbelt().getTools()) {
-    		if(t.getToolInfo().getName().equals("Jhove")) {
-    			//t.setEnabled(false);
-    		}
-    		if(t.getToolInfo().getName().equals("Exiftool")) {
-    			//t.setEnabled(false);
-    		}
-    	}
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/fitsBasicVideoTestOutput.xml");
-    	
-	}
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
+    @Test
+    public void testFitsVideo_AVC() throws Exception {
+
+        File input = new File("testfiles/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4");
+
+        for (Tool t : fits.getToolbelt().getTools()) {
+            if (t.getToolInfo().getName().equals("Jhove")) {
+                // t.setEnabled(false);
+            }
+            if (t.getToolInfo().getName().equals("Exiftool")) {
+                // t.setEnabled(false);
+            }
+        }
+
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/fitsBasicVideoTestOutput.xml");
+    }
+
+    @Test
+    public void testFitsVideo_DV() throws Exception {
+
+        File input = new File("testfiles/FITS-SAMPLE-26.mov");
+
+        for (Tool t : fits.getToolbelt().getTools()) {
+            if (t.getToolInfo().getName().equals("Jhove")) {
+                // t.setEnabled(false);
+            }
+            if (t.getToolInfo().getName().equals("Exiftool")) {
+                // t.setEnabled(false);
+            }
+        }
+
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/fitsBasicVideoTestOutput.xml");
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/FitsOutputXmlTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/FitsOutputXmlTest.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,13 +20,17 @@ package edu.harvard.hul.ois.fits.junit;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLIdentical;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsMetadataElement;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
+import edu.harvard.hul.ois.fits.tests.IgnoreAttributeValuesDifferenceListener;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.DifferenceListener;
 import org.jdom2.Document;
@@ -39,82 +43,75 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsMetadataElement;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
-import edu.harvard.hul.ois.fits.tests.IgnoreAttributeValuesDifferenceListener;
-
 /*
  * BROKEN TEST
  */
 @Ignore
-@RunWith(value=Parameterized.class)
+@RunWith(value = Parameterized.class)
 public class FitsOutputXmlTest extends AbstractLoggingTest {
-	
+
     private FitsOutput expected;
     private FitsOutput actual;
     private XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-    
+
     public FitsOutputXmlTest() {
-    	super();
+        super();
     }
 
     public FitsOutputXmlTest(FitsOutput expected, FitsOutput value) {
-    	super();
+        super();
         this.expected = expected;
         this.actual = value;
     }
-    
+
     @Parameters
-    public static Collection<FitsOutput[]> data() throws Exception {	
-    	Fits fits = new Fits("");
-    	SAXBuilder builder = new SAXBuilder();
-       List<FitsOutput[]> inputs = new ArrayList<FitsOutput[]>();
-	
-		File inputDir =new File("tests/input");
-		File outputDir =new File("tests/output");
-				
-		for(File input : inputDir.listFiles()) {
-			//skip directories
-			if(input.isDirectory()) {
-				continue;
-			}
-			FitsOutput fitsOut = fits.examine(input);
-			
-			File outputFile = new File(outputDir + File.separator + input.getName()+".xml");
-			if(!outputFile.exists()) {
-				System.err.println("Not Found: "+outputFile.getPath());
-				continue;
-			}
-			Document expectedXml = builder.build(new FileInputStream(outputFile));
-			FitsOutput expectedFits = new FitsOutput(expectedXml);
-			
-			FitsOutput[][] tmp = new FitsOutput[][]{{expectedFits,fitsOut}};
-			inputs.add(tmp[0]);
-		}
+    public static Collection<FitsOutput[]> data() throws Exception {
+        Fits fits = new Fits("");
+        SAXBuilder builder = new SAXBuilder();
+        List<FitsOutput[]> inputs = new ArrayList<FitsOutput[]>();
+
+        File inputDir = new File("tests/input");
+        File outputDir = new File("tests/output");
+
+        for (File input : inputDir.listFiles()) {
+            // skip directories
+            if (input.isDirectory()) {
+                continue;
+            }
+            FitsOutput fitsOut = fits.examine(input);
+
+            File outputFile = new File(outputDir + File.separator + input.getName() + ".xml");
+            if (!outputFile.exists()) {
+                System.err.println("Not Found: " + outputFile.getPath());
+                continue;
+            }
+            Document expectedXml = builder.build(new FileInputStream(outputFile));
+            FitsOutput expectedFits = new FitsOutput(expectedXml);
+
+            FitsOutput[][] tmp = new FitsOutput[][] {{expectedFits, fitsOut}};
+            inputs.add(tmp[0]);
+        }
         return inputs;
     }
-    
-	@Test
-	public void testEquality() throws Exception {	
-		//convert FitsOutput xml doms to strings for the diff	
-		StringWriter sw = new StringWriter();
-		Document expectedDom = expected.getFitsXml();
-		Document actualDom = actual.getFitsXml();
-		serializer.output(actualDom, sw);
-		String actualStr = sw.toString(); 
-		sw = new StringWriter();
-		serializer.output(expectedDom, sw);
-		String expectedStr = sw.toString();
-		
-		//get the file name in case of a failure
-		FitsMetadataElement item = actual.getFileInfoElement("filename");
-	    DifferenceListener myDifferenceListener = new IgnoreAttributeValuesDifferenceListener();
-	    Diff diff = new Diff(expectedStr,actualStr);
-	    diff.overrideDifferenceListener(myDifferenceListener);
 
-	    assertXMLIdentical("Error comparing: "+item.getValue(), diff, true);
-	}
-	
+    @Test
+    public void testEquality() throws Exception {
+        // convert FitsOutput xml doms to strings for the diff
+        StringWriter sw = new StringWriter();
+        Document expectedDom = expected.getFitsXml();
+        Document actualDom = actual.getFitsXml();
+        serializer.output(actualDom, sw);
+        String actualStr = sw.toString();
+        sw = new StringWriter();
+        serializer.output(expectedDom, sw);
+        String expectedStr = sw.toString();
+
+        // get the file name in case of a failure
+        FitsMetadataElement item = actual.getFileInfoElement("filename");
+        DifferenceListener myDifferenceListener = new IgnoreAttributeValuesDifferenceListener();
+        Diff diff = new Diff(expectedStr, actualStr);
+        diff.overrideDifferenceListener(myDifferenceListener);
+
+        assertXMLIdentical("Error comparing: " + item.getValue(), diff, true);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/IgnoreNamedElementsDifferenceListener.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/IgnoreNamedElementsDifferenceListener.java
@@ -2,7 +2,6 @@ package edu.harvard.hul.ois.fits.junit;
 
 import java.util.HashSet;
 import java.util.Set;
-
 import org.custommonkey.xmlunit.Difference;
 import org.custommonkey.xmlunit.DifferenceConstants;
 import org.custommonkey.xmlunit.DifferenceListener;
@@ -11,20 +10,20 @@ import org.w3c.dom.Node;
 public class IgnoreNamedElementsDifferenceListener implements DifferenceListener {
     private Set<String> blackList = new HashSet<String>();
 
-    public IgnoreNamedElementsDifferenceListener(String ...elementNames) {
+    public IgnoreNamedElementsDifferenceListener(String... elementNames) {
         for (String name : elementNames) {
             blackList.add(name);
         }
     }
 
     public int differenceFound(Difference difference) {
-    	// If Element or attribute has name in the blackList, ignore differences
+        // If Element or attribute has name in the blackList, ignore differences
         if (difference.getId() == DifferenceConstants.TEXT_VALUE_ID) {
-            if (blackList.contains(difference.getControlNodeDetail().getNode().getParentNode().getNodeName())) {
+            if (blackList.contains(
+                    difference.getControlNodeDetail().getNode().getParentNode().getNodeName())) {
                 return DifferenceListener.RETURN_IGNORE_DIFFERENCE_NODES_IDENTICAL;
             }
-        }
-        else if (difference.getId() == DifferenceConstants.ATTR_VALUE_ID) {
+        } else if (difference.getId() == DifferenceConstants.ATTR_VALUE_ID) {
             if (blackList.contains(difference.getControlNodeDetail().getNode().getNodeName())) {
                 return DifferenceListener.RETURN_IGNORE_DIFFERENCE_NODES_IDENTICAL;
             }
@@ -33,7 +32,5 @@ public class IgnoreNamedElementsDifferenceListener implements DifferenceListener
         return DifferenceListener.RETURN_ACCEPT_DIFFERENCE;
     }
 
-    public void skippedComparison(Node node, Node node1) {
-
-    }
+    public void skippedComparison(Node node, Node node1) {}
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/M4aTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/M4aTest.java
@@ -1,62 +1,58 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import java.io.File;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
-
-
 public class M4aTest extends AbstractLoggingTest {
-    
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
-		fits = new Fits(null, fitsConfigFile);
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@Test
-	public void testM4a() throws Exception {	
-		
-		String fileName = "sample.m4a";
-    	File input = new File("testfiles/" + fileName);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
-	}
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
+        fits = new Fits(null, fitsConfigFile);
+    }
 
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
+
+    @Test
+    public void testM4a() throws Exception {
+
+        String fileName = "sample.m4a";
+        File input = new File("testfiles/" + fileName);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/M4aXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/M4aXmlUnitTest.java
@@ -1,93 +1,87 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
-
 public class M4aXmlUnitTest extends AbstractXmlUnitTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-	
-	@Override
-	protected String[] getIgnoredXmlElements() {
-		String[] ignored = super.getIgnoredXmlElements();
-		List<String> additionalIgnored = new ArrayList<>(Arrays.asList(ignored));
-		additionalIgnored.add("ID");
-		additionalIgnored.add("audioObjectRef");
-		additionalIgnored.add("formatRef");
-		additionalIgnored.add("faceRef");
-		additionalIgnored.add("faceRegionRef");
-		additionalIgnored.add("ownerRef");
-		
-		return additionalIgnored.toArray(new String[additionalIgnored.size()]);
-	}
-    
-	@Test
-	public void testM4a() throws Exception {	
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-		String inputFilename = "sample.m4a";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
+    @Override
+    protected String[] getIgnoredXmlElements() {
+        String[] ignored = super.getIgnoredXmlElements();
+        List<String> additionalIgnored = new ArrayList<>(Arrays.asList(ignored));
+        additionalIgnored.add("ID");
+        additionalIgnored.add("audioObjectRef");
+        additionalIgnored.add("formatRef");
+        additionalIgnored.add("faceRef");
+        additionalIgnored.add("faceRegionRef");
+        additionalIgnored.add("ownerRef");
+
+        return additionalIgnored.toArray(new String[additionalIgnored.size()]);
+    }
+
+    @Test
+    public void testM4a() throws Exception {
+
+        String inputFilename = "sample.m4a";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/MP3Test.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/MP3Test.java
@@ -1,62 +1,58 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import java.io.File;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
-
-
 public class MP3Test extends AbstractLoggingTest {
-    
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
-		fits = new Fits(null, fitsConfigFile);
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@Test
-	public void testMP3() throws Exception {	
-		
-		String fileName = "Jess26676_Pugua.mp3";
-    	File input = new File("testfiles/" + fileName);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
-	}
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
+        fits = new Fits(null, fitsConfigFile);
+    }
 
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
+
+    @Test
+    public void testMP3() throws Exception {
+
+        String fileName = "Jess26676_Pugua.mp3";
+        File input = new File("testfiles/" + fileName);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/MP3XmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/MP3XmlUnitTest.java
@@ -1,93 +1,87 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
-
 public class MP3XmlUnitTest extends AbstractXmlUnitTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-	
-	@Override
-	protected String[] getIgnoredXmlElements() {
-		String[] ignored = super.getIgnoredXmlElements();
-		List<String> additionalIgnored = new ArrayList<>(Arrays.asList(ignored));
-		additionalIgnored.add("ID");
-		additionalIgnored.add("audioObjectRef");
-		additionalIgnored.add("formatRef");
-		additionalIgnored.add("faceRef");
-		additionalIgnored.add("faceRegionRef");
-		additionalIgnored.add("ownerRef");
-		
-		return additionalIgnored.toArray(new String[additionalIgnored.size()]);
-	}
-    
-	@Test
-	public void testMP3() throws Exception {	
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-		String inputFilename = "Jess26676_Pugua.mp3";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
+    @Override
+    protected String[] getIgnoredXmlElements() {
+        String[] ignored = super.getIgnoredXmlElements();
+        List<String> additionalIgnored = new ArrayList<>(Arrays.asList(ignored));
+        additionalIgnored.add("ID");
+        additionalIgnored.add("audioObjectRef");
+        additionalIgnored.add("formatRef");
+        additionalIgnored.add("faceRef");
+        additionalIgnored.add("faceRegionRef");
+        additionalIgnored.add("ownerRef");
+
+        return additionalIgnored.toArray(new String[additionalIgnored.size()]);
+    }
+
+    @Test
+    public void testMP3() throws Exception {
+
+        String inputFilename = "Jess26676_Pugua.mp3";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/MixTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/MixTest.java
@@ -1,169 +1,166 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import java.io.File;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
-
 public class MixTest extends AbstractLoggingTest {
 
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
-		fits = new Fits(null, fitsConfigFile);
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-    
-	@Test
-	public void testMIX() throws Exception {	
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
+        fits = new Fits(null, fitsConfigFile);
+    }
 
-		String inputFilename = "topazscanner.tif";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-				
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-	
-	@Test
-	public void testUncompressedTif() throws Exception {
-		
-		String inputFilename = "4072820.tif";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	
-		fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testMixJpg() throws Exception {	
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		String filename = "3426592.jpg";
-    	File input = new File("testfiles/" + filename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-    	
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + filename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testJpgExif() throws Exception {	
+    @Test
+    public void testMIX() throws Exception {
 
-		String filename = "ICFA.KC.BIA.1524-small.jpg";
-    	File input = new File("testfiles/" + filename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-						
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + filename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testJpgExif2() throws Exception {	
+        String inputFilename = "topazscanner.tif";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
 
-		String filename = "JPEGTest_20170591--JPEGTest_20170591.jpeg";
-    	File input = new File("testfiles/" + filename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + filename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testJpgJfif() throws Exception {	
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-		String filename = "gps.jpg";
-    	File input = new File("testfiles/" + filename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + filename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testTwoPageTiff() throws Exception {	
+    @Test
+    public void testUncompressedTif() throws Exception {
 
-		String filename = "W00EGS1016782-I01JW30--I01JW300001__0001.tif";
-    	File input = new File("testfiles/" + filename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + filename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testJp2_1() throws Exception {
+        String inputFilename = "4072820.tif";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
 
-		String inputFilename = "test.jp2";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testJp2_2() throws Exception {
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-		String inputFilename = "006607203_00018.jp2";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-	
-	@Test
-	public void testNotWellFormedJp2() throws Exception {
+    @Test
+    public void testMixJpg() throws Exception {
 
-		String inputFilename = "2339337_not_well_formed.jp2";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
+        String filename = "3426592.jpg";
+        File input = new File("testfiles/" + filename);
 
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + filename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testJpgExif() throws Exception {
+
+        String filename = "ICFA.KC.BIA.1524-small.jpg";
+        File input = new File("testfiles/" + filename);
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + filename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testJpgExif2() throws Exception {
+
+        String filename = "JPEGTest_20170591--JPEGTest_20170591.jpeg";
+        File input = new File("testfiles/" + filename);
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + filename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testJpgJfif() throws Exception {
+
+        String filename = "gps.jpg";
+        File input = new File("testfiles/" + filename);
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + filename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testTwoPageTiff() throws Exception {
+
+        String filename = "W00EGS1016782-I01JW30--I01JW300001__0001.tif";
+        File input = new File("testfiles/" + filename);
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + filename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testJp2_1() throws Exception {
+
+        String inputFilename = "test.jp2";
+        File input = new File("testfiles/" + inputFilename);
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testJp2_2() throws Exception {
+
+        String inputFilename = "006607203_00018.jp2";
+        File input = new File("testfiles/" + inputFilename);
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testNotWellFormedJp2() throws Exception {
+
+        String inputFilename = "2339337_not_well_formed.jp2";
+        File input = new File("testfiles/" + inputFilename);
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/MixXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/MixXmlUnitTest.java
@@ -1,297 +1,274 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 public class MixXmlUnitTest extends AbstractXmlUnitTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-    
-	@Test
-	public void testMIX() throws Exception {	
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-		String inputFilename = "topazscanner.tif";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @Test
+    public void testMIX() throws Exception {
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String inputFilename = "topazscanner.tif";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testUncompressedTif() throws Exception {
-		
-		String inputFilename = "4072820.tif";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		fitsOut.addStandardCombinedFormat();
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
 
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testJpgExif() throws Exception {	
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		String inputFilename = "ICFA.KC.BIA.1524-small.jpg";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+    @Test
+    public void testUncompressedTif() throws Exception {
 
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        String inputFilename = "4072820.tif";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
 
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        fitsOut.addStandardCombinedFormat();
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testJpgExif2() throws Exception {	
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		String inputFilename = "gps.jpg";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testJpgExif() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testJpgJfif() throws Exception {	
+        String inputFilename = "ICFA.KC.BIA.1524-small.jpg";
+        File input = new File("testfiles/" + inputFilename);
 
-		String inputFilename = "GLOBE1.JPG";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        FitsOutput fitsOut = fits.examine(input);
 
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testJpg2() throws Exception {
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		String inputFilename = "JPEGTest_20170591--JPEGTest_20170591.jpeg";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testJpgExif2() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testTwoPageTiff() throws Exception {
+        String inputFilename = "gps.jpg";
+        File input = new File("testfiles/" + inputFilename);
 
-		String inputFilename = "W00EGS1016782-I01JW30--I01JW300001__0001.tif";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-    	
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        FitsOutput fitsOut = fits.examine(input);
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testJp2_1() throws Exception {
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		String inputFilename = "test.jp2";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testJpgJfif() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testJp2_2() throws Exception {
+        String inputFilename = "GLOBE1.JPG";
+        File input = new File("testfiles/" + inputFilename);
 
-		String inputFilename = "006607203_00018.jp2";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        FitsOutput fitsOut = fits.examine(input);
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testNotWellFormedJp2() throws Exception {
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		String inputFilename = "2339337_not_well_formed.jp2";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = fits.examine(input);
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testJpg2() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        String inputFilename = "JPEGTest_20170591--JPEGTest_20170591.jpeg";
+        File input = new File("testfiles/" + inputFilename);
 
+        FitsOutput fitsOut = fits.examine(input);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testTwoPageTiff() throws Exception {
+
+        String inputFilename = "W00EGS1016782-I01JW30--I01JW300001__0001.tif";
+        File input = new File("testfiles/" + inputFilename);
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testJp2_1() throws Exception {
+
+        String inputFilename = "test.jp2";
+        File input = new File("testfiles/" + inputFilename);
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testJp2_2() throws Exception {
+
+        String inputFilename = "006607203_00018.jp2";
+        File input = new File("testfiles/" + inputFilename);
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testNotWellFormedJp2() throws Exception {
+
+        String inputFilename = "2339337_not_well_formed.jp2";
+        File input = new File("testfiles/" + inputFilename);
+
+        FitsOutput fitsOut = fits.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/TextMDTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/TextMDTest.java
@@ -1,82 +1,78 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import java.io.File;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
-
-
 public class TextMDTest extends AbstractLoggingTest {
-    
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
-		fits = new Fits(null, fitsConfigFile);
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@Test
-	public void testUTF16TextMD() throws Exception {	
-		
-		String fileName = "utf16.txt";
-    	File input = new File("testfiles/" + fileName);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
-	}
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
+        fits = new Fits(null, fitsConfigFile);
+    }
 
-	@Test
-	public void testPlainText() throws Exception {	
-		
-		String fileName = "plain-text.txt";
-    	File input = new File("testfiles/" + fileName);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
-	}
-    
-	@Test
-	public void testCsv() throws Exception {	
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		String fileName = "random_data.csv";
-    	File input = new File("testfiles/" + fileName);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
-	}
+    @Test
+    public void testUTF16TextMD() throws Exception {
 
+        String fileName = "utf16.txt";
+        File input = new File("testfiles/" + fileName);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testPlainText() throws Exception {
+
+        String fileName = "plain-text.txt";
+        File input = new File("testfiles/" + fileName);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testCsv() throws Exception {
+
+        String fileName = "random_data.csv";
+        File input = new File("testfiles/" + fileName);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/TextMDXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/TextMDXmlUnitTest.java
@@ -1,98 +1,92 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
-
 public class TextMDXmlUnitTest extends AbstractXmlUnitTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-    
-	@Test
-	public void testUTF16TextMD() throws Exception {
-		testFile("utf16.txt");
-	}
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@Test
-	public void testPlainText() throws Exception {
-		testFile("plain-text.txt");
-	}
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-	@Test
-	public void testCsv() throws Exception {
-		testFile("random_data.csv");
-	}
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-	@Test
-	public void testTei() throws Exception {
-		testFile("P3EKWCX2XYWWB8Y.xml");
-	}
+    @Test
+    public void testUTF16TextMD() throws Exception {
+        testFile("utf16.txt");
+    }
 
-	@Test
-	public void testKml() throws Exception {
-		testFile("KXXJXH4YTGWQ68W.kml");
-	}
+    @Test
+    public void testPlainText() throws Exception {
+        testFile("plain-text.txt");
+    }
 
-	private void testFile(String inputFilename) throws Exception {
-		File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+    @Test
+    public void testCsv() throws Exception {
+        testFile("random_data.csv");
+    }
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @Test
+    public void testTei() throws Exception {
+        testFile("P3EKWCX2XYWWB8Y.xml");
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testKml() throws Exception {
+        testFile("KXXJXH4YTGWQ68W.kml");
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+    private void testFile(String inputFilename) throws Exception {
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/VTTToolTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/VTTToolTest.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * Copyright 2016 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,76 +20,70 @@ package edu.harvard.hul.ois.fits.junit;
 
 import static org.junit.Assert.fail;
 
-import java.io.File;
-import java.util.List;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.FitsOutput;
 import edu.harvard.hul.ois.fits.identity.FitsIdentity;
 import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
+import java.io.File;
+import java.util.List;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class VTTToolTest extends AbstractLoggingTest {
 
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
-		fits = new Fits(null, fitsConfigFile);
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
+        fits = new Fits(null, fitsConfigFile);
+    }
 
-	@Test  
-	public void testVttRead() throws Exception {   
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		String inputFilename = "simple_webvtt.vtt";
-		File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    @Test
+    public void testVttRead() throws Exception {
 
-		List <FitsIdentity> identities = fitsOut.getIdentities();
-		
-		for(FitsIdentity identity : identities) {
-			if(!identity.getMimetype().contains("text/vtt")) {
-				fail("This should be identified as a WebVTT file with mimetype of text/vtt");
-			}
-		}
+        String inputFilename = "simple_webvtt.vtt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
 
-	}
+        List<FitsIdentity> identities = fitsOut.getIdentities();
 
+        for (FitsIdentity identity : identities) {
+            if (!identity.getMimetype().contains("text/vtt")) {
+                fail("This should be identified as a WebVTT file with mimetype of text/vtt");
+            }
+        }
+    }
 
-	@Test  
-	public void testInvalidVttRead() throws Exception {   
+    @Test
+    public void testInvalidVttRead() throws Exception {
 
-		String inputFilename = "invalid_webvtt.vtt";
-		File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+        String inputFilename = "invalid_webvtt.vtt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
 
-		List <FitsIdentity> identities = fitsOut.getIdentities();
-		
-		// Since this is an invalid VTT file, it should be identified as "text/plain"
-		for(FitsIdentity identity : identities) {
-			if(!identity.getMimetype().contains("text/plain")) {
-				fail("This should not be identified as a text/plain file");
-			}
-		}
+        List<FitsIdentity> identities = fitsOut.getIdentities();
 
-	}    
-
+        // Since this is an invalid VTT file, it should be identified as "text/plain"
+        for (FitsIdentity identity : identities) {
+            if (!identity.getMimetype().contains("text/plain")) {
+                fail("This should not be identified as a text/plain file");
+            }
+        }
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/VTTToolXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/VTTToolXmlUnitTest.java
@@ -1,75 +1,70 @@
-/* 
+/*
  * Copyright 2016 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 public class VTTToolXmlUnitTest extends AbstractXmlUnitTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@Test  
-	public void testVtt() throws Exception {   
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-		String inputFilename = "simple_webvtt.vtt";
-		File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @Test
+    public void testVtt() throws Exception {
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String inputFilename = "simple_webvtt.vtt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/VideoStdSchemaTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/VideoStdSchemaTest.java
@@ -1,93 +1,90 @@
-/* 
+/*
  * Copyright 2014 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
 import java.io.File;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
-
 public class VideoStdSchemaTest extends AbstractLoggingTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-//		fits = new Fits();
-// Use the following two lines to turn on tool output
-		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
-		fits = new Fits(null, fitsConfigFile);
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-    
-    @Test  
-	public void testVideo_DV() throws Exception {   
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-		String fileName = "FITS-SAMPLE-26.mov";
-    	File input = new File("testfiles/" + fileName);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
-	}    
-    
-    @Test  
-	public void testMp4() throws Exception {   
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        //		fits = new Fits();
+        // Use the following two lines to turn on tool output
+        File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
+        fits = new Fits(null, fitsConfigFile);
+    }
 
-		String fileName = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
-    	File input = new File("testfiles/" + fileName);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
-	}
-    
-    @Test  
-    public void testVideo() throws Exception {   
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
+
+    @Test
+    public void testVideo_DV() throws Exception {
+
+        String fileName = "FITS-SAMPLE-26.mov";
+        File input = new File("testfiles/" + fileName);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testMp4() throws Exception {
+
+        String fileName = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
+        File input = new File("testfiles/" + fileName);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testVideo() throws Exception {
 
         String fileName = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov";
         File input = new File("testfiles/" + fileName);
         FitsOutput fitsOut = fits.examine(input);
         fitsOut.addStandardCombinedFormat();
         fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
-    }    
-    
+    }
+
     @Test
     public void testMxfVideo() throws Exception {
 
-    	String fileName = "freeMXF-mxf1a.mxf";
-    	File input = new File("testfiles/" + fileName);
-    	FitsOutput fitsOut = fits.examine(input);
-		fitsOut.addStandardCombinedFormat();
-		fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
-	}
-
+        String fileName = "freeMXF-mxf1a.mxf";
+        File input = new File("testfiles/" + fileName);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + fileName + OUTPUT_FILE_SUFFIX);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/VideoStdSchemaXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/VideoStdSchemaXmlUnitTest.java
@@ -1,288 +1,276 @@
-/* 
+/*
  * Copyright 2015 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 public class VideoStdSchemaXmlUnitTest extends AbstractXmlUnitTest {
-	
-	// These override the values in the parent class.
-	private static final String[] OVERRIDING_IGNORED_XML_ELEMENTS = {
-			"version",
-			"toolversion",
-			"dateModified",
-			"fslastmodified",
-			"startDate",
-			"startTime",
-			"timestamp", 
-			"fitsExecutionTime",
-			"executionTime",
-			"filepath",
-			"location",
-			"lastmodified",
-			"ebucore:locator"};
 
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
+    // These override the values in the parent class.
+    private static final String[] OVERRIDING_IGNORED_XML_ELEMENTS = {
+        "version",
+        "toolversion",
+        "dateModified",
+        "fslastmodified",
+        "startDate",
+        "startTime",
+        "timestamp",
+        "fitsExecutionTime",
+        "executionTime",
+        "filepath",
+        "location",
+        "lastmodified",
+        "ebucore:locator"
+    };
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-	@Test  
-	public void testVideoXmlUnitFitsOutput_AVC() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testVideoXmlUnitFitsOutput_AVC() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test  
-	public void testVideoXmlUnitFitsOutput_DV() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-26.mov";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}	
-	
-	@Test  
-	public void testVideoXmlUnitStandardOutput_AVC() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		
-		// Output stream for FITS to write to 
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		
-		// Create standard output in the stream passed in
-		Fits.outputStandardSchemaXml(fitsOut, out);
-		
-		File file = new File("test-generated-output/" + inputFilename + "-standard-only" + ACTUAL_OUTPUT_FILE_SUFFIX);
-		FileOutputStream fos = new FileOutputStream(file);
-		fos.write(out.toByteArray());
-		fos.flush();
-		fos.close();
-		
-		// Turn output stream into a String HtmlUnit can use
-		String actualXmlStr = new String(out.toByteArray(),"UTF-8");
-		
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + "-standard-only" + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test  
-	public void testVideoXmlUnitStandardOutput_DV() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-26.mov";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		
-		// Output stream for FITS to write to 
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		
-		// Create standard output in the stream passed in
-		Fits.outputStandardSchemaXml(fitsOut, out);
+    @Test
+    public void testVideoXmlUnitFitsOutput_DV() throws Exception {
+
+        String inputFilename = "FITS-SAMPLE-26.mov";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testVideoXmlUnitStandardOutput_AVC() throws Exception {
+
+        String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+
+        // Output stream for FITS to write to
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // Create standard output in the stream passed in
+        Fits.outputStandardSchemaXml(fitsOut, out);
 
         File file = new File("test-generated-output/" + inputFilename + "-standard-only" + ACTUAL_OUTPUT_FILE_SUFFIX);
         FileOutputStream fos = new FileOutputStream(file);
         fos.write(out.toByteArray());
         fos.flush();
         fos.close();
-		
-		// Turn output stream into a String HtmlUnit can use
-		String actualXmlStr = new String(out.toByteArray(),"UTF-8");
-		
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output//" + inputFilename + "-standard-only" + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}	
-	
-	@Test  
-	public void testVideoXmlUnitCombinedOutput_DV() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-26.mov";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		// Include standard schema output 
-		fitsOut.addStandardCombinedFormat();
+        // Turn output stream into a String HtmlUnit can use
+        String actualXmlStr = new String(out.toByteArray(), "UTF-8");
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		// Turn output stream into a String HtmlUnit can use
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        // Read in the expected XML file
+        Scanner scan = new Scanner(
+                new File("testfiles/output/" + inputFilename + "-standard-only" + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		// also save file to disk for visual examination
-		File file = new File("test-generated-output/" + inputFilename + "-combined" + ACTUAL_OUTPUT_FILE_SUFFIX);
-		FileOutputStream fos = new FileOutputStream(file);
-		fitsOut.output(fos);
-		fos.close();
-		
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-	            "testfiles/output/" + inputFilename + "-combined" + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	/**
-	 * Tests that the output from FITS matches the expected output.
-	 */
-	@Test
-	public void testVideoXmlUnitOutput_MXF() throws Exception {
-		
-    	String inputFilename = "freeMXF-mxf1a.mxf";
+    @Test
+    public void testVideoXmlUnitStandardOutput_DV() throws Exception {
 
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-		
-		// Turn output stream into a String HtmlUnit can use
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-		
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-	            "testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String inputFilename = "FITS-SAMPLE-26.mov";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test  
-	public void testVideoXmlUnitCombinedOutput() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		// Create combined output in the stream passed in
-		fitsOut.addStandardCombinedFormat();
-		
-		// Turn output stream into a String HtmlUnit can use
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-		
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-	            "testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        // Output stream for FITS to write to
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}	
-	
-	@Test  
-	public void testVideoXmlUnitFitsOutput_AVC_NO_MD5() throws Exception {
-		
-		File fitsConfigFile = new File("testfiles/properties/fits_no_md5_video.xml");
-		Fits fits = new Fits(null, fitsConfigFile);
-		
-		// First generate the FITS output
-    	String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		fitsOut.saveToDisk("test-generated-output/" + "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1_mp4_FITS_NO_MD5_XmlUnitActualOutput.xml");
+        // Create standard output in the stream passed in
+        Fits.outputStandardSchemaXml(fitsOut, out);
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        File file = new File("test-generated-output/" + inputFilename + "-standard-only" + ACTUAL_OUTPUT_FILE_SUFFIX);
+        FileOutputStream fos = new FileOutputStream(file);
+        fos.write(out.toByteArray());
+        fos.flush();
+        fos.close();
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1_mp4_FITS_NO_MD5.xml"));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        // Turn output stream into a String HtmlUnit can use
+        String actualXmlStr = new String(out.toByteArray(), "UTF-8");
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        // Read in the expected XML file
+        Scanner scan = new Scanner(
+                new File("testfiles/output//" + inputFilename + "-standard-only" + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-	/**
-	 * Send in set of XML elements to ignore that overrides the default.
-	 */
-	@Override
-	protected String[] getIgnoredXmlElements() {
-		return OVERRIDING_IGNORED_XML_ELEMENTS;
-	}
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testVideoXmlUnitCombinedOutput_DV() throws Exception {
+
+        String inputFilename = "FITS-SAMPLE-26.mov";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        // Include standard schema output
+        fitsOut.addStandardCombinedFormat();
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        // Turn output stream into a String HtmlUnit can use
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // also save file to disk for visual examination
+        File file = new File("test-generated-output/" + inputFilename + "-combined" + ACTUAL_OUTPUT_FILE_SUFFIX);
+        FileOutputStream fos = new FileOutputStream(file);
+        fitsOut.output(fos);
+        fos.close();
+
+        // Read in the expected XML file
+        Scanner scan =
+                new Scanner(new File("testfiles/output/" + inputFilename + "-combined" + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    /**
+     * Tests that the output from FITS matches the expected output.
+     */
+    @Test
+    public void testVideoXmlUnitOutput_MXF() throws Exception {
+
+        String inputFilename = "freeMXF-mxf1a.mxf";
+
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        // Turn output stream into a String HtmlUnit can use
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testVideoXmlUnitCombinedOutput() throws Exception {
+
+        String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        // Create combined output in the stream passed in
+        fitsOut.addStandardCombinedFormat();
+
+        // Turn output stream into a String HtmlUnit can use
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testVideoXmlUnitFitsOutput_AVC_NO_MD5() throws Exception {
+
+        File fitsConfigFile = new File("testfiles/properties/fits_no_md5_video.xml");
+        Fits fits = new Fits(null, fitsConfigFile);
+
+        // First generate the FITS output
+        String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/"
+                + "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1_mp4_FITS_NO_MD5_XmlUnitActualOutput.xml");
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan =
+                new Scanner(new File("testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1_mp4_FITS_NO_MD5.xml"));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    /**
+     * Send in set of XML elements to ignore that overrides the default.
+     */
+    @Override
+    protected String[] getIgnoredXmlElements() {
+        return OVERRIDING_IGNORED_XML_ELEMENTS;
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/ZipTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/ZipTest.java
@@ -1,106 +1,103 @@
-/* 
+/*
  * Copyright 2016 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These generated FITS output with tool output on the given files files.
- * 
+ *
  * @author dan179
  */
 public class ZipTest extends AbstractXmlUnitTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
-		fits = new Fits(null, fitsConfigFile);
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-	
-	@Test
-	public void testZipFile() throws Exception {
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-    	String inputFilename = "assorted-files.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-	
-	@Test
-	public void testSingleFileZipFile() throws Exception {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        File fitsConfigFile = new File("testfiles/properties/fits-full-with-tool-output.xml");
+        fits = new Fits(null, fitsConfigFile);
+    }
 
-    	String inputFilename = "40415587.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-	
-	@Test
-	public void testCompressedEncryptedZipFile() throws Exception {
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-    	String inputFilename = "compressed-encrypted.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-	
-	@Test
-	public void testUncompressedEncryptedZipFile() throws Exception {
+    @Test
+    public void testZipFile() throws Exception {
 
-    	String inputFilename = "uncompressed-encrypted.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
-	
-	@Test
-	public void testEmbeddedDirectoriesZipFile() throws Exception {
+        String inputFilename = "assorted-files.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 
-    	String inputFilename = "multiple-file-types-and-folders.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-	}
+    @Test
+    public void testSingleFileZipFile() throws Exception {
 
+        String inputFilename = "40415587.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testCompressedEncryptedZipFile() throws Exception {
+
+        String inputFilename = "compressed-encrypted.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testUncompressedEncryptedZipFile() throws Exception {
+
+        String inputFilename = "uncompressed-encrypted.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
+
+    @Test
+    public void testEmbeddedDirectoriesZipFile() throws Exception {
+
+        String inputFilename = "multiple-file-types-and-folders.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/ZipXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/ZipXmlUnitTest.java
@@ -1,189 +1,174 @@
-/* 
+/*
  * Copyright 2016 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These tests compare actual FITS output with expected output on ZIP files.
  * These tests should be run with &lt;display-tool-output&gt;false&lt;/display-tool-output&gt; in fits.xml.
- * 
+ *
  * @author dan179
  */
 public class ZipXmlUnitTest extends AbstractXmlUnitTest {
-	
-	/*
-	 *  Only one Fits instance is needed to run all tests.
-	 *  This also speeds up the tests.
-	 */
-	private static Fits fits;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
-		// Set up FITS for entire class.
-		fits = new Fits();
-	}
-	
-	@AfterClass
-	public static void afterClass() {
-		fits = null;
-	}
-	
-	@Test
-	public void testUncompressedZipFile() throws Exception {
+    /*
+     *  Only one Fits instance is needed to run all tests.
+     *  This also speeds up the tests.
+     */
+    private static Fits fits;
 
-    	String inputFilename = "32044020597662.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Set up FITS for entire class.
+        fits = new Fits();
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @AfterClass
+    public static void afterClass() {
+        fits = null;
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testCompressedZipFile() throws Exception {
+    @Test
+    public void testUncompressedZipFile() throws Exception {
 
-    	String inputFilename = "assorted-files.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        String inputFilename = "32044020597662.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testSingleFileZipFile() throws Exception {
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-    	String inputFilename = "40415587.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testCompressedZipFile() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testCompressedEncryptedZipFile() throws Exception {
+        String inputFilename = "assorted-files.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-    	String inputFilename = "compressed-encrypted.zip"; // 0sample1-compressed
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testUncompressedEncryptedZipFile() throws Exception {
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-    	String inputFilename = "uncompressed-encrypted.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @Test
+    public void testSingleFileZipFile() throws Exception {
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String inputFilename = "40415587.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testEmbeddedDirectoriesZipFile() throws Exception {
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-    	String inputFilename = "multiple-file-types-and-folders.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+    @Test
+    public void testCompressedEncryptedZipFile() throws Exception {
 
+        String inputFilename = "compressed-encrypted.zip"; // 0sample1-compressed
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testUncompressedEncryptedZipFile() throws Exception {
+
+        String inputFilename = "uncompressed-encrypted.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testEmbeddedDirectoriesZipFile() throws Exception {
+
+        String inputFilename = "multiple-file-types-and-folders.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/service/AdobeIllustratorXmlUnitServiceTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/service/AdobeIllustratorXmlUnitServiceTest.java
@@ -1,26 +1,27 @@
-/* 
+/*
  * Copyright 2016 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit.service;
 
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
@@ -28,50 +29,44 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These tests compare actual FITS output with expected output on Adobe Illustrator files.
  * NOTE: This is an integration test that requires a running web application with the
  * FITS Service running.
- * 
+ *
  * @author dan179
  */
 @Ignore
 public class AdobeIllustratorXmlUnitServiceTest extends AbstractXmlUnitTest {
-	
-	@BeforeClass
-	public static void initializeHttpClient() throws Exception {
-		AbstractXmlUnitTest.beforeServiceTest();
-	}
-	
-	@AfterClass
-	public static void afterClass() throws Exception {
-		AbstractXmlUnitTest.afterServiceTest();
-	}
-	
-	@Test
-	public void testAdobeIllustratorFile() throws Exception {
 
-    	String inputFilename = "MMS-82A.08.12.02.ai";
-    	File input = new File("testfiles/" + inputFilename);
+    @BeforeClass
+    public static void initializeHttpClient() throws Exception {
+        AbstractXmlUnitTest.beforeServiceTest();
+    }
 
-		FitsOutput fitsOut = super.examine(input);
-    	
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @AfterClass
+    public static void afterClass() throws Exception {
+        AbstractXmlUnitTest.afterServiceTest();
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testAdobeIllustratorFile() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        String inputFilename = "MMS-82A.08.12.02.ai";
+        File input = new File("testfiles/" + inputFilename);
 
+        FitsOutput fitsOut = super.examine(input);
+
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/service/AudioStdSchemaTestXmlServiceUnit_NoMD5.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/service/AudioStdSchemaTestXmlServiceUnit_NoMD5.java
@@ -1,26 +1,28 @@
-/* 
+/*
  * Copyright 2015 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit.service;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
@@ -28,75 +30,66 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These tests compare actual FITS output with expected output on audio files.
  * NOTE: This is an integration test that requires a running web application with the
  * FITS Service running.
- * 
+ *
  * @author dan179
  */
 @Ignore
 public class AudioStdSchemaTestXmlServiceUnit_NoMD5 extends AbstractXmlUnitTest {
 
-	@BeforeClass
-	public static void initializeHttpClient() throws Exception {
-		AbstractXmlUnitTest.beforeServiceTest();
-	}
-	
-	@AfterClass
-	public static void afterClass() throws Exception {
-		AbstractXmlUnitTest.afterServiceTest();
-	}
-    
-    @Test  
-	public void testAudioChunk() throws Exception {   
+    @BeforeClass
+    public static void initializeHttpClient() throws Exception {
+        AbstractXmlUnitTest.beforeServiceTest();
+    }
 
-		String inputFilename = "testchunk.wav";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @AfterClass
+    public static void afterClass() throws Exception {
+        AbstractXmlUnitTest.afterServiceTest();
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testAudioChunk() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        String inputFilename = "testchunk.wav";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-	
-	@Test  
-	public void testAudioMD_noMD5() throws Exception {
-		
-		// use an alternate fits.xml file where a MD5 checksum is not generated
-		File fitsConfigFile = new File("testfiles/properties/fits_no_md5_audio.xml");
-    	Fits fits = new Fits(null, fitsConfigFile);
-		
-		// First generate the FITS output
-		String inputFilename = "test.wav";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+    @Test
+    public void testAudioMD_noMD5() throws Exception {
+
+        // use an alternate fits.xml file where a MD5 checksum is not generated
+        File fitsConfigFile = new File("testfiles/properties/fits_no_md5_audio.xml");
+        Fits fits = new Fits(null, fitsConfigFile);
+
+        // First generate the FITS output
+        String inputFilename = "test.wav";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/service/DocMDXmlUnitServiceTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/service/DocMDXmlUnitServiceTest.java
@@ -1,26 +1,27 @@
-/* 
+/*
  * Copyright 2016 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit.service;
 
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
@@ -28,575 +29,527 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These tests compare actual FITS output with expected output on various word processing documents.
  * These tests should be run with &lt;display-tool-output&gt;false&lt;/display-tool-output&gt; in fits.xml.
  * NOTE: This is an integration test that requires a running web application with the
  * FITS Service running.
- * 
+ *
  * @author dan179
  */
 @Ignore
 public class DocMDXmlUnitServiceTest extends AbstractXmlUnitTest {
 
-	@BeforeClass
-	public static void initializeHttpClient() throws Exception {
-		AbstractXmlUnitTest.beforeServiceTest();
-	}
-	
-	@AfterClass
-	public static void afterClass() throws Exception {
-		AbstractXmlUnitTest.afterServiceTest();
-	}
-	
-	@Test
-	public void testWordDocUrlEmbeddedResources() throws Exception {
-
-    	String inputFilename = "Word2003_has_URLs_has_embedded_resources.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocGraphics() throws Exception {
-
-    	String inputFilename = "Word2003_many_graphics.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocPasswordProtected() throws Exception {
-
-    	String inputFilename = "Word2003PasswordProtected.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDoc2011() throws Exception {
-
-    	String inputFilename = "Word2011_Has_Outline.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocLibreOffice() throws Exception {
-
-    	String inputFilename = "LibreOffice.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocHyperlinks() throws Exception {
-
-    	String inputFilename = "Word2003_has_table_of_contents.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocPasswordAndEncrypted() throws Exception {
-
-    	String inputFilename = "Word_protected_encrypted.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocMacMSWord() throws Exception {
-
-    	String inputFilename = "MacMSWORD_4-5.doc";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testWordDocV2() throws Exception {
-
-    	String inputFilename = "NEWSSLID_Word2_0.DOC";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testOpenOfficeDoc() throws Exception {
-
-    	String inputFilename = "LibreODT-Ur-doc.odt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testOpenOfficeDocEmbeddedResources() throws Exception {
-
-    	String inputFilename = "LibreODTwFormulas.odt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testOpenOfficeDocHasTables() throws Exception {
-
-    	String inputFilename = "LibreODT-hasTables.odt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testOpenOfficeDocUnparseableDate() throws Exception {
-
-    	String inputFilename = "UnparseableDate.odt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testWordDocxOutput() throws Exception {
-
-    	String inputFilename = "Word_has_index.docx";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	/*
-	 * This output of this document produces what looks to be invalid output.
-	 */
-	@Test
-	public void testWordDocxPasswordProtected() throws Exception {
-
-    	String inputFilename = "WordPasswordProtected.docx";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testWordDocmOutput() throws Exception {
-
-    	String inputFilename = "Document_Has_Form_Controls.docm";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testEpubOutput() throws Exception {
-
-    	// process multiple files to examine different types of output
-    	String[] inputFilenames = {"Winnie-the-Pooh-protected.epub", // not properly identified as epub mimetype
-    			"GeographyofBliss_oneChapter.epub",
-    			"aliceDynamic_images_metadata_tableOfContents.epub", // not properly identified as epub mimetype
-    			"epub30-test-font-embedding-obfuscation.epub",
-    			"Calibre_hasTable_of_Contents.epub"};
-
-    	for (String inputFilename : inputFilenames) {
-    		
-        	File input = new File("testfiles/" + inputFilename);
-        	FitsOutput fitsOut = super.examine(input);
-        	fitsOut.addStandardCombinedFormat();
-        	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-        	
-    		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-    		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-    		// Read in the expected XML file
-    		Scanner scan = new Scanner(new File(
-    				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-    		String expectedXmlStr = scan.
-    				useDelimiter("\\Z").next();
-    		scan.close();
-
-    		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-    	}
-	}
-	
-	@Test
-	public void testWPDOutput() throws Exception {
-    	
-    	// process multiple files to examine different types of output
-    	String[] inputFilenames = { //"WordPerfect6-7.wpd",
-    			"WordPerfect4_2.wp",
-    			"WordPerfect5_0.wp",
-    			"WordPerfect5_2.wp" };
-//    			"WordPerfectCompoundFile.wpd"};  // (not identified as a WordPerfect document)
-
-    	for (String inputFilename : inputFilenames) {
-        	File input = new File("testfiles/" + inputFilename);
-        	FitsOutput fitsOut = super.examine(input);
-        	fitsOut.addStandardCombinedFormat();
-        	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-        	
-    		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-    		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-    		// Read in the expected XML file
-    		Scanner scan = new Scanner(new File(
-    				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-    		String expectedXmlStr = scan.
-    				useDelimiter("\\Z").next();
-    		scan.close();
-
-    		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-    	}
-	}
-	
-	@Test
-	public void testRtfOutput() throws Exception {
-
-    	String inputFilename = "TestDoc.rtf";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testRtfWithCompanyOutput() throws Exception {
-
-    	String inputFilename = "Doc2.rtf";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
-
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testPdf() throws Exception {
-		
-    	String[] inputFilenames = {"PDF_embedded_resources.pdf",
-    			"HasChangeHistory.pdf",
-    			"PDF_eng.pdf",
-    			"HasAnnotations.pdf"};
-
-    	for (String inputFilename : inputFilenames) {
-    		File input = new File("testfiles/" + inputFilename);
-	    	FitsOutput fitsOut = super.examine(input);
-	    	fitsOut.addStandardCombinedFormat();
-	    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-	    	
-			XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-			String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-	
-			// Read in the expected XML file
-			Scanner scan = new Scanner(new File(
-					"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-			String expectedXmlStr = scan.
-					useDelimiter("\\Z").next();
-			scan.close();
-	
-			testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-    	}
-	}
-    
-	@Test
-	public void testPdfA() throws Exception {
-		
-    	String[] inputFilenames = {"PDFa_equations.pdf",
-    			"PDFa_multiplefonts.pdf",
-    			"PDFa_has_form.pdf",
-    			"PDFa_has_table_of_contents.pdf",
-    			"PDFa_has_tables.pdf",
-    			"PDFA_Document with tables.pdf",
-    			"PDFa_embedded_resources.pdf"};
-
-    	for (String inputFilename : inputFilenames) {
-    		File input = new File("testfiles/" + inputFilename);
-	    	FitsOutput fitsOut = super.examine(input);
-	    	fitsOut.addStandardCombinedFormat();
-	    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-	    	
-			XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-			String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-	
-			// Read in the expected XML file
-			Scanner scan = new Scanner(new File(
-					"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-			String expectedXmlStr = scan.
-					useDelimiter("\\Z").next();
-			scan.close();
-	
-			testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-    	}
-	}
-    
-	@Test
-	public void testPdfX() throws Exception {
-		
-    	String[] inputFilenames = {
-    			"altona_technical_1v2_x3_has_annotations.pdf",
-    			"Book_pdfx1a.pdf", // converts to PDF/A
-    			"PDFx3.pdf" // converts to PDF/A
-    			};
-
-    	for (String inputFilename : inputFilenames) {
-    		File input = new File("testfiles/" + inputFilename);
-	    	FitsOutput fitsOut = super.examine(input);
-        	fitsOut.addStandardCombinedFormat();
-	    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-	    	
-			XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-			String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-	
-			// Read in the expected XML file
-			Scanner scan = new Scanner(new File(
-					"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-			String expectedXmlStr = scan.
-					useDelimiter("\\Z").next();
-			scan.close();
-	
-			testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-    	}
-	}
+    @BeforeClass
+    public static void initializeHttpClient() throws Exception {
+        AbstractXmlUnitTest.beforeServiceTest();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        AbstractXmlUnitTest.afterServiceTest();
+    }
+
+    @Test
+    public void testWordDocUrlEmbeddedResources() throws Exception {
+
+        String inputFilename = "Word2003_has_URLs_has_embedded_resources.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocGraphics() throws Exception {
+
+        String inputFilename = "Word2003_many_graphics.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocPasswordProtected() throws Exception {
+
+        String inputFilename = "Word2003PasswordProtected.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDoc2011() throws Exception {
+
+        String inputFilename = "Word2011_Has_Outline.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocLibreOffice() throws Exception {
+
+        String inputFilename = "LibreOffice.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocHyperlinks() throws Exception {
 
+        String inputFilename = "Word2003_has_table_of_contents.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocPasswordAndEncrypted() throws Exception {
+
+        String inputFilename = "Word_protected_encrypted.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocMacMSWord() throws Exception {
+
+        String inputFilename = "MacMSWORD_4-5.doc";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocV2() throws Exception {
+
+        String inputFilename = "NEWSSLID_Word2_0.DOC";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testOpenOfficeDoc() throws Exception {
+
+        String inputFilename = "LibreODT-Ur-doc.odt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testOpenOfficeDocEmbeddedResources() throws Exception {
+
+        String inputFilename = "LibreODTwFormulas.odt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testOpenOfficeDocHasTables() throws Exception {
+
+        String inputFilename = "LibreODT-hasTables.odt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testOpenOfficeDocUnparseableDate() throws Exception {
+
+        String inputFilename = "UnparseableDate.odt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocxOutput() throws Exception {
+
+        String inputFilename = "Word_has_index.docx";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    /*
+     * This output of this document produces what looks to be invalid output.
+     */
+    @Test
+    public void testWordDocxPasswordProtected() throws Exception {
+
+        String inputFilename = "WordPasswordProtected.docx";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testWordDocmOutput() throws Exception {
+
+        String inputFilename = "Document_Has_Form_Controls.docm";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testEpubOutput() throws Exception {
+
+        // process multiple files to examine different types of output
+        String[] inputFilenames = {
+            "Winnie-the-Pooh-protected.epub", // not properly identified as epub mimetype
+            "GeographyofBliss_oneChapter.epub",
+            "aliceDynamic_images_metadata_tableOfContents.epub", // not properly identified as epub mimetype
+            "epub30-test-font-embedding-obfuscation.epub",
+            "Calibre_hasTable_of_Contents.epub"
+        };
+
+        for (String inputFilename : inputFilenames) {
+
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = super.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+            XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+            String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+            // Read in the expected XML file
+            Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+            String expectedXmlStr = scan.useDelimiter("\\Z").next();
+            scan.close();
+
+            testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+        }
+    }
+
+    @Test
+    public void testWPDOutput() throws Exception {
+
+        // process multiple files to examine different types of output
+        String[] inputFilenames = { // "WordPerfect6-7.wpd",
+            "WordPerfect4_2.wp", "WordPerfect5_0.wp", "WordPerfect5_2.wp"
+        };
+        //    			"WordPerfectCompoundFile.wpd"};  // (not identified as a WordPerfect document)
+
+        for (String inputFilename : inputFilenames) {
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = super.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+            XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+            String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+            // Read in the expected XML file
+            Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+            String expectedXmlStr = scan.useDelimiter("\\Z").next();
+            scan.close();
+
+            testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+        }
+    }
+
+    @Test
+    public void testRtfOutput() throws Exception {
+
+        String inputFilename = "TestDoc.rtf";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testRtfWithCompanyOutput() throws Exception {
+
+        String inputFilename = "Doc2.rtf";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testPdf() throws Exception {
+
+        String[] inputFilenames = {
+            "PDF_embedded_resources.pdf", "HasChangeHistory.pdf", "PDF_eng.pdf", "HasAnnotations.pdf"
+        };
+
+        for (String inputFilename : inputFilenames) {
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = super.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+            XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+            String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+            // Read in the expected XML file
+            Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+            String expectedXmlStr = scan.useDelimiter("\\Z").next();
+            scan.close();
+
+            testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+        }
+    }
+
+    @Test
+    public void testPdfA() throws Exception {
+
+        String[] inputFilenames = {
+            "PDFa_equations.pdf",
+            "PDFa_multiplefonts.pdf",
+            "PDFa_has_form.pdf",
+            "PDFa_has_table_of_contents.pdf",
+            "PDFa_has_tables.pdf",
+            "PDFA_Document with tables.pdf",
+            "PDFa_embedded_resources.pdf"
+        };
+
+        for (String inputFilename : inputFilenames) {
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = super.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+            XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+            String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+            // Read in the expected XML file
+            Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+            String expectedXmlStr = scan.useDelimiter("\\Z").next();
+            scan.close();
+
+            testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+        }
+    }
+
+    @Test
+    public void testPdfX() throws Exception {
+
+        String[] inputFilenames = {
+            "altona_technical_1v2_x3_has_annotations.pdf",
+            "Book_pdfx1a.pdf", // converts to PDF/A
+            "PDFx3.pdf" // converts to PDF/A
+        };
+
+        for (String inputFilename : inputFilenames) {
+            File input = new File("testfiles/" + inputFilename);
+            FitsOutput fitsOut = super.examine(input);
+            fitsOut.addStandardCombinedFormat();
+            fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+            XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+            String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+            // Read in the expected XML file
+            Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+            String expectedXmlStr = scan.useDelimiter("\\Z").next();
+            scan.close();
+
+            testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+        }
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/service/MP3XmlUnitServiceTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/service/MP3XmlUnitServiceTest.java
@@ -1,29 +1,30 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit.service;
 
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
@@ -31,63 +32,57 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These tests compare actual FITS output with expected output on MP3 files.
  * NOTE: This is an integration test that requires a running web application with the
  * FITS Service running.
- * 
+ *
  * @author dan179
  */
 @Ignore
 public class MP3XmlUnitServiceTest extends AbstractXmlUnitTest {
 
-	@BeforeClass
-	public static void initializeHttpClient() throws Exception {
-		AbstractXmlUnitTest.beforeServiceTest();
-	}
-	
-	@AfterClass
-	public static void afterClass() throws Exception {
-		AbstractXmlUnitTest.afterServiceTest();
-	}
-	
-	@Override
-	protected String[] getIgnoredXmlElements() {
-		String[] ignored = super.getIgnoredXmlElements();
-		List<String> additionalIgnored = new ArrayList<>(Arrays.asList(ignored));
-		additionalIgnored.add("ID");
-		additionalIgnored.add("audioObjectRef");
-		additionalIgnored.add("formatRef");
-		additionalIgnored.add("faceRef");
-		additionalIgnored.add("faceRegionRef");
-		additionalIgnored.add("ownerRef");
-		
-		return additionalIgnored.toArray(new String[additionalIgnored.size()]);
-	}
-    
-	@Test
-	public void testMP3() throws Exception {	
+    @BeforeClass
+    public static void initializeHttpClient() throws Exception {
+        AbstractXmlUnitTest.beforeServiceTest();
+    }
 
-		String inputFilename = "Jess26676_Pugua.mp3";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @AfterClass
+    public static void afterClass() throws Exception {
+        AbstractXmlUnitTest.afterServiceTest();
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Override
+    protected String[] getIgnoredXmlElements() {
+        String[] ignored = super.getIgnoredXmlElements();
+        List<String> additionalIgnored = new ArrayList<>(Arrays.asList(ignored));
+        additionalIgnored.add("ID");
+        additionalIgnored.add("audioObjectRef");
+        additionalIgnored.add("formatRef");
+        additionalIgnored.add("faceRef");
+        additionalIgnored.add("faceRegionRef");
+        additionalIgnored.add("ownerRef");
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
+        return additionalIgnored.toArray(new String[additionalIgnored.size()]);
+    }
+
+    @Test
+    public void testMP3() throws Exception {
+
+        String inputFilename = "Jess26676_Pugua.mp3";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/service/MixXmlUnitServiceTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/service/MixXmlUnitServiceTest.java
@@ -1,26 +1,27 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit.service;
 
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
@@ -28,247 +29,225 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These tests compare actual FITS output with expected output on image files.
  * NOTE: This is an integration test that requires a running web application with the
  * FITS Service running.
- * 
+ *
  * @author dan179
  */
 @Ignore
 public class MixXmlUnitServiceTest extends AbstractXmlUnitTest {
 
-	@BeforeClass
-	public static void initializeHttpClient() throws Exception {
-		AbstractXmlUnitTest.beforeServiceTest();
-	}
-	
-	@AfterClass
-	public static void afterClass() throws Exception {
-		AbstractXmlUnitTest.afterServiceTest();
-	}
-    
-	@Test
-	public void testMIX() throws Exception {	
+    @BeforeClass
+    public static void initializeHttpClient() throws Exception {
+        AbstractXmlUnitTest.beforeServiceTest();
+    }
 
-		String inputFilename = "topazscanner.tif";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+    @AfterClass
+    public static void afterClass() throws Exception {
+        AbstractXmlUnitTest.afterServiceTest();
+    }
 
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+    @Test
+    public void testMIX() throws Exception {
 
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        String inputFilename = "topazscanner.tif";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testUncompressedTif() throws Exception {
-		
-		String inputFilename = "4072820.tif";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		fitsOut.addStandardCombinedFormat();
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testJpgExif() throws Exception {	
+    @Test
+    public void testUncompressedTif() throws Exception {
 
-		String inputFilename = "ICFA.KC.BIA.1524-small.jpg";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = super.examine(input);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String inputFilename = "4072820.tif";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
 
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        fitsOut.addStandardCombinedFormat();
 
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testJpgExif2() throws Exception {	
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		String inputFilename = "gps.jpg";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = super.examine(input);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @Test
+    public void testJpgExif() throws Exception {
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String inputFilename = "ICFA.KC.BIA.1524-small.jpg";
+        File input = new File("testfiles/" + inputFilename);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testJpgJfif() throws Exception {	
+        FitsOutput fitsOut = super.examine(input);
 
-		String inputFilename = "GLOBE1.JPG";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = super.examine(input);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
 
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testJpg2() throws Exception {
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		String inputFilename = "JPEGTest_20170591--JPEGTest_20170591.jpeg";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = super.examine(input);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @Test
+    public void testJpgExif2() throws Exception {
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String inputFilename = "gps.jpg";
+        File input = new File("testfiles/" + inputFilename);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testTwoPageTiff() throws Exception {
+        FitsOutput fitsOut = super.examine(input);
 
-		String inputFilename = "W00EGS1016782-I01JW30--I01JW300001__0001.tif";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = super.examine(input);
-    	
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testJp2_1() throws Exception {
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		String inputFilename = "test.jp2";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = super.examine(input);
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @Test
+    public void testJpgJfif() throws Exception {
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String inputFilename = "GLOBE1.JPG";
+        File input = new File("testfiles/" + inputFilename);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-    
-	@Test
-	public void testJp2_2() throws Exception {
+        FitsOutput fitsOut = super.examine(input);
 
-		String inputFilename = "006607203_00018.jp2";
-    	File input = new File("testfiles/" + inputFilename);
-    	
-    	FitsOutput fitsOut = super.examine(input);
-		
-		fitsOut.addStandardCombinedFormat(); // output all data to file
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testJpg2() throws Exception {
+
+        String inputFilename = "JPEGTest_20170591--JPEGTest_20170591.jpeg";
+        File input = new File("testfiles/" + inputFilename);
+
+        FitsOutput fitsOut = super.examine(input);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testTwoPageTiff() throws Exception {
+
+        String inputFilename = "W00EGS1016782-I01JW30--I01JW300001__0001.tif";
+        File input = new File("testfiles/" + inputFilename);
+
+        FitsOutput fitsOut = super.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testJp2_1() throws Exception {
+
+        String inputFilename = "test.jp2";
+        File input = new File("testfiles/" + inputFilename);
+
+        FitsOutput fitsOut = super.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testJp2_2() throws Exception {
+
+        String inputFilename = "006607203_00018.jp2";
+        File input = new File("testfiles/" + inputFilename);
+
+        FitsOutput fitsOut = super.examine(input);
+
+        fitsOut.addStandardCombinedFormat(); // output all data to file
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/service/TextMDXmlUnitServiceTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/service/TextMDXmlUnitServiceTest.java
@@ -1,26 +1,27 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit.service;
 
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
@@ -28,93 +29,83 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These tests compare actual FITS output with expected output on text files.
  * NOTE: This is an integration test that requires a running web application with the
  * FITS Service running.
- * 
+ *
  * @author dan179
  */
 @Ignore
 public class TextMDXmlUnitServiceTest extends AbstractXmlUnitTest {
 
-	@BeforeClass
-	public static void initializeHttpClient() throws Exception {
-		AbstractXmlUnitTest.beforeServiceTest();
-	}
-	
-	@AfterClass
-	public static void afterClass() throws Exception {
-		AbstractXmlUnitTest.afterServiceTest();
-	}
-    
-	@Test
-	public void testUTF16TextMD() throws Exception {	
+    @BeforeClass
+    public static void initializeHttpClient() throws Exception {
+        AbstractXmlUnitTest.beforeServiceTest();
+    }
 
-		String inputFilename = "utf16.txt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @AfterClass
+    public static void afterClass() throws Exception {
+        AbstractXmlUnitTest.afterServiceTest();
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testUTF16TextMD() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        String inputFilename = "utf16.txt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-	@Test
-	public void testPlainText() throws Exception {	
-		
-		String inputFilename = "plain-text.txt";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-	@Test
-	public void testCsv() throws Exception {	
-    	
-    	String inputFilename = "random_data.csv";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @Test
+    public void testPlainText() throws Exception {
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String inputFilename = "plain-text.txt";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testCsv() throws Exception {
+
+        String inputFilename = "random_data.csv";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/service/VideoStdSchemaTestXmlServiceUnit.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/service/VideoStdSchemaTestXmlServiceUnit.java
@@ -1,27 +1,29 @@
-/* 
+/*
  * Copyright 2015 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit.service;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
@@ -29,280 +31,265 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These tests compare actual FITS output with expected output on video files.
  * NOTE: This is an integration test that requires a running web application with the
  * FITS Service running.
- * 
+ *
  * @author dan179
  */
 @Ignore
 public class VideoStdSchemaTestXmlServiceUnit extends AbstractXmlUnitTest {
 
-	@BeforeClass
-	public static void initializeHttpClient() throws Exception {
-		AbstractXmlUnitTest.beforeServiceTest();
-	}
-	
-	@AfterClass
-	public static void afterClass() throws Exception {
-		AbstractXmlUnitTest.afterServiceTest();
-	}
-	
-	// These override the values in the parent class.
-	private static final String[] OVERRIDING_IGNORED_XML_ELEMENTS = {
-			"version",
-			"toolversion",
-			"dateModified",
-			"fslastmodified",
-			"startDate",
-			"startTime",
-			"timestamp", 
-			"fitsExecutionTime",
-			"executionTime",
-			"filepath",
-			"location",
-			"lastmodified",
-			"ebucore:locator"};
+    @BeforeClass
+    public static void initializeHttpClient() throws Exception {
+        AbstractXmlUnitTest.beforeServiceTest();
+    }
 
-	@Test  
-	public void testVideoXmlUnitFitsOutput_AVC() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = super.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+    @AfterClass
+    public static void afterClass() throws Exception {
+        AbstractXmlUnitTest.afterServiceTest();
+    }
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    // These override the values in the parent class.
+    private static final String[] OVERRIDING_IGNORED_XML_ELEMENTS = {
+        "version",
+        "toolversion",
+        "dateModified",
+        "fslastmodified",
+        "startDate",
+        "startTime",
+        "timestamp",
+        "fitsExecutionTime",
+        "executionTime",
+        "filepath",
+        "location",
+        "lastmodified",
+        "ebucore:locator"
+    };
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testVideoXmlUnitFitsOutput_AVC() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test  
-	public void testVideoXmlUnitFitsOutput_DV() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-26.mov";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = super.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+        String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}	
-	
-	@Test  
-	public void testVideoXmlUnitStandardOutput_AVC() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = super.examine(input);
-		
-		// Output stream for FITS to write to 
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		
-		// Create standard output in the stream passed in
-		Fits.outputStandardSchemaXml(fitsOut, out);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + "-standard-only" + ACTUAL_OUTPUT_FILE_SUFFIX);
-		
-		// Turn output stream into a String HtmlUnit can use
-		String actualXmlStr = new String(out.toByteArray(),"UTF-8");
-		
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + "-standard-only" + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test  
-	public void testVideoXmlUnitStandardOutput_DV() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-26.mov";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = super.examine(input);
-		
-		// Output stream for FITS to write to 
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		
-		// Create standard output in the stream passed in
-		Fits.outputStandardSchemaXml(fitsOut, out);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + "-standard-only" + ACTUAL_OUTPUT_FILE_SUFFIX);
-		
-		// Turn output stream into a String HtmlUnit can use
-		String actualXmlStr = new String(out.toByteArray(),"UTF-8");
-		
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output//" + inputFilename + "-standard-only" + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testVideoXmlUnitFitsOutput_DV() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}	
-	
-	@Test  
-	public void testVideoXmlUnitCombinedOutput_AVC() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = super.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + "-combined" + ACTUAL_OUTPUT_FILE_SUFFIX);
-		
-		// Output stream for FITS to write to 
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		
-		// Turn output stream into a String HtmlUnit can use
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-		
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-	            "testfiles/output/" + inputFilename + "-combined" + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String inputFilename = "FITS-SAMPLE-26.mov";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test  
-	public void testVideoXmlUnitCombinedOutput_DV() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-26.mov";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = super.examine(input);
-		
-		// Output stream for FITS to write to 
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		
-		// Create combined output in the stream passed in
-		Fits.outputStandardCombinedFormat(fitsOut, out);
-		
-		// Turn output stream into a String HtmlUnit can use
-		String actualXmlStr = new String(out.toByteArray(),"UTF-8");
-		fitsOut.saveToDisk("test-generated-output/" + inputFilename + "-combined" + ACTUAL_OUTPUT_FILE_SUFFIX);
-		
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-	            "testfiles/output/" + inputFilename + "-combined" + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	/**
-	 * Tests that the output from FITS matches the expected output.
-	 */
-	@Test
-	public void testVideoXmlUnitOutput_MXF() throws Exception {
-		
-    	String inputFilename = "freeMXF-mxf1a.mxf";
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = super.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-		
-		// Output stream for FITS to write to 
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		
-		// Turn output stream into a String HtmlUnit can use
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
-		
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-	            "testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test  
-	public void testVideoXmlUnitCombinedOutput_MPEG2() throws Exception {
-		
-    	String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = super.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-		
-		// Output stream for FITS to write to 
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		
-		// Create combined output in the stream passed in
-		Fits.outputStandardCombinedFormat(fitsOut, out);
-		
-		// Turn output stream into a String HtmlUnit can use
-		String actualXmlStr = new String(out.toByteArray(),"UTF-8");
-		
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-	            "testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testVideoXmlUnitStandardOutput_AVC() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}	
-	
-	@Test  
-	public void testVideoXmlUnitFitsOutput_AVC_NO_MD5() throws Exception {
-		
-		File fitsConfigFile = new File("testfiles/properties/fits_no_md5_video.xml");
-		Fits fits = new Fits(null, fitsConfigFile);
-		
-		// First generate the FITS output
-    	String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
-    	File input = new File("testfiles/" + inputFilename);
-		FitsOutput fitsOut = fits.examine(input);
-		fitsOut.saveToDisk("test-generated-output/" + "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1_mp4_FITS_NO_MD5_XmlUnitActualOutput.xml");
+        String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
 
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        // Output stream for FITS to write to
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1_mp4_FITS_NO_MD5.xml"));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        // Create standard output in the stream passed in
+        Fits.outputStandardSchemaXml(fitsOut, out);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + "-standard-only" + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        // Turn output stream into a String HtmlUnit can use
+        String actualXmlStr = new String(out.toByteArray(), "UTF-8");
 
-	/**
-	 * Send in set of XML elements to ignore that overrides the default.
-	 */
-	@Override
-	protected String[] getIgnoredXmlElements() {
-		return OVERRIDING_IGNORED_XML_ELEMENTS;
-	}
+        // Read in the expected XML file
+        Scanner scan = new Scanner(
+                new File("testfiles/output/" + inputFilename + "-standard-only" + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testVideoXmlUnitStandardOutput_DV() throws Exception {
+
+        String inputFilename = "FITS-SAMPLE-26.mov";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+
+        // Output stream for FITS to write to
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // Create standard output in the stream passed in
+        Fits.outputStandardSchemaXml(fitsOut, out);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + "-standard-only" + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        // Turn output stream into a String HtmlUnit can use
+        String actualXmlStr = new String(out.toByteArray(), "UTF-8");
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(
+                new File("testfiles/output//" + inputFilename + "-standard-only" + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testVideoXmlUnitCombinedOutput_AVC() throws Exception {
+
+        String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + "-combined" + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        // Output stream for FITS to write to
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // Turn output stream into a String HtmlUnit can use
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan =
+                new Scanner(new File("testfiles/output/" + inputFilename + "-combined" + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testVideoXmlUnitCombinedOutput_DV() throws Exception {
+
+        String inputFilename = "FITS-SAMPLE-26.mov";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+
+        // Output stream for FITS to write to
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // Create combined output in the stream passed in
+        Fits.outputStandardCombinedFormat(fitsOut, out);
+
+        // Turn output stream into a String HtmlUnit can use
+        String actualXmlStr = new String(out.toByteArray(), "UTF-8");
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + "-combined" + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        // Read in the expected XML file
+        Scanner scan =
+                new Scanner(new File("testfiles/output/" + inputFilename + "-combined" + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    /**
+     * Tests that the output from FITS matches the expected output.
+     */
+    @Test
+    public void testVideoXmlUnitOutput_MXF() throws Exception {
+
+        String inputFilename = "freeMXF-mxf1a.mxf";
+
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        // Output stream for FITS to write to
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // Turn output stream into a String HtmlUnit can use
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testVideoXmlUnitCombinedOutput_MPEG2() throws Exception {
+
+        String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        // Output stream for FITS to write to
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // Create combined output in the stream passed in
+        Fits.outputStandardCombinedFormat(fitsOut, out);
+
+        // Turn output stream into a String HtmlUnit can use
+        String actualXmlStr = new String(out.toByteArray(), "UTF-8");
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testVideoXmlUnitFitsOutput_AVC_NO_MD5() throws Exception {
+
+        File fitsConfigFile = new File("testfiles/properties/fits_no_md5_video.xml");
+        Fits fits = new Fits(null, fitsConfigFile);
+
+        // First generate the FITS output
+        String inputFilename = "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = fits.examine(input);
+        fitsOut.saveToDisk("test-generated-output/"
+                + "FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1_mp4_FITS_NO_MD5_XmlUnitActualOutput.xml");
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan =
+                new Scanner(new File("testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1_mp4_FITS_NO_MD5.xml"));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    /**
+     * Send in set of XML elements to ignore that overrides the default.
+     */
+    @Override
+    protected String[] getIgnoredXmlElements() {
+        return OVERRIDING_IGNORED_XML_ELEMENTS;
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/junit/service/ZipXmlUnitServiceTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/service/ZipXmlUnitServiceTest.java
@@ -1,26 +1,27 @@
-/* 
+/*
  * Copyright 2016 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.junit.service;
 
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
 import java.io.File;
 import java.util.Scanner;
-
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.AfterClass;
@@ -28,158 +29,142 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.tests.AbstractXmlUnitTest;
-
 /**
  * These tests compare actual FITS output with expected output on ZIP files.
  * These tests should be run with &lt;display-tool-output&gt;false&lt;/display-tool-output&gt; in fits.xml.
  * NOTE: This is an integration test that requires a running web application with the
  * FITS Service running.
- * 
+ *
  * @author dan179
  */
 @Ignore
 public class ZipXmlUnitServiceTest extends AbstractXmlUnitTest {
 
-	@BeforeClass
-	public static void initializeHttpClient() throws Exception {
-		AbstractXmlUnitTest.beforeServiceTest();
-	}
-	
-	@AfterClass
-	public static void afterClass() throws Exception {
-		AbstractXmlUnitTest.afterServiceTest();
-	}
-	
-	@Test
-	public void testUncompressedZipFile() throws Exception {
+    @BeforeClass
+    public static void initializeHttpClient() throws Exception {
+        AbstractXmlUnitTest.beforeServiceTest();
+    }
 
-    	String inputFilename = "32044020597662.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @AfterClass
+    public static void afterClass() throws Exception {
+        AbstractXmlUnitTest.afterServiceTest();
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testUncompressedZipFile() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testCompressedZipFile() throws Exception {
+        String inputFilename = "32044020597662.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-    	String inputFilename = "assorted-files.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testSingleFileZipFile() throws Exception {
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-    	String inputFilename = "40415587.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+    @Test
+    public void testCompressedZipFile() throws Exception {
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        String inputFilename = "assorted-files.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testCompressedEncryptedZipFile() throws Exception {
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-    	String inputFilename = "compressed-encrypted.zip"; // 0sample1-compressed
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testUncompressedEncryptedZipFile() throws Exception {
+    @Test
+    public void testSingleFileZipFile() throws Exception {
 
-    	String inputFilename = "uncompressed-encrypted.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        String inputFilename = "40415587.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
-	
-	@Test
-	public void testEmbeddedDirectoriesZipFile() throws Exception {
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
 
-    	String inputFilename = "multiple-file-types-and-folders.zip";
-    	File input = new File("testfiles/" + inputFilename);
-    	FitsOutput fitsOut = super.examine(input);
-    	fitsOut.addStandardCombinedFormat();
-    	fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
-    	
-		XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
-		String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 
-		// Read in the expected XML file
-		Scanner scan = new Scanner(new File(
-				"testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
-		String expectedXmlStr = scan.
-				useDelimiter("\\Z").next();
-		scan.close();
+    @Test
+    public void testCompressedEncryptedZipFile() throws Exception {
 
-		testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
-	}
+        String inputFilename = "compressed-encrypted.zip"; // 0sample1-compressed
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
 
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testUncompressedEncryptedZipFile() throws Exception {
+
+        String inputFilename = "uncompressed-encrypted.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + ACTUAL_OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
+
+    @Test
+    public void testEmbeddedDirectoriesZipFile() throws Exception {
+
+        String inputFilename = "multiple-file-types-and-folders.zip";
+        File input = new File("testfiles/" + inputFilename);
+        FitsOutput fitsOut = super.examine(input);
+        fitsOut.addStandardCombinedFormat();
+        fitsOut.saveToDisk("test-generated-output/" + inputFilename + OUTPUT_FILE_SUFFIX);
+
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+        String actualXmlStr = serializer.outputString(fitsOut.getFitsXml());
+
+        // Read in the expected XML file
+        Scanner scan = new Scanner(new File("testfiles/output/" + inputFilename + EXPECTED_OUTPUT_FILE_SUFFIX));
+        String expectedXmlStr = scan.useDelimiter("\\Z").next();
+        scan.close();
+
+        testActualAgainstExpected(actualXmlStr, expectedXmlStr, inputFilename);
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/tests/AbstractLoggingTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/tests/AbstractLoggingTest.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * Copyright 2017 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,21 +24,21 @@ import java.io.File;
  * This base class is for initializing logging for test classes to set the logging configuration
  * in the Fits constructor by means of an environment variable. This allows for a separate logging configuration for test classes
  * other than the default logging as set up within FITS.java.
- * 
+ *
  * @see edu.harvard.hul.ois.fits.Fits#Fits(String, File)
  * @author dan179
  */
 public abstract class AbstractLoggingTest {
-	
-	// Suffix added to input file name for actual FITS output file NOT used for test comparison.
-	protected static final String OUTPUT_FILE_SUFFIX = "_Output.xml";
 
-	/**
-	 * Configure logging with the test logging configuration file by setting a system property.
-	 * See "Default Initialization Procedure" here: https://logging.apache.org/log4j/2.x/manual/
-	 */
-	static {
-		File log4jConfig = new File("src/test/resources/log4j2.xml");
-	    System.setProperty( "log4j2.configurationFile", log4jConfig.toURI().toString());
-	}
+    // Suffix added to input file name for actual FITS output file NOT used for test comparison.
+    protected static final String OUTPUT_FILE_SUFFIX = "_Output.xml";
+
+    /**
+     * Configure logging with the test logging configuration file by setting a system property.
+     * See "Default Initialization Procedure" here: https://logging.apache.org/log4j/2.x/manual/
+     */
+    static {
+        File log4jConfig = new File("src/test/resources/log4j2.xml");
+        System.setProperty("log4j2.configurationFile", log4jConfig.toURI().toString());
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/tests/AbstractXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/tests/AbstractXmlUnitTest.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * Copyright 2017 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,6 +20,8 @@ package edu.harvard.hul.ois.fits.tests;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLIdentical;
 
+import edu.harvard.hul.ois.fits.FitsOutput;
+import edu.harvard.hul.ois.fits.junit.IgnoreNamedElementsDifferenceListener;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +29,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -46,147 +47,143 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
-import edu.harvard.hul.ois.fits.FitsOutput;
-import edu.harvard.hul.ois.fits.junit.IgnoreNamedElementsDifferenceListener;
-
 /**
  * Base class containing common functionality for performing XMLUnit tests.
- * 
+ *
  * @author dan179
  */
 public class AbstractXmlUnitTest extends AbstractLoggingTest {
-	
-	// Suffix added to input file name for actual FITS output file used for test comparison.
-	protected static final String ACTUAL_OUTPUT_FILE_SUFFIX = "_XmlUnitActualOutput.xml";
 
-	// Suffix added to input file name for finding expected FITS output file.
-	protected static final String EXPECTED_OUTPUT_FILE_SUFFIX = "_XmlUnitExpectedOutput.xml";
+    // Suffix added to input file name for actual FITS output file used for test comparison.
+    protected static final String ACTUAL_OUTPUT_FILE_SUFFIX = "_XmlUnitActualOutput.xml";
 
-	// These are the attributes that should be ignored when comparing actual FITS output with
-	// the expected output file.
-	private static final String[] IGNORED_XML_ELEMENTS = {
-			"version",
-			"created",
-			"toolversion",
-			"dateModified",
-			"fslastmodified",
-			"startDate",
-			"startTime",
-			"timestamp", 
-			"fitsExecutionTime",
-			"executionTime",
-			"filepath",
-			"location",
-			"lastmodified"};
+    // Suffix added to input file name for finding expected FITS output file.
+    protected static final String EXPECTED_OUTPUT_FILE_SUFFIX = "_XmlUnitExpectedOutput.xml";
 
-	// To be used when accessing an external FITS Servlet deployment.
-	private static CloseableHttpClient httpclient;
-	// Location of external FITS Servlet instance.
-	private static String servicePostURL = "http://localhost:8080/fits/examine?includeStandardOutput=false";
+    // These are the attributes that should be ignored when comparing actual FITS output with
+    // the expected output file.
+    private static final String[] IGNORED_XML_ELEMENTS = {
+        "version",
+        "created",
+        "toolversion",
+        "dateModified",
+        "fslastmodified",
+        "startDate",
+        "startTime",
+        "timestamp",
+        "fitsExecutionTime",
+        "executionTime",
+        "filepath",
+        "location",
+        "lastmodified"
+    };
 
-	private static Logger logger = null;
+    // To be used when accessing an external FITS Servlet deployment.
+    private static CloseableHttpClient httpclient;
+    // Location of external FITS Servlet instance.
+    private static String servicePostURL = "http://localhost:8080/fits/examine?includeStandardOutput=false";
 
-	@BeforeClass
-	public static void abstractClassSetup() throws Exception {
-		// Set up XMLUnit for all classes.
-	    logger = LoggerFactory.getLogger(AbstractXmlUnitTest.class);
-		XMLUnit.setIgnoreWhitespace(true);
-		XMLUnit.setNormalizeWhitespace(true);
-	}
+    private static Logger logger = null;
 
-	/**
-	 * Allows for the overriding of XML elements to be ignored in the XMLUnit comparison.
-	 */
-	protected String[] getIgnoredXmlElements() {
-		return IGNORED_XML_ELEMENTS;
-	}
-	
-	/**
-	 * This method performs the actual test of actual FITS output against expected.
-	 */
-	protected void testActualAgainstExpected(String actualXmlStr, String expectedXmlStr, String inputFilename)
-			throws SAXException, IOException {
-		Diff diff = new Diff(expectedXmlStr,actualXmlStr);
+    @BeforeClass
+    public static void abstractClassSetup() throws Exception {
+        // Set up XMLUnit for all classes.
+        logger = LoggerFactory.getLogger(AbstractXmlUnitTest.class);
+        XMLUnit.setIgnoreWhitespace(true);
+        XMLUnit.setNormalizeWhitespace(true);
+    }
 
-		// Initialize attributes or elements to ignore for difference checking
-		diff.overrideDifferenceListener(new IgnoreNamedElementsDifferenceListener(getIgnoredXmlElements()));
+    /**
+     * Allows for the overriding of XML elements to be ignored in the XMLUnit comparison.
+     */
+    protected String[] getIgnoredXmlElements() {
+        return IGNORED_XML_ELEMENTS;
+    }
 
-		DetailedDiff detailedDiff = new DetailedDiff(diff);
+    /**
+     * This method performs the actual test of actual FITS output against expected.
+     */
+    protected void testActualAgainstExpected(String actualXmlStr, String expectedXmlStr, String inputFilename)
+            throws SAXException, IOException {
+        Diff diff = new Diff(expectedXmlStr, actualXmlStr);
 
-		// Display any Differences
-		@SuppressWarnings("unchecked")
-		List<Difference> diffs = detailedDiff.getAllDifferences();
-		if (!diff.identical()) { 
-			StringBuffer differenceDescription = new StringBuffer(); 
-			differenceDescription.append(diffs.size()).append(" differences for input file: " + inputFilename); 
-			
-			System.out.println(differenceDescription.toString());
-			for(Difference difference : diffs) {
-				System.out.println(difference.toString());
-			}
+        // Initialize attributes or elements to ignore for difference checking
+        diff.overrideDifferenceListener(new IgnoreNamedElementsDifferenceListener(getIgnoredXmlElements()));
 
-		}
-		assertXMLIdentical("Differences in XML for file: " + inputFilename, diff, true);
-	}
-	
-	/**
-	 * To be called from a @BeforeClass method in a class that is testing an external FITS web application.
-	 */
-	protected static void beforeServiceTest() throws Exception {
-        httpclient = HttpClients.createDefault();
-	}
+        DetailedDiff detailedDiff = new DetailedDiff(diff);
 
-	/**
-	 * To be called from a @AfterClass method in a class that is testing an external FITS web application.
-	 */
-	protected static void afterServiceTest() throws Exception {
-        if (httpclient != null) {
-        	httpclient.close();
+        // Display any Differences
+        @SuppressWarnings("unchecked")
+        List<Difference> diffs = detailedDiff.getAllDifferences();
+        if (!diff.identical()) {
+            StringBuffer differenceDescription = new StringBuffer();
+            differenceDescription.append(diffs.size()).append(" differences for input file: " + inputFilename);
+
+            System.out.println(differenceDescription.toString());
+            for (Difference difference : diffs) {
+                System.out.println(difference.toString());
+            }
         }
-	}
+        assertXMLIdentical("Differences in XML for file: " + inputFilename, diff, true);
+    }
 
-	/**
-	 * To be called from a method in a class that is testing an external FITS web application.
-	 */
-	protected FitsOutput examine(File inputFile) throws Exception {
-		
-    	HttpPost httpPost = new HttpPost(servicePostURL);
-		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-		builder.addBinaryBody("datafile", inputFile, ContentType.APPLICATION_OCTET_STREAM, inputFile.getName());
-		HttpEntity reqEntity = builder.build();
-		httpPost.setEntity(reqEntity);
+    /**
+     * To be called from a @BeforeClass method in a class that is testing an external FITS web application.
+     */
+    protected static void beforeServiceTest() throws Exception {
+        httpclient = HttpClients.createDefault();
+    }
 
-		logger.info("executing request " + httpPost.getRequestLine());
-		CloseableHttpResponse response = httpclient.execute(httpPost);
-		
-		FitsOutput fitsOutput = null;
-		try {
-			logger.info("HTTP Response Status Line: " + response.getStatusLine());
-			// Expecting a 200 Status Code
-			if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-				String reason = response.getStatusLine().getReasonPhrase();
-				logger.warn("Unexpected HTTP response status code:[" + response.getStatusLine().getStatusCode() +
-						"] -- Reason (if available): " + reason);
-			} else {
-				HttpEntity resEntity = response.getEntity();
-				InputStream is = resEntity.getContent();
-				BufferedReader in = new BufferedReader( new InputStreamReader( is, StandardCharsets.UTF_8.name() ) );
+    /**
+     * To be called from a @AfterClass method in a class that is testing an external FITS web application.
+     */
+    protected static void afterServiceTest() throws Exception {
+        if (httpclient != null) {
+            httpclient.close();
+        }
+    }
 
-				String output;
-				StringBuilder sb = new StringBuilder();
-				while ( (output = in.readLine()) != null ) {
-					sb.append( output );
-					sb.append(System.getProperty("line.separator"));
-				}
-				logger.info(sb.toString());
-				in.close();
-				EntityUtils.consume(resEntity);
-				fitsOutput = new FitsOutput(sb.toString());
-			}
-		} finally {
-			response.close();
-		}
-		return fitsOutput;
-	}
+    /**
+     * To be called from a method in a class that is testing an external FITS web application.
+     */
+    protected FitsOutput examine(File inputFile) throws Exception {
 
+        HttpPost httpPost = new HttpPost(servicePostURL);
+        MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+        builder.addBinaryBody("datafile", inputFile, ContentType.APPLICATION_OCTET_STREAM, inputFile.getName());
+        HttpEntity reqEntity = builder.build();
+        httpPost.setEntity(reqEntity);
+
+        logger.info("executing request " + httpPost.getRequestLine());
+        CloseableHttpResponse response = httpclient.execute(httpPost);
+
+        FitsOutput fitsOutput = null;
+        try {
+            logger.info("HTTP Response Status Line: " + response.getStatusLine());
+            // Expecting a 200 Status Code
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                String reason = response.getStatusLine().getReasonPhrase();
+                logger.warn("Unexpected HTTP response status code:["
+                        + response.getStatusLine().getStatusCode() + "] -- Reason (if available): " + reason);
+            } else {
+                HttpEntity resEntity = response.getEntity();
+                InputStream is = resEntity.getContent();
+                BufferedReader in = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8.name()));
+
+                String output;
+                StringBuilder sb = new StringBuilder();
+                while ((output = in.readLine()) != null) {
+                    sb.append(output);
+                    sb.append(System.getProperty("line.separator"));
+                }
+                logger.info(sb.toString());
+                in.close();
+                EntityUtils.consume(resEntity);
+                fitsOutput = new FitsOutput(sb.toString());
+            }
+        } finally {
+            response.close();
+        }
+        return fitsOutput;
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/tests/IgnoreAttributeValuesDifferenceListener.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/tests/IgnoreAttributeValuesDifferenceListener.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,35 +24,31 @@ import org.custommonkey.xmlunit.DifferenceListener;
 import org.w3c.dom.Node;
 
 public class IgnoreAttributeValuesDifferenceListener implements DifferenceListener {
-	
-	 private static final int[] IGNORE_VALUES = new int[] {
-		   DifferenceConstants.ATTR_VALUE.getId(),
-		   DifferenceConstants.ATTR_VALUE_EXPLICITLY_SPECIFIED.getId()
-		   };
 
+    private static final int[] IGNORE_VALUES = new int[] {
+        DifferenceConstants.ATTR_VALUE.getId(), DifferenceConstants.ATTR_VALUE_EXPLICITLY_SPECIFIED.getId()
+    };
 
-	public int differenceFound(Difference diff) {
-		if (isIgnoredDifference(diff)) {
-			return RETURN_IGNORE_DIFFERENCE_NODES_SIMILAR;
-		} else {
-			return RETURN_ACCEPT_DIFFERENCE;
-		}
-	}
+    public int differenceFound(Difference diff) {
+        if (isIgnoredDifference(diff)) {
+            return RETURN_IGNORE_DIFFERENCE_NODES_SIMILAR;
+        } else {
+            return RETURN_ACCEPT_DIFFERENCE;
+        }
+    }
 
+    public void skippedComparison(Node arg0, Node arg1) {
+        // do nothing here
 
-	public void skippedComparison(Node arg0, Node arg1) {
-		// do nothing here
+    }
 
-	}
-	
-	private boolean isIgnoredDifference(Difference difference) {
-		int differenceId = difference.getId();
-		for (int i=0; i < IGNORE_VALUES.length; ++i) {
-			if (differenceId == IGNORE_VALUES[i]) {
-				return true;
-			}
-		}
-		return false;
-	}
-
+    private boolean isIgnoredDifference(Difference difference) {
+        int differenceId = difference.getId();
+        for (int i = 0; i < IGNORE_VALUES.length; ++i) {
+            if (differenceId == IGNORE_VALUES[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/tests/TestOutput.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/tests/TestOutput.java
@@ -1,30 +1,32 @@
-/* 
+/*
  * Copyright 2009 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.tests;
 
+import edu.harvard.hul.ois.fits.Fits;
+import edu.harvard.hul.ois.fits.FitsMetadataElement;
+import edu.harvard.hul.ois.fits.FitsOutput;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
-
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.DifferenceListener;
 import org.jdom2.Document;
@@ -32,143 +34,130 @@ import org.jdom2.input.SAXBuilder;
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 
-import edu.harvard.hul.ois.fits.Fits;
-import edu.harvard.hul.ois.fits.FitsMetadataElement;
-import edu.harvard.hul.ois.fits.FitsOutput;
-
-
-
 public class TestOutput {
-	
-	private static final String USAGE = "generatetestoutput [create | test] input_dir output_dir";
 
-	/**
-	 * @param args
-	 * @throws Exception 
-	 */
-	public static void main(String[] args) throws Exception {
-		
-		if(args.length != 3) {
-			System.out.println("Invalid Syntax");
-			System.out.println("Usage:\n"+ USAGE);
-			System.exit(0);
-		}
-        
-        if(args[0].equals("create")) {
-        	createTestOutput(args[1],args[2]);
+    private static final String USAGE = "generatetestoutput [create | test] input_dir output_dir";
+
+    /**
+     * @param args
+     * @throws Exception
+     */
+    public static void main(String[] args) throws Exception {
+
+        if (args.length != 3) {
+            System.out.println("Invalid Syntax");
+            System.out.println("Usage:\n" + USAGE);
+            System.exit(0);
         }
-        else if(args[0].equals("test")){
-        	test(args[1],args[2]);
+
+        if (args[0].equals("create")) {
+            createTestOutput(args[1], args[2]);
+        } else if (args[0].equals("test")) {
+            test(args[1], args[2]);
+        } else {
+            System.out.println("Usage:\n" + USAGE);
+            System.exit(0);
         }
-        else {
-	    	System.out.println("Usage:\n"+ USAGE);
-	    	System.exit(0);       	
+    }
+
+    private static void createTestOutput(String input, String output) throws Exception {
+        // prompt for confirmation
+        System.out.print("This will erase all existing test output, continue? [y/n]: ");
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String userConfirm = null;
+        try {
+            userConfirm = br.readLine();
+        } catch (IOException ioe) {
+            System.out.println("IO error reading input");
+            System.exit(1);
         }
- 	}
-	
-	private static void createTestOutput(String input, String output) throws Exception {
-		//prompt for confirmation
-		System.out.print("This will erase all existing test output, continue? [y/n]: ");
-		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-		String userConfirm = null;
-		try {
-			userConfirm = br.readLine();
-		} catch (IOException ioe) {
-		   System.out.println("IO error reading input");
-		   System.exit(1);
-		}
 
-		if(!userConfirm.equalsIgnoreCase("y")) {
-			System.out.println("exiting");
-			System.exit(0);
-		}
-		
-		File inputDir = new File(input);
-		File outputDir = new File(output);
-		
-		//delete all existing output
-		for(File outputFile : outputDir.listFiles()) {
-			//only delete the .xml files
-			if(!outputFile.getPath().endsWith(".xml")) {
-				continue;
-			}
-			System.out.println("deleting " + outputFile.getPath());
-			outputFile.delete();
-		}
-		
-		Fits fits = new Fits("");
-		
-		//create new output for files in input dir
-		for(File inputFile : inputDir.listFiles()) {
-			//skip directories
-			if(inputFile.isDirectory()) {
-				continue;
-			}
-			System.out.println("processing " + inputFile.getPath());
-			FitsOutput fitsOutput = fits.examine(inputFile);
-			fitsOutput.saveToDisk(outputDir.getPath()+File.separator+inputFile.getName()+".xml");
-		}
-		
-		System.out.println("All Done");
+        if (!userConfirm.equalsIgnoreCase("y")) {
+            System.out.println("exiting");
+            System.exit(0);
+        }
 
-	}
-	
-	private static void test(String input, String output) throws Exception {
-	   	Fits fits = new Fits("");
-    	SAXBuilder builder = new SAXBuilder();  	
-    	XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());  	
-    	
-		File inputDir =new File(input);
-		File outputDir =new File(output);
-		
-		int passed = 0;
-		int failed = 0;
-				
-		for(File inputFile : inputDir.listFiles()) {
-			//skip directories
-			if(inputFile.isDirectory()) {
-				continue;
-			}
-			StringWriter sw = new StringWriter();
-			
-			FitsOutput fitsOut = fits.examine(inputFile);
-			serializer.output(fitsOut.getFitsXml(), sw);
-			String actualStr = sw.toString(); 
-			
-			File outputFile = new File(outputDir + File.separator + inputFile.getName()+".xml");
-			if(!outputFile.exists()) {
-				System.err.println("Not Found: "+outputFile.getPath());
-				continue;
-			}
-			Document expectedXml = builder.build(new FileInputStream(outputFile));
-			sw = new StringWriter();
-			serializer.output(expectedXml, sw);
-			String expectedStr = sw.toString();
-			
-			//get the file name in case of a failure
-			FitsMetadataElement item = fitsOut.getFileInfoElement("filename");
-		    DifferenceListener myDifferenceListener = new IgnoreAttributeValuesDifferenceListener();
-		    Diff diff = new Diff(expectedStr,actualStr);
-		    diff.overrideDifferenceListener(myDifferenceListener);
+        File inputDir = new File(input);
+        File outputDir = new File(output);
 
-		    if(diff.similar()) {
-		    	System.out.println("PASS: "+item.getValue());
-		    	passed++;
-		    }
-		    else {
-		    	System.err.println("FAIL: "+item.getValue());
-		    	failed++;
-		    }
-		}
-		System.out.println("All Done");
-		System.out.println(passed + " tests passed");
-		if(failed != 0) {
-			System.err.println(failed + " tests failed");
-		}
-		else {
-			System.out.println(failed + " tests failed");
-		}
+        // delete all existing output
+        for (File outputFile : outputDir.listFiles()) {
+            // only delete the .xml files
+            if (!outputFile.getPath().endsWith(".xml")) {
+                continue;
+            }
+            System.out.println("deleting " + outputFile.getPath());
+            outputFile.delete();
+        }
 
-	}
+        Fits fits = new Fits("");
 
+        // create new output for files in input dir
+        for (File inputFile : inputDir.listFiles()) {
+            // skip directories
+            if (inputFile.isDirectory()) {
+                continue;
+            }
+            System.out.println("processing " + inputFile.getPath());
+            FitsOutput fitsOutput = fits.examine(inputFile);
+            fitsOutput.saveToDisk(outputDir.getPath() + File.separator + inputFile.getName() + ".xml");
+        }
+
+        System.out.println("All Done");
+    }
+
+    private static void test(String input, String output) throws Exception {
+        Fits fits = new Fits("");
+        SAXBuilder builder = new SAXBuilder();
+        XMLOutputter serializer = new XMLOutputter(Format.getPrettyFormat());
+
+        File inputDir = new File(input);
+        File outputDir = new File(output);
+
+        int passed = 0;
+        int failed = 0;
+
+        for (File inputFile : inputDir.listFiles()) {
+            // skip directories
+            if (inputFile.isDirectory()) {
+                continue;
+            }
+            StringWriter sw = new StringWriter();
+
+            FitsOutput fitsOut = fits.examine(inputFile);
+            serializer.output(fitsOut.getFitsXml(), sw);
+            String actualStr = sw.toString();
+
+            File outputFile = new File(outputDir + File.separator + inputFile.getName() + ".xml");
+            if (!outputFile.exists()) {
+                System.err.println("Not Found: " + outputFile.getPath());
+                continue;
+            }
+            Document expectedXml = builder.build(new FileInputStream(outputFile));
+            sw = new StringWriter();
+            serializer.output(expectedXml, sw);
+            String expectedStr = sw.toString();
+
+            // get the file name in case of a failure
+            FitsMetadataElement item = fitsOut.getFileInfoElement("filename");
+            DifferenceListener myDifferenceListener = new IgnoreAttributeValuesDifferenceListener();
+            Diff diff = new Diff(expectedStr, actualStr);
+            diff.overrideDifferenceListener(myDifferenceListener);
+
+            if (diff.similar()) {
+                System.out.println("PASS: " + item.getValue());
+                passed++;
+            } else {
+                System.err.println("FAIL: " + item.getValue());
+                failed++;
+            }
+        }
+        System.out.println("All Done");
+        System.out.println(passed + " tests passed");
+        if (failed != 0) {
+            System.err.println(failed + " tests failed");
+        } else {
+            System.out.println(failed + " tests failed");
+        }
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/tools/NoArgumentTestTool.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/tools/NoArgumentTestTool.java
@@ -1,54 +1,53 @@
-/* 
+/*
  * Copyright 2017 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.tools;
 
-import java.io.File;
-
 import edu.harvard.hul.ois.fits.exceptions.FitsConfigurationException;
 import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import java.io.File;
 
 /**
  * A no-argument trivial implementation of the Tool interface to test reflection in ToolBelt.
- * 
+ *
  * @see edu.harvard.hul.ois.fits.tools.ToolBeltTest#noArgumentConstructorToolTest()
  */
 public class NoArgumentTestTool extends ToolBase implements Tool {
 
-	/**
-	 * @throws FitsConfigurationException
-	 */
-	public NoArgumentTestTool() throws FitsToolException {
-		super();
-	}
+    /**
+     * @throws FitsConfigurationException
+     */
+    public NoArgumentTestTool() throws FitsToolException {
+        super();
+    }
 
-	@Override
-	public ToolOutput extractInfo(File file) throws FitsToolException {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public ToolOutput extractInfo(File file) throws FitsToolException {
+        throw new UnsupportedOperationException();
+    }
 
-	@Override
-	public boolean isEnabled() {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public boolean isEnabled() {
+        throw new UnsupportedOperationException();
+    }
 
-	@Override
-	public void setEnabled(boolean value) {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public void setEnabled(boolean value) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/tools/OneArgumentTestTool.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/tools/OneArgumentTestTool.java
@@ -1,55 +1,54 @@
-/* 
+/*
  * Copyright 2017 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
 package edu.harvard.hul.ois.fits.tools;
 
-import java.io.File;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.exceptions.FitsToolException;
+import java.io.File;
 
 /**
  * A one-argument trivial implementation of the Tool interface to test
  * reflection in ToolBelt.
- * 
+ *
  * @see edu.harvard.hul.ois.fits.tools.ToolBeltTest#oneArgumentConstructorToolTest()
  */
 public class OneArgumentTestTool extends ToolBase implements Tool {
 
-	/**
-	 * 
-	 */
-	public OneArgumentTestTool(Fits fits) throws FitsToolException {
-		super();
-	}
+    /**
+     *
+     */
+    public OneArgumentTestTool(Fits fits) throws FitsToolException {
+        super();
+    }
 
-	@Override
-	public ToolOutput extractInfo(File file) throws FitsToolException {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public ToolOutput extractInfo(File file) throws FitsToolException {
+        throw new UnsupportedOperationException();
+    }
 
-	@Override
-	public boolean isEnabled() {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public boolean isEnabled() {
+        throw new UnsupportedOperationException();
+    }
 
-	@Override
-	public void setEnabled(boolean value) {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public void setEnabled(boolean value) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/tools/ToolBeltTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/tools/ToolBeltTest.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * Copyright 2017 Harvard University Library
- * 
+ *
  * This file is part of FITS (File Information Tool Set).
- * 
+ *
  * FITS is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * FITS is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with FITS.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,53 +21,51 @@ package edu.harvard.hul.ois.fits.tools;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
-import java.io.File;
-
-import org.junit.Test;
-
 import edu.harvard.hul.ois.fits.Fits;
 import edu.harvard.hul.ois.fits.exceptions.FitsConfigurationException;
 import edu.harvard.hul.ois.fits.tests.AbstractLoggingTest;
+import java.io.File;
+import org.junit.Test;
 
 public class ToolBeltTest extends AbstractLoggingTest {
 
-	/**
-	 * Tests reflection code in ToolBelt for instantiating a Tool implementation
-	 * which contains only (default) no-argument constructor.
-	 * 
-	 * @see edu.harvard.hul.ois.fits.tools.ToolBelt#createToolClassInstance(
-	 *      Class<?>, Fits)
-	 */
-	@Test
-	public void noArgumentConstructorToolTest() {
-		File fitsConfigFile = new File("testfiles/properties/fits_test_no_arg_tool.xml");
-		assertNotNull(fitsConfigFile);
-		try {
-			// Instantiating Fits will exercise the ToolBelt.
-			@SuppressWarnings("unused")
-			Fits fits = new Fits(null, fitsConfigFile);
-		} catch (FitsConfigurationException e) {
-			fail("Could not instantiate Fits or the XMLConfiguration: " + e.getMessage());
-		}
-	}
+    /**
+     * Tests reflection code in ToolBelt for instantiating a Tool implementation
+     * which contains only (default) no-argument constructor.
+     *
+     * @see edu.harvard.hul.ois.fits.tools.ToolBelt#createToolClassInstance(
+     *      Class<?>, Fits)
+     */
+    @Test
+    public void noArgumentConstructorToolTest() {
+        File fitsConfigFile = new File("testfiles/properties/fits_test_no_arg_tool.xml");
+        assertNotNull(fitsConfigFile);
+        try {
+            // Instantiating Fits will exercise the ToolBelt.
+            @SuppressWarnings("unused")
+            Fits fits = new Fits(null, fitsConfigFile);
+        } catch (FitsConfigurationException e) {
+            fail("Could not instantiate Fits or the XMLConfiguration: " + e.getMessage());
+        }
+    }
 
-	/**
-	 * Tests reflection code in ToolBelt for instantiating a Tool implementation
-	 * which contains a 1-argument constructor with Fits as the argument.
-	 * 
-	 * @see edu.harvard.hul.ois.fits.tools.ToolBelt#createToolClassInstance(
-	 *      Class<?>, Fits)
-	 */
-	@Test
-	public void oneArgumentConstructorToolTest() {
-		File fitsConfigFile = new File("testfiles/properties/fits_test_one_arg_tool.xml");
-		assertNotNull(fitsConfigFile);
-		try {
-			// Instantiating Fits will exercise the ToolBelt.
-			@SuppressWarnings("unused")
-			Fits fits = new Fits(null, fitsConfigFile);
-		} catch (FitsConfigurationException e) {
-			fail("Could not instantiate Fits or the XMLConfiguration: " + e.getMessage());
-		}
-	}
+    /**
+     * Tests reflection code in ToolBelt for instantiating a Tool implementation
+     * which contains a 1-argument constructor with Fits as the argument.
+     *
+     * @see edu.harvard.hul.ois.fits.tools.ToolBelt#createToolClassInstance(
+     *      Class<?>, Fits)
+     */
+    @Test
+    public void oneArgumentConstructorToolTest() {
+        File fitsConfigFile = new File("testfiles/properties/fits_test_one_arg_tool.xml");
+        assertNotNull(fitsConfigFile);
+        try {
+            // Instantiating Fits will exercise the ToolBelt.
+            @SuppressWarnings("unused")
+            Fits fits = new Fits(null, fitsConfigFile);
+        } catch (FitsConfigurationException e) {
+            fail("Could not instantiate Fits or the XMLConfiguration: " + e.getMessage());
+        }
+    }
 }

--- a/src/test/java/edu/harvard/hul/ois/fits/util/DateTimeUtilTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/util/DateTimeUtilTest.java
@@ -10,9 +10,9 @@
 
 package edu.harvard.hul.ois.fits.util;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 public class DateTimeUtilTest {
 
@@ -62,5 +62,4 @@ public class DateTimeUtilTest {
         assertEquals("bogus", DateTimeUtil.standardize("bogus"));
         assertEquals("2020-02-20 01", DateTimeUtil.standardize("2020-02-20 01"));
     }
-
 }


### PR DESCRIPTION
This PR integrates a code formatter. The formatting in FITS extremely inconsistent, even within the same file. This PR integrates [Spotless](https://github.com/diffplug/spotless/blob/main/plugin-maven/README.md) to use the [palantir-java-format](https://github.com/palantir/palantir-java-format), and it applies the formatter to the entire project. `spotless:check` is bound to the `compile` phase, which means that going forward Spotless will ensure that the build fails if there are any files differ from the format. Use `mvn spotless:apply` to apply the formatter to the project. The formatter also has IDE integration ([such as](https://plugins.jetbrains.com/plugin/13180-palantir-java-format)), though I have not personally tried it yet.