### PR TITLE
add cli option for enabling debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ all tools that identify a file is included, even if the identified format is _no
 identity. This is a behavior change from previous versions. If you prefer the old behavior, set the value
 to `true` in your `fits.xml`.
 - Add CLI option `-t` for including raw tool output in the report.
+- Add CLI option `-d` for enabling debug output.
 - Fix DROID container format identification.
 - exiftool raw output now only outputs XML.
 - Fix bug where errors from one run were being incorrectly reported on subsequent runs.

--- a/src/main/java/edu/harvard/hul/ois/fits/Fits.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/Fits.java
@@ -81,6 +81,7 @@ public class Fits {
     private static boolean nestDirs;
     private static final XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
     private static boolean rawToolOutput = false;
+    private static boolean debug = false;
 
     private static final String FITS_CONFIG_FILE_NAME = "fits.xml";
     private static final String VERSION_PROPERTIES_FILE = "version.properties";
@@ -248,6 +249,7 @@ public class Fits {
         options.addOption("v", false, "print version information");
         options.addOption("f", true, "alternate fits.xml configuration file location (optional)");
         options.addOption("t", false, "include all raw tool output");
+        options.addOption("d", false, "include debug output");
         OptionGroup outputOptions = new OptionGroup();
         Option stdxml = new Option(
                 "x",
@@ -275,17 +277,10 @@ public class Fits {
             System.out.println(Fits.VERSION);
             System.exit(0);
         }
-        if (cmd.hasOption("r")) {
-            traverseDirs = true;
-        } else {
-            traverseDirs = false;
-        }
-        if (cmd.hasOption("n")) {
-            nestDirs = true;
-        } else {
-            nestDirs = false;
-        }
+        traverseDirs = cmd.hasOption("r");
+        nestDirs = cmd.hasOption("n");
         rawToolOutput = cmd.hasOption("t");
+        debug = cmd.hasOption("d");
 
         File fitsConfigFile = null;
         try {
@@ -328,8 +323,12 @@ public class Fits {
                 System.exit(1);
             }
         } catch (FitsException fe) {
-            System.err.println(fe.getMessage());
-            System.exit(1);
+            if (debug) {
+                throw fe;
+            } else {
+                System.err.println(fe.getMessage());
+                System.exit(1);
+            }
         }
 
         System.exit(0);

--- a/src/main/java/edu/harvard/hul/ois/fits/Fits.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/Fits.java
@@ -53,7 +53,6 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.commons.lang.StringUtils;

--- a/src/main/java/edu/harvard/hul/ois/fits/Fits.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/Fits.java
@@ -232,7 +232,7 @@ public class Fits {
         toolbelt = new ToolBelt(config, this);
     }
 
-    public static void main(String[] args) throws FitsException, IOException, ParseException, XMLStreamException {
+    public static void main(String[] args) throws Exception {
 
         setFitsVersionFromFile();
 
@@ -322,7 +322,7 @@ public class Fits {
                 printHelp(options);
                 System.exit(1);
             }
-        } catch (FitsException fe) {
+        } catch (Exception fe) {
             if (debug) {
                 throw fe;
             } else {


### PR DESCRIPTION
**Resolves Issue**: https://github.com/harvard-lts/fits/issues/146

# What does this Pull Request do?

The code was already changed earlier this year to not print stack traces in the cli by default. This adds a `-d` flag that enables printing them again, which could be useful.

Note that exceptions with stack traces are still logged to the console regardless of this setting if they come through the logging framework. If we wanted, we could configure this at runtime by doing something [like this](https://github.com/fcrepo-exts/fcrepo-doctor/blob/main/src/main/java/org/fcrepo/doctor/cli/DoctorCmd.java#L219). However, I don't know if we should or not because it would override a user's custom logging settings. If a user really doesn't want the stack traces to be logged to the console, they could always just update the logging properties.

# How should this be tested?

```shell
# no trace
just run -i bogus

# trace
just run -i bogus -d
```

# Interested parties

@awoods 
