### PR TITLE
fix MediaInfo bit rate mode check to account for VBR

### DIFF
--- a/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoUtil.java
+++ b/src/main/java/edu/harvard/hul/ois/fits/tools/mediainfo/MediaInfoUtil.java
@@ -713,7 +713,7 @@ public class MediaInfoUtil {
                     // NOTE: If the bitRateMode is Variable (VBR), set it to the value for
                     // BitRateMax
                     String bitRateMode = videoTrackValuesMap.get(id).get("bitRateMode");
-                    if (!StringUtils.isEmpty(bitRateMode) && bitRateMode.equals("Variable")) {
+                    if (isVariableBitRate(bitRateMode)) {
                         String bitRateMax = videoTrackValuesMap.get(id).get("bitRateMax");
                         if (!StringUtils.isEmpty(bitRateMax)) {
                             childElement.setText(bitRateMax);
@@ -794,8 +794,7 @@ public class MediaInfoUtil {
                     // NOTE: If the bitRateMode is Variable (VBR), set it to the value for
                     // BitRateMax
                     String bitRateMode = audioTrackValuesMap.get(id).get("bitRateMode");
-                    if (!StringUtils.isEmpty(bitRateMode)
-                            && (bitRateMode.equals("Variable") || bitRateMode.equals("VBR"))) {
+                    if (isVariableBitRate(bitRateMode)) {
                         String bitRateMax = audioTrackValuesMap.get(id).get("bitRateMax");
                         if (!StringUtils.isEmpty(bitRateMax)) {
                             childElement.setText(bitRateMax);
@@ -848,5 +847,9 @@ public class MediaInfoUtil {
         for (Element elementToRemove : elementsToRemove) {
             elementToRemove.getParent().removeContent(elementToRemove);
         }
+    }
+
+    private boolean isVariableBitRate(String mode) {
+        return !StringUtils.isEmpty(mode) && (mode.equals("Variable") || mode.equals("VBR"));
     }
 }

--- a/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov_XmlUnitExpectedOutput.xml
@@ -35,7 +35,7 @@
         <compression>Lossy</compression>
         <byteOrder>Unknown</byteOrder>
         <bitDepth>8 bits</bitDepth>
-        <bitRate>2153111</bitRate>
+        <bitRate>6000000</bitRate>
         <bitRateMode>Variable</bitRateMode>
         <duration>4138</duration>
         <delay>7141968</delay>
@@ -87,7 +87,7 @@
                   <ebucore:version>Main@Main</ebucore:version>
                   <ebucore:family>MPEG-2</ebucore:family>
                 </ebucore:codec>
-                <ebucore:bitRate>2153111</ebucore:bitRate>
+                <ebucore:bitRate>6000000</ebucore:bitRate>
                 <ebucore:bitRateMode>variable</ebucore:bitRateMode>
                 <ebucore:scanningFormat>interlaced</ebucore:scanningFormat>
                 <ebucore:videoTrack trackId="1" />


### PR DESCRIPTION
On variable bitrate files, FITS was supposed to select the max bit rate. This was not working correctly because it was matching on the mode "Variable" rather than the mode "VBR".