### PR TITLE
add justfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,25 @@ To run the formatter:
 
 When the project builds, it checks the formatting and will fail if there are any files that are not formatted per the standard.
 
+### Just
+
+You can optionally install [Just](https://github.com/casey/just) and use it to execute shortcut commands within the
+project for doing things like running tests, formatting, and building. Execute `just` to see the available commands:
+
+```shell
+Available recipes:
+    build               # Builds FITS
+    build-image         # Builds the Docker image
+    default             # Lists available commands
+    format              # Applies the code formatter
+    run +ARGS           # Executes FITS within a Docker container. This requires that the image has already been built (just build-image).
+    test                # Runs the tests within a Docker container. Requires the image to already exist (just test-build-image). The image does NOT need to be rebuilt between runs.
+    test-build-image    # Builds the Docker image that's used for running the tests
+    test-filter PATTERN # Runs the tests that match the pattern within a Docker container. Requires the image to already exist (just test-build-image). The image does NOT need to be rebuilt between runs.
+```
+
+The commands are defined in [justfile](justfile).
+
 License Details
 ---------------
 FITS is released under the [GNU LGPL](http://www.gnu.org/licenses/lgpl.html) open source license. The source code for FITS is included in the downloadable ZIP files.

--- a/justfile
+++ b/justfile
@@ -1,3 +1,7 @@
+# Lists available commands
+default:
+    just --list
+
 # Builds FITS
 build:
     mvn -DskipTests clean package
@@ -6,7 +10,7 @@ build:
 build-image: build
     docker build -f docker/Dockerfile -t fits .
 
-# Executes FITS within a Docker container. This requires that the image has already been built.
+# Executes FITS within a Docker container. This requires that the image has already been built (just build-image).
 run +ARGS:
     docker run --rm -v `pwd`:/work:z fits {{ARGS}}
 
@@ -14,14 +18,14 @@ run +ARGS:
 test-build-image:
     docker build -f docker/Dockerfile-test -t fits-test .
 
-# Runs the tests within a Docker container. This requires that the image has already been built.
+# Runs the tests within a Docker container. Requires the image to already exist (just test-build-image). The image does NOT need to be rebuilt between runs.
 test:
     docker run --rm -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test mvn clean test
 
-# Runs the tests that match the pattern within a Docker container. This requires that the image has already been built.
+# Runs the tests that match the pattern within a Docker container. Requires the image to already exist (just test-build-image). The image does NOT need to be rebuilt between runs.
 test-filter PATTERN:
     docker run --rm -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test mvn clean test -Dtest={{PATTERN}}
 
-# Applys the code formatter
+# Applies the code formatter
 format:
     mvn spotless:apply

--- a/justfile
+++ b/justfile
@@ -1,0 +1,28 @@
+# [Just](https://github.com/casey/just) convenience bindings.
+
+default:
+    just --list
+
+# Builds FITS
+build:
+    mvn -DskipTests clean package
+
+# Builds the Docker image
+build-image: build
+    docker build -f docker/Dockerfile -t fits .
+
+# Executes FITS within a Docker container. This requires that the image has already been built.
+run +ARGS:
+    docker run --rm -v `pwd`:/work:z fits {{ARGS}}
+
+# Builds the Docker image that's used for running the tests
+test-build-image:
+    docker build -f docker/Dockerfile-test -t fits-test .
+
+# Runs the tests within a Docker container. This requires that the image has already been built.
+test:
+    docker run --rm -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test mvn clean test
+
+# Applys the code formatter
+format:
+    mvn spotless:apply

--- a/justfile
+++ b/justfile
@@ -1,8 +1,3 @@
-# [Just](https://github.com/casey/just) convenience bindings.
-
-default:
-    just --list
-
 # Builds FITS
 build:
     mvn -DskipTests clean package
@@ -22,6 +17,10 @@ test-build-image:
 # Runs the tests within a Docker container. This requires that the image has already been built.
 test:
     docker run --rm -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test mvn clean test
+
+# Runs the tests that match the pattern within a Docker container. This requires that the image has already been built.
+test-filter PATTERN:
+    docker run --rm -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test mvn clean test -Dtest={{PATTERN}}
 
 # Applys the code formatter
 format:


### PR DESCRIPTION
This PR adds a convenience [Just](https://github.com/casey/just) integration. The only purpose is to make development easier by removing the need to look up complicated commands. Some examples:

Running the tests in docker:

```shell
just test-build-image
just test
```

Building a fresh image and running FITS on a local file:

```shell
just build-image
just run -i my-cool-file.pdf
```