### PR TITLE
correct MediaInfo Format_Profile field name

### DIFF
--- a/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoUtil.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoUtil.java
@@ -278,7 +278,7 @@ public class MediaInfoUtil {
             String codecName = getMediaInfoString(ndx, "Format", MediaInfoNativeWrapper.StreamKind.Video);
             addDataToMap(videoTrackValuesMap, id, "codecName", codecName);
 
-            String codecVersion = getMediaInfoString(ndx, "Format_profile", MediaInfoNativeWrapper.StreamKind.Video);
+            String codecVersion = getMediaInfoString(ndx, "Format_Profile", MediaInfoNativeWrapper.StreamKind.Video);
             addDataToMap(videoTrackValuesMap, id, "codecVersion", codecVersion);
 
             // By design - if the 4CC code is not one expected, then don't

--- a/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4-default_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4-default_XmlUnitExpectedOutput.xml
@@ -30,6 +30,7 @@
         <videoDataEncoding>avc1</videoDataEncoding>
         <codecId>avc1</codecId>
         <codecCC>avc1</codecCC>
+        <codecVersion>Main@L4.1</codecVersion>
         <codecName>AVC</codecName>
         <codecFamily>H.264</codecFamily>
         <codecInfo>Advanced Video Codec</codecInfo>

--- a/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4-no-md5_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4-no-md5_XmlUnitExpectedOutput.xml
@@ -29,6 +29,7 @@
         <videoDataEncoding>avc1</videoDataEncoding>
         <codecId>avc1</codecId>
         <codecCC>avc1</codecCC>
+        <codecVersion>Main@L4.1</codecVersion>
         <codecName>AVC</codecName>
         <codecFamily>H.264</codecFamily>
         <codecInfo>Advanced Video Codec</codecInfo>

--- a/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4-standard-only_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4-standard-only_XmlUnitExpectedOutput.xml
@@ -16,6 +16,7 @@
                       <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">avc1</dc:identifier>
                    </ebucore:codecIdentifier>
                    <ebucore:name>AVC</ebucore:name>
+                   <ebucore:version>Main@L4.1</ebucore:version>
                    <ebucore:family>H.264</ebucore:family>
                 </ebucore:codec>
                 <ebucore:bitRate>17375067</ebucore:bitRate>

--- a/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov_XmlUnitExpectedOutput.xml
@@ -29,6 +29,7 @@
         <videoDataEncoding>m2v1</videoDataEncoding>
         <codecId>m2v1</codecId>
         <codecCC>m2v1</codecCC>
+        <codecVersion>Main@Main</codecVersion>
         <codecName>MPEG Video</codecName>
         <codecFamily>MPEG-2</codecFamily>
         <compression>Lossy</compression>
@@ -83,6 +84,7 @@
                     <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">m2v1</dc:identifier>
                   </ebucore:codecIdentifier>
                   <ebucore:name>MPEG Video</ebucore:name>
+                  <ebucore:version>Main@Main</ebucore:version>
                   <ebucore:family>MPEG-2</ebucore:family>
                 </ebucore:codec>
                 <ebucore:bitRate>2153111</ebucore:bitRate>

--- a/testfiles/output/freeMXF-mxf1a.mxf-default_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/freeMXF-mxf1a.mxf-default_XmlUnitExpectedOutput.xml
@@ -31,6 +31,7 @@
       <track type="video" id="2" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
         <videoDataEncoding>0D01030102046001</videoDataEncoding>
         <codecId>0D01030102046001</codecId>
+        <codecVersion>Main@Main</codecVersion>
         <codecName>MPEG Video</codecName>
         <compression>Lossy</compression>
         <byteOrder>Unknown</byteOrder>


### PR DESCRIPTION
The casing for the MediaInfo `Format_Profile` was incorrect, causing it to not extract the data correct.