### PR TITLE
include hclaps as a main dependency

### DIFF
--- a/fits-pom.xml
+++ b/fits-pom.xml
@@ -307,8 +307,6 @@
             <groupId>edu.harvard.lts.tools</groupId>
             <artifactId>hclaps</artifactId>
             <version>${hclaps.version}</version>
-            <!-- not included in main lib directory - only in subdirectory -->
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>nz.govt.natlib</groupId>


### PR DESCRIPTION
**Resolves Issue**: https://github.com/harvard-lts/fits/issues/366

# What does this Pull Request do?

hclaps was accidentally removed the from the lib directory earlier this year when it was upgraded. Rather than adding it back to the lib directory, I included it as a normal dependency, which is also how the aes lib is being included. Given that they don't have additional dependencies, unlike the rest of the tools under lib, I don't think it really hurts to include them this way.

# How should this be tested?

The tests didn't catch this issue because the jar was present when the tests ran, it just wasn't bundled in the release artifact. To test you'll need to:

```java
just build-image
just run testfiles/input/test.wav
```