### PR TITLE
Tool upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add jpylyzer 2.1.0 for processing jp2 files.
 - Tool upgrades
   - DROID 6.5.2
-  - ExifTool 12.42
+  - ExifTool 12.50
   - File 5.43
   - Jhove 1.26.1
   - MediaInfo 22.09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ to `true` in your `fits.xml`.
 - Do not infer a timezone for exif timestamps.
 - Preserve whitespace within text elements. This ensures that significant spaces aren't trimmed from codec codes,
 but could also result in unwanted whitespace in other elements.
+- No longer run NZME on image files by default.
 - General internal dependency upgrades.
 
 ## Version 1.5.5 (5/10/2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - File 5.43
   - Jhove 1.26.1
   - MediaInfo 22.09
-  - Tika 2.3.0
+  - Tika 2.6.0
 - Add FITS config option `consolidate-first-identity`, defaulted to `false`. This means that metadata from
 all tools that identify a file is included, even if the identified format is _not_ the highest ranked
 identity. This is a behavior change from previous versions. If you prefer the old behavior, set the value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Tool upgrades
   - DROID 6.5.2
   - ExifTool 12.42
+  - File 5.43
   - Jhove 1.26.1
   - MediaInfo 22.09
   - Tika 2.3.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,8 @@
 
 FROM docker.io/eclipse-temurin:17-jre-jammy
 
-ARG FILE_VERSION=5.41
-ARG FILE_SHA256=13e532c7b364f7d57e23dfeea3147103150cb90593a57af86c10e4f6e411603f
+ARG FILE_VERSION=5.43
+ARG FILE_SHA256=8c8015e91ae0e8d0321d94c78239892ef9dbc70c4ade0008c0e95894abfb1991
 
 RUN apt-get update && \
     apt-get install -yqq \

--- a/docker/Dockerfile-release
+++ b/docker/Dockerfile-release
@@ -21,8 +21,8 @@
 
 FROM docker.io/eclipse-temurin:17-jre-jammy
 
-ARG FILE_VERSION=5.41
-ARG FILE_SHA256=13e532c7b364f7d57e23dfeea3147103150cb90593a57af86c10e4f6e411603f
+ARG FILE_VERSION=5.43
+ARG FILE_SHA256=8c8015e91ae0e8d0321d94c78239892ef9dbc70c4ade0008c0e95894abfb1991
 
 RUN apt-get update && \
     apt-get install -yqq \

--- a/docker/Dockerfile-test
+++ b/docker/Dockerfile-test
@@ -12,8 +12,8 @@
 
 FROM docker.io/maven:3-eclipse-temurin-17
 
-ARG FILE_VERSION=5.41
-ARG FILE_SHA256=13e532c7b364f7d57e23dfeea3147103150cb90593a57af86c10e4f6e411603f
+ARG FILE_VERSION=5.43
+ARG FILE_SHA256=8c8015e91ae0e8d0321d94c78239892ef9dbc70c4ade0008c0e95894abfb1991
 
 # Set timezone to eastern because some of the tests need this
 RUN echo 'America/New_York' > /etc/timezone

--- a/fits-pom.xml
+++ b/fits-pom.xml
@@ -278,7 +278,7 @@
         <dependency>
             <groupId>org.xmlresolver</groupId>
             <artifactId>xmlresolver</artifactId>
-            <version>4.2.0</version>
+            <version>4.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.joyent.util</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>11</java.version>
         <java.target>11</java.target>
         <bcmail.version>132</bcmail.version>
-        <log4j.version>2.17.2</log4j.version>
+        <log4j.version>2.19.0</log4j.version>
         <slf4j.version>1.7.36</slf4j.version>
         <jdom2.version>2.0.6.1</jdom2.version>
         <woodstox.version>4.4.1</woodstox.version>
@@ -35,11 +35,11 @@
         <hclaps.version>2.2.0</hclaps.version>
         <fast-md5.version>2.7.1</fast-md5.version>
         <aes31.version>31.4.0</aes31.version>
-        <gson.version>2.9.0</gson.version>
+        <gson.version>2.10</gson.version>
         <nzmetool.version>3.6GA</nzmetool.version>
         <xerces-impl.version>2.12.2</xerces-impl.version>
         <xml-apis.version>1.4.01</xml-apis.version>
-        <saxon.version>11.2</saxon.version>
+        <saxon.version>11.4</saxon.version>
         <embarc.version>0.2</embarc.version>
 
         <!-- Tool properties -->

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <embarc.version>0.2</embarc.version>
 
         <!-- Tool properties -->
