### PR TITLE
remove unneeded placeholder dirs

### DIFF
--- a/lib/adltool/placeholder.txt
+++ b/lib/adltool/placeholder.txt
@@ -1,2 +1,0 @@
-Placeholder file for empty directory so directory is recognized by Git.
-This file may be deleted once a JAR file is added to this directory.

--- a/lib/audioinfo/placeholder.txt
+++ b/lib/audioinfo/placeholder.txt
@@ -1,2 +1,0 @@
-Placeholder file for empty directory so directory is recognized by Git.
-This file may be deleted once a JAR file is added to this directory.

--- a/lib/exiftool/placeholder.txt
+++ b/lib/exiftool/placeholder.txt
@@ -1,2 +1,0 @@
-Placeholder file for empty directory so directory is recognized by Git.
-This file may be deleted once a JAR file is added to this directory.

--- a/lib/ffident/placeholder.txt
+++ b/lib/ffident/placeholder.txt
@@ -1,2 +1,0 @@
-Placeholder file for empty directory so directory is recognized by Git.
-This file may be deleted once a JAR file is added to this directory.

--- a/lib/fileinfo/placeholder.txt
+++ b/lib/fileinfo/placeholder.txt
@@ -1,2 +1,0 @@
-Placeholder file for empty directory so directory is recognized by Git.
-This file may be deleted once a JAR file is added to this directory.

--- a/lib/fileutility/placeholder.txt
+++ b/lib/fileutility/placeholder.txt
@@ -1,2 +1,0 @@
-Placeholder file for empty directory so directory is recognized by Git.
-This file may be deleted once a JAR file is added to this directory.

--- a/lib/mediainfo/placeholder.txt
+++ b/lib/mediainfo/placeholder.txt
@@ -1,2 +1,0 @@
-Placeholder file for empty directory so directory is recognized by Git.
-This file may be deleted once a JAR file is added to this directory.

--- a/lib/xmlmetadata/placeholder.txt
+++ b/lib/xmlmetadata/placeholder.txt
@@ -1,2 +1,0 @@
-Placeholder file for empty directory so directory is recognized by Git.
-This file may be deleted once a JAR file is added to this directory.


### PR DESCRIPTION
Removed a bunch of placeholder directories that will never be used. These directories are for loading jar dependencies to a tool's classpath, and these tools don't used jars.