### PR TITLE
make windows jpylyzer command path absolute

### DIFF
--- a/src/main/java/edu/harvard/hul/ois/fits/Fits.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/Fits.java
@@ -163,7 +163,8 @@ public class Fits {
         String log4jSystemProp = System.getProperty("log4j2.configurationFile");
         if (log4jSystemProp == null) {
             File log4jProperties = new File(FITS_HOME + "log4j2.xml");
-            System.setProperty("log4j2.configurationFile", log4jProperties.getPath());
+            System.setProperty(
+                    "log4j2.configurationFile", log4jProperties.toURI().toString());
         }
         logger = LoggerFactory.getLogger(Fits.class);
         logger.info("Logging initialized with: " + System.getProperty("log4j2.configurationFile"));

--- a/src/main/java/edu/harvard/hul/ois/fits/tools/jpylyzer/Jpylyzer.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/jpylyzer/Jpylyzer.java
@@ -63,7 +63,8 @@ public class Jpylyzer extends ToolBase {
 
         if (osName.startsWith("Windows")) {
             workingDir = WINDOWS_ROOT;
-            command = List.of("jpylyzer.exe");
+            command = List.of(
+                    WINDOWS_ROOT.resolve("jpylyzer.exe").toAbsolutePath().toString());
             info.setNote("jpylyzer for windows");
             log.debug("jpylyzer will use Windows environment");
         } else if (isPythonAvailable()) {


### PR DESCRIPTION
1. Fixes the windows jpylyzer integration.
2. Fixes the log4j2.xml path on windows.