-        <tika.version>2.3.0</tika.version>
+        <tika.version>2.6.0</tika.version>
         <tika.dir>lib/tika</tika.dir>
         <droid.version>6.5.2</droid.version>
         <droid.dir>lib/droid</droid.dir>

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/tika/TikaTool.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/tika/TikaTool.java
@@ -201,7 +201,7 @@ public class TikaTool extends ToolBase {
 
     private static final Namespace fitsNS = Namespace.getNamespace(Fits.XML_NAMESPACE);
     private static final String TOOL_NAME = "Tika";
-    private static final String TOOL_VERSION = "2.3.0"; // Hard-coded version till we can do better
+    private static final String TOOL_VERSION = "2.6.0"; // Hard-coded version till we can do better
 
     private static final MimeTypes mimeTypes = MimeTypes.getDefaultMimeTypes();
     private final Parser tikaParser;

--- a/testfiles/output/4072820.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/4072820.tif_XmlUnitExpectedOutput.xml
@@ -13,10 +13,9 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20.1">13941032</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Adobe Photoshop CS Macintosh</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="12.40" status="CONFLICT">2005-12-15T12:46:50</lastmodified>
-    <lastmodified toolname="Tika" toolversion="2.3.0" status="CONFLICT">2005-12-15T07:46:50</lastmodified>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2005-12-15T12:46:50</lastmodified>
     <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2005-12-15T15:56:19Z</created>
-    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2005-12-15T05:56:19</created>
+    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2005-12-15T10:56:19</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/4072820.tif</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">4072820.tif</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">4a333061a5619b94aa5afc3bb106eb54</md5checksum>

--- a/testfiles/output/GLOBE1.JPG_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/GLOBE1.JPG_XmlUnitExpectedOutput.xml
@@ -6,7 +6,6 @@
       <tool toolname="Jhove" toolversion="1.26.0" />
       <tool toolname="file utility" toolversion="5.41" />
       <tool toolname="Exiftool" toolversion="12.40" />
-      <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <version toolname="Droid" toolversion="6.5.2">1.01</version>
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/43</externalIdentifier>
     </identity>
@@ -35,7 +34,6 @@
       <ySamplingFrequency toolname="Exiftool" toolversion="12.40">1</ySamplingFrequency>
       <bitsPerSample toolname="Jhove" toolversion="1.26.0">8 8 8</bitsPerSample>
       <samplesPerPixel toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">3</samplesPerPixel>
-      <lightSource toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">unknown</lightSource>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -61,14 +59,6 @@
           </mix:BasicImageInformation>
           <mix:ImageCaptureMetadata>
             <mix:GeneralCaptureInformation />
-            <mix:DigitalCameraCapture>
-              <mix:DigitalCameraModel />
-              <mix:CameraCaptureSettings>
-                <mix:ImageData>
-                  <mix:lightSource>unknown</mix:lightSource>
-                </mix:ImageData>
-              </mix:CameraCaptureSettings>
-            </mix:DigitalCameraCapture>
           </mix:ImageCaptureMetadata>
           <mix:ImageAssessmentMetadata>
             <mix:SpatialMetrics>
@@ -106,7 +96,7 @@
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="117" />
     <tool toolname="Exiftool" toolversion="12.40" executionTime="319" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="116" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
     <tool toolname="OIS File Information" toolversion="1.0" executionTime="37" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="60" />

--- a/testfiles/output/ICFA.KC.BIA.1524-small.jpg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/ICFA.KC.BIA.1524-small.jpg_XmlUnitExpectedOutput.xml
@@ -6,7 +6,6 @@
       <tool toolname="Jhove" toolversion="1.20.1" />
       <tool toolname="file utility" toolversion="5.39" />
       <tool toolname="Exiftool" toolversion="11.54" />
-      <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <version toolname="Droid" toolversion="6.4" status="CONFLICT">2.2.1</version>
       <version toolname="file utility" toolversion="5.39" status="CONFLICT">16</version>
       <version toolname="Exiftool" toolversion="11.54" status="CONFLICT">5.5</version>
@@ -15,11 +14,9 @@
   </identification>
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20.1">38829</size>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="CONFLICT">Canon EOS 5D Mark II</creatingApplicationName>
-    <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">Adobe Photoshop CS6 (Windows)</creatingApplicationName>
+    <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Canon EOS 5D Mark II</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="12.50">2017-01-30T11:39:51</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2010-07-07T14:22:53</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2017-01-30T11:39:51</created>
+    <created toolname="Exiftool" toolversion="12.40">2010-07-07T14:22:53</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/ICFA.KC.BIA.1524-small.jpg</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">ICFA.KC.BIA.1524-small.jpg</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">0108175c9153da1d41278066a2e3c1a2</md5checksum>
@@ -43,7 +40,7 @@
       <colorSpace toolname="Exiftool" toolversion="12.40" status="CONFLICT">RGB</colorSpace>
       <iccProfileName toolname="Jhove" toolversion="1.20.1">Adobe RGB (1998)</iccProfileName>
       <YCbCrSubSampling toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1 1</YCbCrSubSampling>
-      <orientation toolname="Exiftool" toolversion="11.54">normal*</orientation>
+      <orientation toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">normal*</orientation>
       <samplingFrequencyUnit toolname="Jhove" toolversion="1.20.1">in.</samplingFrequencyUnit>
       <xSamplingFrequency toolname="Jhove" toolversion="1.20.1">350</xSamplingFrequency>
       <ySamplingFrequency toolname="Jhove" toolversion="1.20.1">350</ySamplingFrequency>
@@ -55,18 +52,14 @@
       <exposureTime toolname="Jhove" toolversion="1.20.1">0.125</exposureTime>
       <isoSpeedRating toolname="Jhove" toolversion="1.20.1">100</isoSpeedRating>
       <exposureBiasValue toolname="Jhove" toolversion="1.20.1">0</exposureBiasValue>
-      <lightSource toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">unknown</lightSource>
       <flash toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">Flash did not fire, compulsory flash mode</flash>
       <focalLength toolname="Jhove" toolversion="1.20.1">50</focalLength>
       <iccProfileVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
       <digitalCameraManufacturer toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Canon</digitalCameraManufacturer>
-      <exifVersion toolname="Exiftool" toolversion="11.54" status="CONFLICT">0221</exifVersion>
-      <exifVersion toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">1220</exifVersion>
+      <exifVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">0221</exifVersion>
       <shutterSpeedValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1/8</shutterSpeedValue>
-      <apertureValue toolname="Exiftool" toolversion="11.54" status="CONFLICT">11.0</apertureValue>
-      <apertureValue toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">6.918863</apertureValue>
-      <maxApertureValue toolname="Exiftool" toolversion="11.54" status="CONFLICT">2.5</maxApertureValue>
-      <maxApertureValue toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2.625</maxApertureValue>
+      <apertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">11.0</apertureValue>
+      <maxApertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.5</maxApertureValue>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -132,7 +125,6 @@
                     <mix:numerator>250</mix:numerator>
                     <mix:denominator>100</mix:denominator>
                   </mix:maxApertureValue>
-                  <mix:lightSource>unknown</mix:lightSource>
                   <mix:flash>Flash did not fire, compulsory flash mode</mix:flash>
                   <mix:focalLength>50.0</mix:focalLength>
                 </mix:ImageData>
@@ -176,7 +168,7 @@
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.39" executionTime="45" />
     <tool toolname="Exiftool" toolversion="11.54" executionTime="401" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="154" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
     <tool toolname="OIS File Information" toolversion="1.0" executionTime="5" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="10" />

--- a/testfiles/output/ICFA.KC.BIA.1524-small.jpg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/ICFA.KC.BIA.1524-small.jpg_XmlUnitExpectedOutput.xml
@@ -17,11 +17,9 @@
     <size toolname="Jhove" toolversion="1.20.1">38829</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="CONFLICT">Canon EOS 5D Mark II</creatingApplicationName>
     <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">Adobe Photoshop CS6 (Windows)</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="12.40" status="CONFLICT">2017-01-30T11:39:51</lastmodified>
-    <lastmodified toolname="Tika" toolversion="2.3.0" status="CONFLICT">2017-01-30T06:39:51</lastmodified>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2017-01-30T11:39:51</lastmodified>
     <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2010-07-07T14:22:53</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2017-01-30T11:39:51</created>
-    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2010-07-07T10:22:53</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/ICFA.KC.BIA.1524-small.jpg</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">ICFA.KC.BIA.1524-small.jpg</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">0108175c9153da1d41278066a2e3c1a2</md5checksum>

--- a/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
@@ -6,7 +6,6 @@
       <tool toolname="Jhove" toolversion="1.20.1" />
       <tool toolname="file utility" toolversion="5.39" />
       <tool toolname="Exiftool" toolversion="11.54" />
-      <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <version toolname="Droid" toolversion="6.4" status="CONFLICT">2.2.1</version>
       <version toolname="file utility" toolversion="5.39" status="CONFLICT">16</version>
       <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">fmt/645</externalIdentifier>
@@ -14,11 +13,9 @@
   </identification>
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20.1">4324778</size>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="CONFLICT">HERO3+ Black Edition</creatingApplicationName>
-    <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">Adobe Photoshop CS6 (Macintosh)</creatingApplicationName>
+    <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">HERO3+ Black Edition</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="12.50">2015-06-25T11:03:38</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2014-10-27T12:34:43</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-06-25T11:03:38</created>
+    <created toolname="Exiftool" toolversion="12.40">2014-10-27T12:34:43</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/JPEGTest_20170591--JPEGTest_20170591.jpeg</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">JPEGTest_20170591--JPEGTest_20170591.jpeg</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">3c5a86c471809d347e99d19c51bd1b94</md5checksum>
@@ -37,8 +34,8 @@
       <colorSpace toolname="Jhove" toolversion="1.24.9">RGB</colorSpace>
       <iccProfileName toolname="Jhove" toolversion="1.20.1">sRGB IEC61966-2.1</iccProfileName>
       <YCbCrSubSampling toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1 1</YCbCrSubSampling>
-      <YCbCrPositioning toolname="Exiftool" toolversion="11.54">1</YCbCrPositioning>
-      <orientation toolname="Exiftool" toolversion="11.54">normal*</orientation>
+      <YCbCrPositioning toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1</YCbCrPositioning>
+      <orientation toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">normal*</orientation>
       <samplingFrequencyUnit toolname="Jhove" toolversion="1.20.1">in.</samplingFrequencyUnit>
       <xSamplingFrequency toolname="Jhove" toolversion="1.20.1">72</xSamplingFrequency>
       <ySamplingFrequency toolname="Jhove" toolversion="1.20.1">72</ySamplingFrequency>
@@ -49,12 +46,10 @@
       <fNumber toolname="Jhove" toolversion="1.20.1">2.8</fNumber>
       <exposureTime toolname="Jhove" toolversion="1.20.1" status="CONFLICT">0.008</exposureTime>
       <exposureTime toolname="Exiftool" toolversion="11.54" status="CONFLICT">0.0083</exposureTime>
-      <exposureTime toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">0.008340283569641367</exposureTime>
       <isoSpeedRating toolname="Jhove" toolversion="1.20.1">142</isoSpeedRating>
       <exposureBiasValue toolname="Jhove" toolversion="1.20.1">0</exposureBiasValue>
       <lightSource toolname="Jhove" toolversion="1.20.1">unknown</lightSource>
-      <subjectDistance toolname="Exiftool" toolversion="11.54" status="CONFLICT">undef</subjectDistance>
-      <subjectDistance toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">NaN</subjectDistance>
+      <subjectDistance toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">undef</subjectDistance>
       <meteringMode toolname="Jhove" toolversion="1.20.1">Center weighted average</meteringMode>
       <flash toolname="Jhove" toolversion="1.20.1">No flash function</flash>
       <focalLength toolname="Jhove" toolversion="1.20.1" status="CONFLICT">2.77</focalLength>
@@ -64,14 +59,12 @@
       <iccProfileVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
       <captureDevice toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">digital still camera</captureDevice>
       <digitalCameraManufacturer toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">GoPro</digitalCameraManufacturer>
-      <exposureProgram toolname="Exiftool" toolversion="11.54">Normal program</exposureProgram>
-      <exifVersion toolname="Exiftool" toolversion="11.54">0221</exifVersion>
+      <exposureProgram toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Normal program</exposureProgram>
+      <exifVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">0221</exifVersion>
       <shutterSpeedValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1/120</shutterSpeedValue>
-      <apertureValue toolname="Exiftool" toolversion="11.54" status="CONFLICT">2.8</apertureValue>
-      <apertureValue toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2.97</apertureValue>
-      <maxApertureValue toolname="Exiftool" toolversion="11.54" status="CONFLICT">2.8</maxApertureValue>
-      <maxApertureValue toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2.97</maxApertureValue>
-      <sensingMethod toolname="Exiftool" toolversion="11.54">One-chip color area sensor</sensingMethod>
+      <apertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.8</apertureValue>
+      <maxApertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.8</maxApertureValue>
+      <sensingMethod toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">One-chip color area sensor</sensingMethod>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -185,7 +178,7 @@
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.39" executionTime="53" />
     <tool toolname="Exiftool" toolversion="11.54" executionTime="352" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="31" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
     <tool toolname="OIS File Information" toolversion="1.0" executionTime="49" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="6" />

--- a/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
@@ -16,11 +16,9 @@
     <size toolname="Jhove" toolversion="1.20.1">4324778</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="CONFLICT">HERO3+ Black Edition</creatingApplicationName>
     <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">Adobe Photoshop CS6 (Macintosh)</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="12.40" status="CONFLICT">2015-06-25T11:03:38</lastmodified>
-    <lastmodified toolname="Tika" toolversion="2.3.0" status="CONFLICT">2015-06-25T07:03:38</lastmodified>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2015-06-25T11:03:38</lastmodified>
     <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2014-10-27T12:34:43</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-06-25T11:03:38</created>
-    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2014-10-27T08:34:43</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/JPEGTest_20170591--JPEGTest_20170591.jpeg</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">JPEGTest_20170591--JPEGTest_20170591.jpeg</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">3c5a86c471809d347e99d19c51bd1b94</md5checksum>

--- a/testfiles/output/W00EGS1016782-I01JW30--I01JW300001__0001.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/W00EGS1016782-I01JW30--I01JW300001__0001.tif_XmlUnitExpectedOutput.xml
@@ -14,9 +14,8 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20">35130</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="12.40" status="CONFLICT">2006-12-19T15:08:15</lastmodified>
-    <lastmodified toolname="Tika" toolversion="2.3.0" status="CONFLICT">2006-12-19T10:08:15</lastmodified>
-    <created toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">2006-12-19T10:08:15</created>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2006-12-19T15:08:15</lastmodified>
+    <created toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">2006-12-19T15:08:15</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/W00EGS1016782-I01JW30--I01JW300001__0001.tif</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">W00EGS1016782-I01JW30--I01JW300001__0001.tif</filename>
     <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">90f9a85c04e1bc2c5c1f689c110b1588</md5checksum>
@@ -64,7 +63,7 @@
           </mix:BasicImageInformation>
           <mix:ImageCaptureMetadata>
             <mix:GeneralCaptureInformation>
-              <mix:dateTimeCreated>2006-12-19T10:08:15</mix:dateTimeCreated>
+              <mix:dateTimeCreated>2006-12-19T15:08:15</mix:dateTimeCreated>
             </mix:GeneralCaptureInformation>
             <mix:ScannerCapture>
               <mix:ScanningSystemSoftware>

--- a/testfiles/output/WordPerfect5_0.wp_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPerfect5_0.wp_XmlUnitExpectedOutput.xml
@@ -3,6 +3,7 @@
   <identification>
     <identity format="WordPerfect Document" mimetype="application/vnd.wordperfect" toolname="FITS" toolversion="1.2.x">
       <tool toolname="Droid" toolversion="6.3" />
+      <tool toolname="file utility" toolversion="5.43" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <version toolname="Droid" toolversion="6.3">5.0</version>
       <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">x-fmt/393</externalIdentifier>

--- a/testfiles/output/WordPerfect5_2.wp_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPerfect5_2.wp_XmlUnitExpectedOutput.xml
@@ -3,6 +3,7 @@
   <identification>
     <identity format="WordPerfect Document" mimetype="application/vnd.wordperfect" toolname="FITS" toolversion="1.2.x">
       <tool toolname="Droid" toolversion="6.3" />
+      <tool toolname="file utility" toolversion="5.43" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <version toolname="Droid" toolversion="6.3">5.1</version>
       <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">x-fmt/394</externalIdentifier>

--- a/testfiles/output/aliceDynamic_images_metadata_tableOfContents.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/aliceDynamic_images_metadata_tableOfContents.epub_XmlUnitExpectedOutput.xml
@@ -21,8 +21,8 @@
       <subject toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">fiction</subject>
       <identifier toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">urn:uuid:1a16ce38-82bd-4e9b-861e-773c2e787a50</identifier>
       <language toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">en-GB</language>
-      <title toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">Alice's Adventures in Wonderland</title>
       <author toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">Lewis Carroll</author>
+      <title toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">Alice's Adventures in Wonderland</title>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:Language>en-GB</docmd:Language>

--- a/testfiles/output/gps.jpg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/gps.jpg_XmlUnitExpectedOutput.xml
@@ -17,11 +17,9 @@
     <size toolname="Jhove" toolversion="1.20.1">41851</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="CONFLICT">FinePix F30</creatingApplicationName>
     <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">Digital Camera FinePix F30     Ver1.02</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="12.40" status="CONFLICT">2006-11-03T02:26:02</lastmodified>
-    <lastmodified toolname="Tika" toolversion="2.3.0" status="CONFLICT">2006-11-02T21:26:02</lastmodified>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2006-11-03T02:26:02</lastmodified>
     <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2006-11-03T07:14:39</created>
     <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2006-11-03T02:26:02</created>
-    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2006-11-03T02:14:39</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/gps.jpg</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">gps.jpg</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">201f1db44775631d307b3ffd62acb3ac</md5checksum>

--- a/testfiles/output/gps.jpg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/gps.jpg_XmlUnitExpectedOutput.xml
@@ -6,7 +6,6 @@
       <tool toolname="Jhove" toolversion="1.20.1" />
       <tool toolname="file utility" toolversion="5.39" />
       <tool toolname="Exiftool" toolversion="11.54" />
-      <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <version toolname="Droid" toolversion="6.4" status="CONFLICT">2.2.1</version>
       <version toolname="Jhove" toolversion="1.20.1" status="CONFLICT">1.01</version>
       <version toolname="file utility" toolversion="5.39" status="CONFLICT">13</version>
@@ -15,11 +14,9 @@
   </identification>
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20.1">41851</size>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="CONFLICT">FinePix F30</creatingApplicationName>
-    <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">Digital Camera FinePix F30     Ver1.02</creatingApplicationName>
+    <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">FinePix F30</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="12.50">2006-11-03T02:26:02</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2006-11-03T07:14:39</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2006-11-03T02:26:02</created>
+    <created toolname="Exiftool" toolversion="12.40">2006-11-03T07:14:39</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/gps.jpg</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">gps.jpg</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">201f1db44775631d307b3ffd62acb3ac</md5checksum>
@@ -38,8 +35,8 @@
       <imageHeight toolname="Jhove" toolversion="1.20.1">800</imageHeight>
       <colorSpace toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">YCbCr</colorSpace>
       <YCbCrSubSampling toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2 2</YCbCrSubSampling>
-      <YCbCrPositioning toolname="Exiftool" toolversion="11.54">2</YCbCrPositioning>
-      <orientation toolname="Exiftool" toolversion="11.54">normal*</orientation>
+      <YCbCrPositioning toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2</YCbCrPositioning>
+      <orientation toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">normal*</orientation>
       <samplingFrequencyUnit toolname="Jhove" toolversion="1.20.1">in.</samplingFrequencyUnit>
       <xSamplingFrequency toolname="Exiftool" toolversion="11.54">72</xSamplingFrequency>
       <ySamplingFrequency toolname="Exiftool" toolversion="11.54">72</ySamplingFrequency>
@@ -50,7 +47,6 @@
       <fNumber toolname="Jhove" toolversion="1.20.1">2.8</fNumber>
       <exposureTime toolname="Jhove" toolversion="1.20.1" status="CONFLICT">0.008</exposureTime>
       <exposureTime toolname="Exiftool" toolversion="11.54" status="CONFLICT">0.0083</exposureTime>
-      <exposureTime toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">0.008333333333333333</exposureTime>
       <isoSpeedRating toolname="Jhove" toolversion="1.20.1">400</isoSpeedRating>
       <brightnessValue toolname="Jhove" toolversion="1.24.9" status="CONFLICT">302100</brightnessValue>
       <brightnessValue toolname="Exiftool" toolversion="12.40" status="CONFLICT">3.02</brightnessValue>
@@ -61,15 +57,12 @@
       <focalLength toolname="Jhove" toolversion="1.20.1">8</focalLength>
       <captureDevice toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">digital still camera</captureDevice>
       <digitalCameraManufacturer toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">FUJIFILM</digitalCameraManufacturer>
-      <exposureProgram toolname="Exiftool" toolversion="11.54">Normal program</exposureProgram>
-      <exifVersion toolname="Exiftool" toolversion="11.54" status="CONFLICT">0221</exifVersion>
-      <exifVersion toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">1220</exifVersion>
+      <exposureProgram toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Normal program</exposureProgram>
+      <exifVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">0221</exifVersion>
       <shutterSpeedValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1/124</shutterSpeedValue>
-      <apertureValue toolname="Exiftool" toolversion="11.54" status="CONFLICT">2.8</apertureValue>
-      <apertureValue toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">3.0</apertureValue>
-      <maxApertureValue toolname="Exiftool" toolversion="11.54" status="CONFLICT">2.8</maxApertureValue>
-      <maxApertureValue toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">3.0</maxApertureValue>
-      <sensingMethod toolname="Exiftool" toolversion="11.54">One-chip color area sensor</sensingMethod>
+      <apertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.8</apertureValue>
+      <maxApertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.8</maxApertureValue>
+      <sensingMethod toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">One-chip color area sensor</sensingMethod>
       <gpsVersionID toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.2.0.0</gpsVersionID>
       <gpsLatitudeRef toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">N</gpsLatitudeRef>
       <gpsLatitude toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">33 deg 24' 51.80" N</gpsLatitude>
@@ -79,7 +72,6 @@
       <gpsStatus toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">A</gpsStatus>
       <gpsMapDatum toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">WGS-84</gpsMapDatum>
       <gpsDateStamp toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2006-11-02</gpsDateStamp>
-      <brightnessvalue toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">3737910</brightnessvalue>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -228,7 +220,7 @@
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.39" executionTime="41" />
     <tool toolname="Exiftool" toolversion="11.54" executionTime="251" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="27" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
     <tool toolname="OIS File Information" toolversion="1.0" executionTime="2" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="6" />

--- a/testfiles/output/signature_corrupted.jp2_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/signature_corrupted.jp2_XmlUnitExpectedOutput.xml
@@ -2,7 +2,6 @@
 <fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="11/12/22, 9:17 AM">
   <identification>
     <identity format="JPEG 2000 JP2" mimetype="image/jp2" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="file utility" toolversion="5.41" />
       <tool toolname="Tika" toolversion="2.3.0" />
       <tool toolname="jpylyzer" toolversion="2.1.0" />
     </identity>

--- a/testfiles/output/simple_webvtt.vtt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/simple_webvtt.vtt_XmlUnitExpectedOutput.xml
@@ -4,6 +4,7 @@
     <identity format="WebVTT" mimetype="text/vtt" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="VTT Tool" toolversion="0.1" />
       <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/1454</externalIdentifier>
     </identity>
   </identification>
@@ -21,7 +22,7 @@
   <metadata>
     <text>
       <linebreak toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">LF</linebreak>
-      <charset toolname="Jhove" toolversion="1.26.0">US-ASCII</charset>
+      <charset toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">US-ASCII</charset>
       <standard>
         <textMD:textMD xmlns:textMD="info:lc/xmlns/textMD-v3">
           <textMD:character_info>

--- a/testfiles/output/topazscanner.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/topazscanner.tif_XmlUnitExpectedOutput.xml
@@ -14,10 +14,9 @@
   <fileinfo>
     <size toolname="Jhove" toolversion="1.20.1">5146108</size>
     <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Adobe Photoshop CS Macintosh</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="12.40" status="CONFLICT">2006-11-28T13:30:06</lastmodified>
-    <lastmodified toolname="Tika" toolversion="2.3.0" status="CONFLICT">2006-11-28T08:30:06</lastmodified>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2006-11-28T13:30:06</lastmodified>
     <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2006-11-28T17:22:59Z</created>
-    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2006-11-28T08:30:06</created>
+    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2006-11-28T13:30:06</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/topazscanner.tif</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">topazscanner.tif</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">c2c36f561b1da65ff74ea2b22fe3fba0</md5checksum>

--- a/testfiles/properties/fits-full-with-tool-output.xml
+++ b/testfiles/properties/fits-full-with-tool-output.xml
@@ -15,7 +15,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.embarc.EmbARC" include-exts="dpx" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,csv,m4a" classpath-dirs="lib/fileutility" />
         <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
-        <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" include-exts="bmp,gif,jpg,jpeg,wp,wpd,odt,doc,pdf,mp3,bfw,flac,html,xml,arc" classpath-dirs="lib/nzmetool,xml/nlnz"/>
+        <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" include-exts="wp,wpd,odt,doc,pdf,mp3,bfw,flac,html,xml,arc" classpath-dirs="lib/nzmetool,xml/nlnz"/>
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />
         <tool class="edu.harvard.hul.ois.fits.tools.ffident.FFIdent" exclude-exts="dng,wps,vsd,jar,ppt,rtf" classpath-dirs="lib/ffident" />

--- a/testfiles/properties/fits-no-consolidation.xml
+++ b/testfiles/properties/fits-no-consolidation.xml
@@ -13,7 +13,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,epub,csv,m4a" classpath-dirs="lib/fileutility" />
         <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
-        <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" include-exts="bmp,gif,jpg,jpeg,wp,wpd,odt,doc,pdf,mp3,bfw,flac,html,xml,arc" classpath-dirs="lib/nzmetool,xml/nlnz"/>
+        <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" include-exts="wp,wpd,odt,doc,pdf,mp3,bfw,flac,html,xml,arc" classpath-dirs="lib/nzmetool,xml/nlnz"/>
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />
         <tool class="edu.harvard.hul.ois.fits.tools.ffident.FFIdent" exclude-exts="dng,wps,vsd,jar,ppt,rtf" classpath-dirs="lib/ffident" />

--- a/tools.properties
+++ b/tools.properties
@@ -1,11 +1,11 @@
 # exiftool
 # When upgrading exiftool, be sure to select a *production release* version (https://www.exiftool.org/history.html).
 # None production releases are not available for download long-term.
-exiftool.version=12.42
-exiftool.unix.url=https://exiftool.org/Image-ExifTool-12.42.tar.gz
-exiftool.unix.md5=4baf1f4306c067de88bad4f6d25766da
-exiftool.windows.url=https://exiftool.org/exiftool-12.42.zip
-exiftool.windows.md5=fa2a1a465106f94f3951071002003651
+exiftool.version=12.50
+exiftool.unix.url=https://exiftool.org/Image-ExifTool-12.50.tar.gz
+exiftool.unix.md5=75dd9d375c1c4798a082dda79eaf6ba7
+exiftool.windows.url=https://exiftool.org/exiftool-12.50.zip
+exiftool.windows.md5=c5cc07cd015c9e029786894243ace2e9
 
 # MediaInfo
 # https://mediaarea.net/en/MediaInfo/Download

--- a/xml/fileutility/fileutility_to_fits.xslt
+++ b/xml/fileutility/fileutility_to_fits.xslt
@@ -558,14 +558,25 @@
 		  			<!-- WORD PERFECT -->
                     <xsl:when test="$format='(Corel/WP)'">
                         <xsl:attribute name="format">
-                            <xsl:value-of select="string('WordPerfect Document')"/>
+                            <xsl:value-of select="'WordPerfect Document'"/>
                         </xsl:attribute>
-                    </xsl:when>     
+                    </xsl:when>
+					<xsl:when test="starts-with($format, 'WordPerfect')">
+						<xsl:attribute name="format">
+							<xsl:value-of select="'WordPerfect Document'" />
+						</xsl:attribute>
+					</xsl:when>
+					<!-- VTT -->
+					<xsl:when test="starts-with($format, 'WebVTT')">
+						<xsl:attribute name="format">
+							<xsl:value-of select="'WebVTT'" />
+						</xsl:attribute>
+					</xsl:when>
 					<xsl:otherwise>
 						<xsl:attribute name="format">
 							<xsl:value-of select="$format"/>
 						</xsl:attribute>
-					</xsl:otherwise>							
+					</xsl:otherwise>
 				</xsl:choose>
 			
 			</identity>

--- a/xml/fits.xml
+++ b/xml/fits.xml
@@ -14,7 +14,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.embarc.EmbARC" include-exts="dpx" classpath-dirs="lib/embarc" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,csv,m4a,dpx" classpath-dirs="lib/fileutility" />
         <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
-        <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" include-exts="bmp,gif,jpg,jpeg,wp,wpd,odt,doc,mp3,bfw,flac,html,xml,arc" classpath-dirs="lib/nzmetool,xml/nlnz"/>
+        <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" include-exts="wp,wpd,odt,doc,mp3,bfw,flac,html,xml,arc" classpath-dirs="lib/nzmetool,xml/nlnz"/>
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />
         <tool class="edu.harvard.hul.ois.fits.tools.ffident.FFIdent" exclude-exts="dng,wps,vsd,jar,ppt,rtf" classpath-dirs="lib/ffident" />


### PR DESCRIPTION
This PR makes the following upgrades:

- Upgrade file to 5.43
- Upgrade exiftool to 12.50
- Upgrade tika to 2.6.0
- Upgrade pom dependencies

Additionally, it updates the `fits.xml` to no longer run NZME on image files by default. I did this because I noticed that it improves the quality of the output by removing inaccurate conflicts. If this change is not desired, I can roll it back. 