### PR TITLE
Reorder jpylyzer tool

### DIFF
--- a/src/test/java/edu/harvard/hul/ois/fits/junit/DocMDXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/junit/DocMDXmlUnitTest.java
@@ -153,10 +153,8 @@ public class DocMDXmlUnitTest extends AbstractXmlUnitTest {
     public void testWPDOutput() throws Exception {
 
         // process multiple files to examine different types of output
-        String[] inputFilenames = { // "WordPerfect6-7.wpd",
-            "WordPerfect4_2.wp", "WordPerfect5_0.wp", "WordPerfect5_2.wp"
-        };
-        //    			"WordPerfectCompoundFile.wpd"};  // (not identified as a WordPerfect document)
+        String[] inputFilenames = {"WordPerfect6-7.wpd", "WordPerfect4_2.wp", "WordPerfect5_0.wp", "WordPerfect5_2.wp"};
+        // "WordPerfectCompoundFile.wpd"}; // (not identified as a WordPerfect document)
 
         for (String inputFilename : inputFilenames) {
             testFile(inputFilename);

--- a/testfiles/output/00266.dpx-default_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/00266.dpx-default_XmlUnitExpectedOutput.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.2-SNAPSHOT" timestamp="3/17/22 10:21 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:03 AM">
   <identification>
-    <identity format="Digital Picture Exchange" mimetype="image/x-dpx" toolname="FITS" toolversion="1.5.2-SNAPSHOT">
+    <identity format="Digital Picture Exchange" mimetype="image/x-dpx" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="embARC" toolversion="0.2" />
-      <tool toolname="Exiftool" toolversion="12.40" />
-      <tool toolname="Tika" toolversion="2.3.0" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
     </identity>
   </identification>
   <fileinfo>
     <created toolname="embARC" toolversion="0.2">2010-12-24</created>
     <copyrightNote toolname="embARC" toolversion="0.2" status="SINGLE_RESULT">Copyright info</copyrightNote>
-    <filepath toolname="embARC" toolversion="0.2">/Users/cpm/Projects/fits-pm/fits/testfiles/00266.dpx</filepath>
+    <filepath toolname="embARC" toolversion="0.2">/fits/testfiles/input/00266.dpx</filepath>
     <filename toolname="embARC" toolversion="0.2">00266.dpx</filename>
     <size toolname="embARC" toolversion="0.2">12697608</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">a269fe44030b4d58cfa710947e5b95a2</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1647523929469</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186250</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
@@ -30,21 +30,21 @@
       <scannerModelSerialNo toolname="embARC" toolversion="0.2" status="SINGLE_RESULT">01018</scannerModelSerialNo>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="4324">
-    <tool toolname="MediaInfo" toolversion="21.09" status="did not run" />
+  <statistics fitsExecutionTime="2740">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="135" />
-    <tool toolname="Jhove" toolversion="1.24.9" executionTime="4310" />
-    <tool toolname="embARC" toolversion="0.2" executionTime="133" />
-    <tool toolname="file utility" toolversion="5.40" status="did not run" />
-    <tool toolname="Exiftool" toolversion="12.40" executionTime="719" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="133" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="710" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="154" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="69" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="2729" />
+    <tool toolname="embARC" toolversion="0.2" executionTime="53" />
+    <tool toolname="file utility" toolversion="5.43" status="did not run" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="271" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="93" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="35" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="33" />
   </statistics>
 </fits>

--- a/testfiles/output/00266.dpx_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/00266.dpx_XmlUnitExpectedOutput.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.2-SNAPSHOT" timestamp="3/17/22 10:11 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:03 AM">
   <identification>
-    <identity format="Digital Picture Exchange" mimetype="image/x-dpx" toolname="FITS" toolversion="1.5.2-SNAPSHOT">
+    <identity format="Digital Picture Exchange" mimetype="image/x-dpx" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="embARC" toolversion="0.2" />
-      <tool toolname="Exiftool" toolversion="12.40" />
-      <tool toolname="Tika" toolversion="2.3.0" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
     </identity>
   </identification>
   <fileinfo>
     <created toolname="embARC" toolversion="0.2">2010-12-24</created>
     <copyrightNote toolname="embARC" toolversion="0.2" status="SINGLE_RESULT">Copyright info</copyrightNote>
-    <filepath toolname="embARC" toolversion="0.2">/Users/cpm/Projects/fits-pm/fits/testfiles/00266.dpx</filepath>
+    <filepath toolname="embARC" toolversion="0.2">/fits/testfiles/input/00266.dpx</filepath>
     <filename toolname="embARC" toolversion="0.2">00266.dpx</filename>
     <size toolname="embARC" toolversion="0.2">12697608</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">a269fe44030b4d58cfa710947e5b95a2</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1647523929469</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186250</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
@@ -68,21 +68,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="4064">
-    <tool toolname="MediaInfo" toolversion="21.09" status="did not run" />
+  <statistics fitsExecutionTime="2719">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="97" />
-    <tool toolname="Jhove" toolversion="1.24.9" executionTime="4049" />
-    <tool toolname="embARC" toolversion="0.2" executionTime="96" />
-    <tool toolname="file utility" toolversion="5.40" status="did not run" />
-    <tool toolname="Exiftool" toolversion="12.40" executionTime="690" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="95" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="680" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="141" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="104" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="2712" />
+    <tool toolname="embARC" toolversion="0.2" executionTime="81" />
+    <tool toolname="file utility" toolversion="5.43" status="did not run" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="270" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="131" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="78" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="64" />
   </statistics>
 </fits>

--- a/testfiles/output/006607203_00018.jp2_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/006607203_00018.jp2_XmlUnitExpectedOutput.xml
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.x" timestamp="2/13/18 2:58 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
-    <identity format="JPEG 2000 JP2" mimetype="image/jp2" toolname="FITS" toolversion="1.4.1">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="Jhove" toolversion="1.20.1" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.14" />
-      <tool toolname="Tika" toolversion="1.19.1" />
+    <identity format="JPEG 2000 JP2" mimetype="image/jp2" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
       <tool toolname="jpylyzer" toolversion="2.1.0" />
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">x-fmt/392</externalIdentifier>
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/392</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.16">3916234</size>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/006607203_00018.jp2</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">006607203_00018.jp2</filename>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">38fada2603f695bc5c5e4255c8167f33</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1446674963000</fslastmodified>
+    <size toolname="Jhove" toolversion="1.26.1">3916234</size>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/006607203_00018.jp2</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">006607203_00018.jp2</filename>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">38fada2603f695bc5c5e4255c8167f33</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186263</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.16">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.16">true</valid>
+    <well-formed toolname="jpylyzer" toolversion="2.1.0">true</well-formed>
+    <valid toolname="jpylyzer" toolversion="2.1.0">true</valid>
   </filestatus>
   <metadata>
     <image>
-      <byteOrder toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">big endian</byteOrder>
-      <compressionScheme toolname="Jhove" toolversion="1.16" status="CONFLICT">JPEG 2000 Lossy</compressionScheme>
-      <compressionScheme toolname="Exiftool" toolversion="10.00" status="CONFLICT">JPEG 2000</compressionScheme>
-      <imageWidth toolname="Jhove" toolversion="1.16">1729</imageWidth>
-      <imageHeight toolname="Jhove" toolversion="1.16">2537</imageHeight>
-      <iccProfileName toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">sRGB IEC61966-2.1</iccProfileName>
-      <tileWidth toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">512</tileWidth>
-      <tileHeight toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">512</tileHeight>
-      <qualityLayers toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">1</qualityLayers>
-      <resolutionLevels toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">5</resolutionLevels>
-      <samplingFrequencyUnit toolname="Jhove" toolversion="1.16" status="CONFLICT">cm</samplingFrequencyUnit>
-      <samplingFrequencyUnit toolname="Exiftool" toolversion="10.00" status="CONFLICT">0.1 mm</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Jhove" toolversion="1.16" status="CONFLICT">118</xSamplingFrequency>
-      <xSamplingFrequency toolname="Exiftool" toolversion="10.00" status="CONFLICT">1.181102</xSamplingFrequency>
-      <ySamplingFrequency toolname="Jhove" toolversion="1.16" status="CONFLICT">118</ySamplingFrequency>
-      <ySamplingFrequency toolname="Exiftool" toolversion="10.00" status="CONFLICT">1.181102</ySamplingFrequency>
-      <bitsPerSample toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">8 8 8</bitsPerSample>
-      <samplesPerPixel toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">3</samplesPerPixel>
-      <iccProfileVersion toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
+      <byteOrder toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">big endian</byteOrder>
+      <compressionScheme toolname="Jhove" toolversion="1.26.1" status="CONFLICT">JPEG 2000 Lossy</compressionScheme>
+      <compressionScheme toolname="Exiftool" toolversion="12.50" status="CONFLICT">JPEG 2000</compressionScheme>
+      <imageWidth toolname="Jhove" toolversion="1.26.1">1729</imageWidth>
+      <imageHeight toolname="Jhove" toolversion="1.26.1">2537</imageHeight>
+      <iccProfileName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">sRGB IEC61966-2.1</iccProfileName>
+      <tileWidth toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">512</tileWidth>
+      <tileHeight toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">512</tileHeight>
+      <qualityLayers toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">1</qualityLayers>
+      <resolutionLevels toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">5</resolutionLevels>
+      <samplingFrequencyUnit toolname="Jhove" toolversion="1.26.1" status="CONFLICT">cm</samplingFrequencyUnit>
+      <samplingFrequencyUnit toolname="Exiftool" toolversion="12.50" status="CONFLICT">0.1 mm</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Jhove" toolversion="1.26.1" status="CONFLICT">118</xSamplingFrequency>
+      <xSamplingFrequency toolname="Exiftool" toolversion="12.50" status="CONFLICT">1.181102</xSamplingFrequency>
+      <ySamplingFrequency toolname="Jhove" toolversion="1.26.1" status="CONFLICT">118</ySamplingFrequency>
+      <ySamplingFrequency toolname="Exiftool" toolversion="12.50" status="CONFLICT">1.181102</ySamplingFrequency>
+      <bitsPerSample toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">8 8 8</bitsPerSample>
+      <samplesPerPixel toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">3</samplesPerPixel>
+      <iccProfileVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -106,22 +106,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="670">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="415">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.3" executionTime="119" />
-    <tool toolname="Jhove" toolversion="1.16" executionTime="606" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="158" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="240" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="225" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="498" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="547" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="188" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="404" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="114" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="164" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="475" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="174" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="76" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="123" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="99" />
   </statistics>
 </fits>
-

--- a/testfiles/output/2339337_not_well_formed.jp2_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/2339337_not_well_formed.jp2_XmlUnitExpectedOutput.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.4.0-SNAPSHOT" timestamp="4/2/19 4:22 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
-    <identity format="JPEG 2000 JP2" mimetype="image/jp2" toolname="FITS" toolversion="1.4.1">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="Jhove" toolversion="1.20.1" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.14" />
-      <tool toolname="Tika" toolversion="1.19.1" />
+    <identity format="JPEG 2000 JP2" mimetype="image/jp2" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
       <tool toolname="jpylyzer" toolversion="2.1.0" />
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">x-fmt/392</externalIdentifier>
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/392</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.20.1">120521</size>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/2339337_not_well_formed.jp2</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">2339337_not_well_formed.jp2</filename>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1c9c7abb1cf187de78f550ec474f9952</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1554236769000</fslastmodified>
+    <size toolname="Jhove" toolversion="1.26.1">120521</size>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/2339337_not_well_formed.jp2</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">2339337_not_well_formed.jp2</filename>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1c9c7abb1cf187de78f550ec474f9952</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186266</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.20.1">false</well-formed>
-    <valid toolname="Jhove" toolversion="1.20.1">false</valid>
-    <message toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">First box of JP2 header must be image header severity=error offset=48</message>
+    <well-formed toolname="jpylyzer" toolversion="2.1.0">false</well-formed>
+    <valid toolname="jpylyzer" toolversion="2.1.0">false</valid>
+    <message toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">First box of JP2 header must be image header severity=error offset=48</message>
   </filestatus>
   <metadata>
     <image>
-      <compressionScheme toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">JPEG 2000</compressionScheme>
-      <imageWidth toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">3039</imageWidth>
-      <imageHeight toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">2490</imageHeight>
-      <iccProfileName toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">Adobe RGB (1998)</iccProfileName>
-      <samplingFrequencyUnit toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">cm</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">3</xSamplingFrequency>
-      <ySamplingFrequency toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">3</ySamplingFrequency>
-      <iccProfileVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
+      <compressionScheme toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">JPEG 2000</compressionScheme>
+      <imageWidth toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">3039</imageWidth>
+      <imageHeight toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2490</imageHeight>
+      <iccProfileName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Adobe RGB (1998)</iccProfileName>
+      <samplingFrequencyUnit toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">cm</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">3</xSamplingFrequency>
+      <ySamplingFrequency toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">3</ySamplingFrequency>
+      <iccProfileVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -75,22 +75,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="713">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="406">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="145" />
-    <tool toolname="Jhove" toolversion="1.20.1" executionTime="583" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="34" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="242" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="152" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="643" />
-    <tool toolname="Exiftool" toolversion="11.14" executionTime="660" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="135" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="351" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="145" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="22" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="497" />
-    <tool toolname="Tika" toolversion="1.19.1" executionTime="185" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="58" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="58" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="42" />
   </statistics>
 </fits>
-

--- a/testfiles/output/32044020597662.zip-default_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/32044020597662.zip-default_XmlUnitExpectedOutput.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0-SNAPSHOT" timestamp="7/10/19 9:19 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:07 AM">
   <identification>
-    <identity format="ZIP Format" mimetype="application/zip" toolname="FITS" toolversion="1.5.0-SNAPSHOT">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="ZIP Format" mimetype="application/zip" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="file utility" toolversion="5.31">1.0</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">x-fmt/263</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="file utility" toolversion="5.43">1.0</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/263</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/32044020597662.zip</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">32044020597662.zip</filename>
-    <size toolname="OIS File Information" toolversion="0.2">95270</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">7c64750915af83a39c35f0e836d3690f</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117982000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/32044020597662.zip</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">32044020597662.zip</filename>
+    <size toolname="OIS File Information" toolversion="1.0">95270</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">7c64750915af83a39c35f0e836d3690f</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186268</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <container>
-      <originalSize toolname="Droid" toolversion="6.4" status="SINGLE_RESULT">83996</originalSize>
-      <compressionMethod toolname="Droid" toolversion="6.4" status="SINGLE_RESULT">stored</compressionMethod>
-      <entries totalEntries="84" toolname="Droid" toolversion="6.4" status="SINGLE_RESULT">
+      <originalSize toolname="Droid" toolversion="6.5.2" status="SINGLE_RESULT">83996</originalSize>
+      <compressionMethod toolname="Droid" toolversion="6.5.2" status="SINGLE_RESULT">stored</compressionMethod>
+      <entries totalEntries="84" toolname="Droid" toolversion="6.5.2" status="SINGLE_RESULT">
         <format name="Hypertext Markup Language" number="1" />
         <format name="JPEG 2000 JP2" number="40" />
         <format name="MD5 File" number="1" />
@@ -31,22 +31,21 @@
       </entries>
     </container>
   </metadata>
-  <statistics fitsExecutionTime="556">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="508">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="122" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="551" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="538" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="26" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="31" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="534" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="139" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="104" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="500" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="32" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="39" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="437" />
   </statistics>
 </fits>
-

--- a/testfiles/output/40415587.zip_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/40415587.zip_XmlUnitExpectedOutput.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0-SNAPSHOT" timestamp="7/10/19 9:19 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:07 AM">
   <identification>
-    <identity format="ZIP Format" mimetype="application/zip" toolname="FITS" toolversion="1.5.0-SNAPSHOT">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="ZIP Format" mimetype="application/zip" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="file utility" toolversion="5.31">2.0</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">x-fmt/263</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="file utility" toolversion="5.43">2.0</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/263</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/40415587.zip</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">40415587.zip</filename>
-    <size toolname="OIS File Information" toolversion="0.2">12716562</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">f91dd3fdf89cc68860029b0ee785ad96</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117982000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/40415587.zip</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">40415587.zip</filename>
+    <size toolname="OIS File Information" toolversion="1.0">12716562</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">f91dd3fdf89cc68860029b0ee785ad96</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186317</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <container>
-      <originalSize toolname="Droid" toolversion="6.4" status="SINGLE_RESULT">12949356</originalSize>
-      <compressionMethod toolname="Droid" toolversion="6.4" status="SINGLE_RESULT">deflate</compressionMethod>
-      <entries totalEntries="1" toolname="Droid" toolversion="6.4" status="SINGLE_RESULT">
+      <originalSize toolname="Droid" toolversion="6.5.2" status="SINGLE_RESULT">12949356</originalSize>
+      <compressionMethod toolname="Droid" toolversion="6.5.2" status="SINGLE_RESULT">deflate</compressionMethod>
+      <entries totalEntries="1" toolname="Droid" toolversion="6.5.2" status="SINGLE_RESULT">
         <format name="Windows Media Video" number="1" />
       </entries>
       <standard>
@@ -42,22 +42,21 @@
       </standard>
     </container>
   </metadata>
-  <statistics fitsExecutionTime="323">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="659">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="317" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="89" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="287" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="82" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="29" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="219" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="574" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="232" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="643" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="342" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="72" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="331" />
   </statistics>
 </fits>
-

--- a/testfiles/output/4072820.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/4072820.tif_XmlUnitExpectedOutput.xml
@@ -1,65 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="12/6/21 3:32 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
-    <identity format="TIFF EXIF" mimetype="image/tiff" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="Jhove" toolversion="1.20.1" />
-      <tool toolname="Exiftool" toolversion="11.54" />
-      <version toolname="Droid" toolversion="6.4" status="CONFLICT">2.2</version>
-      <version toolname="Jhove" toolversion="1.20.1" status="CONFLICT">6.0</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">x-fmt/387</externalIdentifier>
+    <identity format="TIFF EXIF" mimetype="image/tiff" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <version toolname="Droid" toolversion="6.5.2" status="CONFLICT">2.2</version>
+      <version toolname="Jhove" toolversion="1.26.1" status="CONFLICT">6.0</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/387</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.20.1">13941032</size>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Adobe Photoshop CS Macintosh</creatingApplicationName>
+    <size toolname="Jhove" toolversion="1.26.1">13941032</size>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Adobe Photoshop CS Macintosh</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="12.50">2005-12-15T12:46:50</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2005-12-15T15:56:19Z</created>
-    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2005-12-15T10:56:19</created>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/4072820.tif</filepath>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">2005-12-15T15:56:19Z</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">2005-12-15T10:56:19</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/4072820.tif</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">4072820.tif</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">4a333061a5619b94aa5afc3bb106eb54</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1516117982000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186540</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">true</valid>
-    <message toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">Value offset not word-aligned: 13941015 severity=info offset=13940738</message>
-    <message toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">Value offset not word-aligned: 13941023 severity=info offset=13940786</message>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
+    <message toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Value offset not word-aligned: 13941015 severity=info offset=13940738</message>
+    <message toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Value offset not word-aligned: 13941023 severity=info offset=13940786</message>
   </filestatus>
   <metadata>
     <image>
-      <byteOrder toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">big endian</byteOrder>
-      <compressionScheme toolname="Jhove" toolversion="1.20.1">Uncompressed</compressionScheme>
-      <imageWidth toolname="Jhove" toolversion="1.20.1">1867</imageWidth>
-      <imageHeight toolname="Jhove" toolversion="1.20.1">2484</imageHeight>
-      <colorSpace toolname="Jhove" toolversion="1.20.1">RGB</colorSpace>
-      <referenceBlackWhite toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">0 255 0 255 0 255</referenceBlackWhite>
-      <iccProfileName toolname="Jhove" toolversion="1.20.1">sRGB IEC61966-2.1</iccProfileName>
-      <orientation toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">normal*</orientation>
-      <samplingFrequencyUnit toolname="Jhove" toolversion="1.20.1">in.</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Jhove" toolversion="1.20.1">300</xSamplingFrequency>
-      <ySamplingFrequency toolname="Jhove" toolversion="1.20.1">300</ySamplingFrequency>
-      <bitsPerSample toolname="Jhove" toolversion="1.20.1">8 8 8</bitsPerSample>
-      <samplesPerPixel toolname="Jhove" toolversion="1.20.1">3</samplesPerPixel>
-      <scanningSoftwareName toolname="Jhove" toolversion="1.20.1">Adobe Photoshop CS Macintosh</scanningSoftwareName>
-      <digitalCameraModelName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">NIKON D100</digitalCameraModelName>
-      <fNumber toolname="Jhove" toolversion="1.20.1">8</fNumber>
-      <exposureTime toolname="Jhove" toolversion="1.20.1" status="CONFLICT">0.033</exposureTime>
-      <exposureTime toolname="Exiftool" toolversion="11.54" status="CONFLICT">0.0333</exposureTime>
-      <exposureBiasValue toolname="Jhove" toolversion="1.20.1">0</exposureBiasValue>
-      <lightSource toolname="Jhove" toolversion="1.20.1">unknown</lightSource>
-      <meteringMode toolname="Jhove" toolversion="1.20.1">Pattern</meteringMode>
-      <flash toolname="Jhove" toolversion="1.20.1">Flash did not fire</flash>
-      <focalLength toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">28.0</focalLength>
-      <iccProfileVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
-      <captureDevice toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">digital still camera</captureDevice>
-      <digitalCameraManufacturer toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">NIKON CORPORATION</digitalCameraManufacturer>
-      <exposureProgram toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Manual</exposureProgram>
-      <exifVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">0220</exifVersion>
-      <maxApertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.8</maxApertureValue>
-      <sensingMethod toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">One-chip color area sensor</sensingMethod>
-      <cfaPattern toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">[Green,Red][Blue,Green]</cfaPattern>
+      <byteOrder toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">big endian</byteOrder>
+      <compressionScheme toolname="Jhove" toolversion="1.26.1">Uncompressed</compressionScheme>
+      <imageWidth toolname="Jhove" toolversion="1.26.1">1867</imageWidth>
+      <imageHeight toolname="Jhove" toolversion="1.26.1">2484</imageHeight>
+      <colorSpace toolname="Jhove" toolversion="1.26.1">RGB</colorSpace>
+      <referenceBlackWhite toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">0 255 0 255 0 255</referenceBlackWhite>
+      <iccProfileName toolname="Jhove" toolversion="1.26.1">sRGB IEC61966-2.1</iccProfileName>
+      <orientation toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">normal*</orientation>
+      <samplingFrequencyUnit toolname="Jhove" toolversion="1.26.1">in.</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Jhove" toolversion="1.26.1">300</xSamplingFrequency>
+      <ySamplingFrequency toolname="Jhove" toolversion="1.26.1">300</ySamplingFrequency>
+      <bitsPerSample toolname="Jhove" toolversion="1.26.1">8 8 8</bitsPerSample>
+      <samplesPerPixel toolname="Jhove" toolversion="1.26.1">3</samplesPerPixel>
+      <scanningSoftwareName toolname="Jhove" toolversion="1.26.1">Adobe Photoshop CS Macintosh</scanningSoftwareName>
+      <digitalCameraModelName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">NIKON D100</digitalCameraModelName>
+      <fNumber toolname="Jhove" toolversion="1.26.1">8</fNumber>
+      <exposureTime toolname="Jhove" toolversion="1.26.1" status="CONFLICT">0.033</exposureTime>
+      <exposureTime toolname="Exiftool" toolversion="12.50" status="CONFLICT">0.0333</exposureTime>
+      <exposureBiasValue toolname="Jhove" toolversion="1.26.1">0</exposureBiasValue>
+      <lightSource toolname="Jhove" toolversion="1.26.1">unknown</lightSource>
+      <meteringMode toolname="Jhove" toolversion="1.26.1">Pattern</meteringMode>
+      <flash toolname="Jhove" toolversion="1.26.1">Flash did not fire</flash>
+      <focalLength toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">28.0</focalLength>
+      <iccProfileVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
+      <captureDevice toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">digital still camera</captureDevice>
+      <digitalCameraManufacturer toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">NIKON CORPORATION</digitalCameraManufacturer>
+      <exposureProgram toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Manual</exposureProgram>
+      <exifVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">0220</exifVersion>
+      <maxApertureValue toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.8</maxApertureValue>
+      <sensingMethod toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">One-chip color area sensor</sensingMethod>
+      <cfaPattern toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">[Green,Red][Blue,Green]</cfaPattern>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -183,22 +183,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="309">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="542">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="199" />
-    <tool toolname="Jhove" toolversion="1.20.1" executionTime="304" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="36" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="277" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="116" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="3" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="162" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="423" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="525" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="218" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="530" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="349" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="113" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="210" />
   </statistics>
 </fits>
-

--- a/testfiles/output/Book_pdfx1a.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Book_pdfx1a.pdf_XmlUnitExpectedOutput.xml
@@ -58,6 +58,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="50" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.26.0" executionTime="331" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="135" />
@@ -67,7 +68,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="73" />
     <tool toolname="Tika" toolversion="2.3.0" executionTime="133" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/Calibre_hasTable_of_Contents.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Calibre_hasTable_of_Contents.epub_XmlUnitExpectedOutput.xml
@@ -42,6 +42,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.4" executionTime="10" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="77" />
@@ -51,7 +52,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="10" />
     <tool toolname="Tika" toolversion="1.21" executionTime="22" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/ConleyPPLec.ppt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/ConleyPPLec.ppt_XmlUnitExpectedOutput.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="8/11/21, 10:10 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Microsoft Powerpoint Presentation" mimetype="application/vnd.ms-powerpoint" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.5" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="12.29" />
-      <tool toolname="Tika" toolversion="2.0.0" />
-      <version toolname="Droid" toolversion="6.5">97-2003</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/126</externalIdentifier>
+    <identity format="Microsoft Powerpoint Presentation" mimetype="application/vnd.ms-powerpoint" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">97-2003</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/126</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="12.29" status="CONFLICT">2003:04:02 16:50:46</lastmodified>
-    <lastmodified toolname="Tika" toolversion="2.0.0" status="CONFLICT">2003-04-02T16:50:46Z</lastmodified>
-    <created toolname="Exiftool" toolversion="12.29" status="CONFLICT">2003:01:03 13:40:42</created>
-    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2003-01-03T13:40:42Z</created>
-    <creatingApplicationName toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">Microsoft PowerPoint</creatingApplicationName>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/home/winckles/workspace/3rd-party/fits/testfiles/ConleyPPLec.ppt</filepath>
+    <lastmodified toolname="Exiftool" toolversion="12.50" status="CONFLICT">2003-04-02T16:50:46</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.6.0" status="CONFLICT">2003-04-02T16:50:46Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">2003-01-03T13:40:42</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">2003-01-03T13:40:42Z</created>
+    <creatingApplicationName toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">Microsoft PowerPoint</creatingApplicationName>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/ConleyPPLec.ppt</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">ConleyPPLec.ppt</filename>
     <size toolname="OIS File Information" toolversion="1.0">83456</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">e57ef0327d753efab0c49286e8296550</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1556115032000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186551</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">26</pageCount>
-      <wordCount toolname="Exiftool" toolversion="12.29">1631</wordCount>
-      <title toolname="Exiftool" toolversion="12.29">Making High Schools Work for All Students</title>
-      <author toolname="Exiftool" toolversion="12.29">David Conley</author>
-      <paragraphCount toolname="Exiftool" toolversion="12.29" status="SINGLE_RESULT">156</paragraphCount>
+      <pageCount toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">26</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">1631</wordCount>
+      <title toolname="Exiftool" toolversion="12.50">Making High Schools Work for All Students</title>
+      <author toolname="Exiftool" toolversion="12.50">David Conley</author>
+      <paragraphCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">156</paragraphCount>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>26</docmd:PageCount>
@@ -39,22 +39,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="1138">
-    <tool toolname="MediaInfo" toolversion="21.03" status="did not run" />
+  <statistics fitsExecutionTime="667">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5" executionTime="225" />
-    <tool toolname="Jhove" toolversion="1.24.0" executionTime="1107" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="82" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="269" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="1096" />
-    <tool toolname="Exiftool" toolversion="12.29" executionTime="1111" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="224" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="624" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="214" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="25" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" status="did not run" />
-    <tool toolname="Tika" toolversion="2.0.0" executionTime="891" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="607" />
   </statistics>
 </fits>
-

--- a/testfiles/output/DH43D5TQESXBZ8W.xlsx_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/DH43D5TQESXBZ8W.xlsx_XmlUnitExpectedOutput.xml
@@ -1,51 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="8/11/21, 9:34 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Office Open XML Workbook" mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.5" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="12.29" />
-      <tool toolname="Tika" toolversion="2.0.0" />
-      <version toolname="Droid" toolversion="6.5">2007 onwards</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/214</externalIdentifier>
+    <identity format="Office Open XML Workbook" mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">2007 onwards</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/214</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="12.40">2016-08-23T15:51:49Z</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40">2016-08-22T16:47:09Z</created>
-    <creatingApplicationName toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">Microsoft Macintosh Excel</creatingApplicationName>
-    <creatingApplicationVersion toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">15.0300</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/home/winckles/workspace/3rd-party/fits/testfiles/DH43D5TQESXBZ8W.xlsx</filepath>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2016-08-23T15:51:49Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50">2016-08-22T16:47:09Z</created>
+    <creatingApplicationName toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">Microsoft Macintosh Excel</creatingApplicationName>
+    <creatingApplicationVersion toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">15.0300</creatingApplicationVersion>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/DH43D5TQESXBZ8W.xlsx</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">DH43D5TQESXBZ8W.xlsx</filename>
     <size toolname="OIS File Information" toolversion="1.0">73914</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">57c0455f671c9437a2f0d84216ec098b</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1628690284393</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186553</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <author toolname="Exiftool" toolversion="12.29">Microsoft Office User</author>
+      <author toolname="Exiftool" toolversion="12.50">Microsoft Office User</author>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd" />
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="1469">
-    <tool toolname="MediaInfo" toolversion="21.03" status="did not run" />
+  <statistics fitsExecutionTime="1727">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5" executionTime="288" />
-    <tool toolname="Jhove" toolversion="1.24.0" executionTime="1404" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="1433" />
-    <tool toolname="Exiftool" toolversion="12.29" executionTime="1416" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="279" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="1301" />
-    <tool toolname="Tika" toolversion="2.0.0" executionTime="1221" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="65" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="222" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="215" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="789" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="45" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="55" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="1690" />
   </statistics>
 </fits>
-

--- a/testfiles/output/Doc2.rtf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Doc2.rtf_XmlUnitExpectedOutput.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.3.1" timestamp="9/18/18 3:35 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Rich Text Format (RTF)" mimetype="application/rtf" toolname="FITS" toolversion="1.3.1">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.01" />
-      <tool toolname="Tika" toolversion="1.18" />
-      <version toolname="Droid" toolversion="6.4">1.9</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">fmt/355</externalIdentifier>
+    <identity format="Rich Text Format (RTF)" mimetype="application/rtf" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">1.9</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/355</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2015:09:24 12:17:00</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:09:24 12:16:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-09-24T16:16:00Z</created>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Doc2.rtf</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Doc2.rtf</filename>
-    <size toolname="OIS File Information" toolversion="0.2">26328</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">26301ff11c920c4e32f9fa7d706390a6</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117982000</fslastmodified>
+    <lastmodified toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2015-09-24T12:17:00</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">2015-09-24T12:16:00</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">2015-09-24T16:16:00Z</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/Doc2.rtf</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">Doc2.rtf</filename>
+    <size toolname="OIS File Information" toolversion="1.0">26328</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">26301ff11c920c4e32f9fa7d706390a6</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186553</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.01">1</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.01">0</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.01">0</characterCount>
-      <author toolname="Exiftool" toolversion="11.01">Aloisio, Paul G.</author>
+      <pageCount toolname="Exiftool" toolversion="12.50">1</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">0</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">0</characterCount>
+      <author toolname="Exiftool" toolversion="12.50">Aloisio, Paul G.</author>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>1</docmd:PageCount>
@@ -36,22 +36,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="635">
-    <tool toolname="MediaInfo" toolversion="18.08.1" status="did not run" />
+  <statistics fitsExecutionTime="287">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="6" />
-    <tool toolname="Jhove" toolversion="1.20" status="did not run" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="26" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="544" />
-    <tool toolname="Exiftool" toolversion="11.01" executionTime="633" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="105" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="267" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="3" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="24" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" status="did not run" />
-    <tool toolname="Tika" toolversion="1.18" executionTime="6" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="43" />
   </statistics>
 </fits>
-

--- a/testfiles/output/Document_Has_Form_Controls.docm_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Document_Has_Form_Controls.docm_XmlUnitExpectedOutput.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.11.0" timestamp="2/12/16 10:01 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Office Open XML Document (Macros Enabled)" mimetype="application/vnd.ms-word.document.macroEnabled.12" toolname="FITS" toolversion="0.11.0">
-      <tool toolname="Droid" toolversion="6.5" />
-      <tool toolname="Exiftool" toolversion="10.00" />
-      <tool toolname="Tika" toolversion="1.10" />
-      <version toolname="Droid" toolversion="6.5">2007 Onwards</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/523</externalIdentifier>
+    <identity format="Office Open XML Document (Macros Enabled)" mimetype="application/vnd.ms-word.document.macroEnabled.12" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">2007 Onwards</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/523</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="12.40">2015-09-30T20:34:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40">2015-09-30T20:34:00Z</created>
-    <creatingApplicationName toolname="Tika" toolversion="1.10" status="SINGLE_RESULT">Microsoft Office Word</creatingApplicationName>
-    <creatingApplicationVersion toolname="Exiftool" toolversion="10.00">14.0000</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Document_Has_Form_Controls.docm</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Document_Has_Form_Controls.docm</filename>
-    <size toolname="OIS File Information" toolversion="0.2">117650</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">acd68a6f5ba25303486add10a62a673e</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1455050482000</fslastmodified>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2015-09-30T20:34:00Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50">2015-09-30T20:34:00Z</created>
+    <creatingApplicationName toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">Microsoft Office Word</creatingApplicationName>
+    <creatingApplicationVersion toolname="Exiftool" toolversion="12.50">14.0000</creatingApplicationVersion>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/Document_Has_Form_Controls.docm</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">Document_Has_Form_Controls.docm</filename>
+    <size toolname="OIS File Information" toolversion="1.0">117650</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">acd68a6f5ba25303486add10a62a673e</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186554</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2</pageCount>
-      <wordCount toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">141</wordCount>
-      <characterCount toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">805</characterCount>
-      <author toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">Zakuta, Vitaly</author>
-      <lineCount toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">6</lineCount>
-      <paragraphCount toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">1</paragraphCount>
+      <pageCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">141</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">805</characterCount>
+      <author toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Zakuta, Vitaly</author>
+      <lineCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">6</lineCount>
+      <paragraphCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">1</paragraphCount>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>2</docmd:PageCount>
@@ -40,22 +40,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="781">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="1142">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="8" />
-    <tool toolname="Jhove" toolversion="1.11" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="34" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="222" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="3" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="7" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="772" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="49" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="176" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="638" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="21" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="58" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="1108" />
   </statistics>
 </fits>
-

--- a/testfiles/output/FITS-SAMPLE-26.mov-default_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/FITS-SAMPLE-26.mov-default_XmlUnitExpectedOutput.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="6/27/22, 11:47 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:07 AM">
   <identification>
     <identity format="Quicktime" mimetype="video/quicktime" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="MediaInfo" toolversion="21.09" />
+      <tool toolname="MediaInfo" toolversion="22.09" />
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="file utility" toolversion="5.41" />
+      <tool toolname="file utility" toolversion="5.43" />
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/384</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <creatingApplicationName toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">Apple QuickTime</creatingApplicationName>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/FITS-SAMPLE-26.mov</filepath>
+    <creatingApplicationName toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">Apple QuickTime</creatingApplicationName>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/FITS-SAMPLE-26.mov</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">FITS-SAMPLE-26.mov</filename>
-    <size toolname="MediaInfo" toolversion="21.09">15060707</size>
+    <size toolname="MediaInfo" toolversion="22.09">15060707</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">9c560fd7e4e6e0834bed9280c4b52d7b</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1439308612000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186655</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <video>
-      <location toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">/fits/testfiles/FITS-SAMPLE-26.mov</location>
-      <mimeType toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">video/quicktime</mimeType>
-      <format toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">Quicktime</format>
-      <formatProfile toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">QuickTime</formatProfile>
-      <duration toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">3971</duration>
-      <timecodeStart toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">01:58:41:27</timecodeStart>
-      <bitRate toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">30341389</bitRate>
-      <dateCreated toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">UTC 2015-03-13 15:36:19</dateCreated>
-      <dateModified toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">UTC 2015-08-11 15:56:52</dateModified>
-      <track type="video" id="1" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
+      <location toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">/fits/testfiles/input/FITS-SAMPLE-26.mov</location>
+      <mimeType toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">video/quicktime</mimeType>
+      <format toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">Quicktime</format>
+      <formatProfile toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">QuickTime</formatProfile>
+      <duration toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">3971</duration>
+      <timecodeStart toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">01:58:41:27</timecodeStart>
+      <bitRate toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">30341389</bitRate>
+      <dateCreated toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">UTC 2015-03-13 15:36:19</dateCreated>
+      <dateModified toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">UTC 2023-01-10 13:43:06</dateModified>
+      <track type="video" id="1" toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">
         <videoDataEncoding>AVdv</videoDataEncoding>
         <codecId>AVdv</codecId>
         <codecCC>AVdv</codecCC>
@@ -53,7 +53,7 @@
         <colorspace>YUV</colorspace>
         <broadcastStandard>NTSC</broadcastStandard>
       </track>
-      <track type="audio" id="3" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
+      <track type="audio" id="3" toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">
         <audioDataEncoding>PCM</audioDataEncoding>
         <codecId>twos</codecId>
         <codecFamily>PCM</codecFamily>
@@ -72,21 +72,21 @@
       </track>
     </video>
   </metadata>
-  <statistics fitsExecutionTime="138">
-    <tool toolname="MediaInfo" toolversion="21.09" executionTime="115" />
+  <statistics fitsExecutionTime="107">
+    <tool toolname="MediaInfo" toolversion="22.09" executionTime="69" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="28" />
-    <tool toolname="Jhove" toolversion="1.24.9" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="129" />
-    <tool toolname="Exiftool" toolversion="12.40" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="108" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="49" />
-    <tool toolname="Tika" toolversion="2.3.0" status="did not run" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="60" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="99" />
+    <tool toolname="Exiftool" toolversion="12.50" status="did not run" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="83" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="35" />
+    <tool toolname="Tika" toolversion="2.6.0" status="did not run" />
   </statistics>
 </fits>

--- a/testfiles/output/FITS-SAMPLE-26.mov_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/FITS-SAMPLE-26.mov_XmlUnitExpectedOutput.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="6/27/22, 11:46 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:06 AM">
   <identification>
     <identity format="Quicktime" mimetype="video/quicktime" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="MediaInfo" toolversion="21.09" />
+      <tool toolname="MediaInfo" toolversion="22.09" />
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="file utility" toolversion="5.41" />
+      <tool toolname="file utility" toolversion="5.43" />
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/384</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <creatingApplicationName toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">Apple QuickTime</creatingApplicationName>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/FITS-SAMPLE-26.mov</filepath>
+    <creatingApplicationName toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">Apple QuickTime</creatingApplicationName>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/FITS-SAMPLE-26.mov</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">FITS-SAMPLE-26.mov</filename>
-    <size toolname="MediaInfo" toolversion="21.09">15060707</size>
+    <size toolname="MediaInfo" toolversion="22.09">15060707</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">9c560fd7e4e6e0834bed9280c4b52d7b</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1439308612000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186655</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <video>
-      <location toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">/fits/testfiles/FITS-SAMPLE-26.mov</location>
-      <mimeType toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">video/quicktime</mimeType>
-      <format toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">Quicktime</format>
-      <formatProfile toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">QuickTime</formatProfile>
-      <duration toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">3971</duration>
-      <timecodeStart toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">01:58:41:27</timecodeStart>
-      <bitRate toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">30341389</bitRate>
-      <dateCreated toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">UTC 2015-03-13 15:36:19</dateCreated>
-      <dateModified toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">UTC 2015-08-11 15:56:52</dateModified>
-      <track type="video" id="1" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
+      <location toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">/fits/testfiles/input/FITS-SAMPLE-26.mov</location>
+      <mimeType toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">video/quicktime</mimeType>
+      <format toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">Quicktime</format>
+      <formatProfile toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">QuickTime</formatProfile>
+      <duration toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">3971</duration>
+      <timecodeStart toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">01:58:41:27</timecodeStart>
+      <bitRate toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">30341389</bitRate>
+      <dateCreated toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">UTC 2015-03-13 15:36:19</dateCreated>
+      <dateModified toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">UTC 2023-01-10 13:43:06</dateModified>
+      <track type="video" id="1" toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">
         <videoDataEncoding>AVdv</videoDataEncoding>
         <codecId>AVdv</codecId>
         <codecCC>AVdv</codecCC>
@@ -53,7 +53,7 @@
         <colorspace>YUV</colorspace>
         <broadcastStandard>NTSC</broadcastStandard>
       </track>
-      <track type="audio" id="3" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
+      <track type="audio" id="3" toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">
         <audioDataEncoding>PCM</audioDataEncoding>
         <codecId>twos</codecId>
         <codecFamily>PCM</codecFamily>
@@ -150,30 +150,30 @@
                 <ebucore:editUnitNumber editRate="1000" factorNumerator="1" factorDenominator="1">3971</ebucore:editUnitNumber>
               </ebucore:duration>
               <ebucore:mimeType typeLabel="video/quicktime" />
-              <ebucore:locator>/fits/testfiles/FITS-SAMPLE-26.mov</ebucore:locator>
+              <ebucore:locator>/fits/testfiles/input/FITS-SAMPLE-26.mov</ebucore:locator>
               <ebucore:technicalAttributeString typeLabel="overallBitRate">30341389</ebucore:technicalAttributeString>
-              <ebucore:dateModified startTime="15:56:52Z" startDate="2015-08-11" />
+              <ebucore:dateModified startTime="13:43:06Z" startDate="2023-01-10" />
             </ebucore:format>
           </ebucore:coreMetadata>
         </ebucore:ebuCoreMain>
       </standard>
     </video>
   </metadata>
-  <statistics fitsExecutionTime="3520">
-    <tool toolname="MediaInfo" toolversion="21.09" executionTime="3481" />
+  <statistics fitsExecutionTime="385">
+    <tool toolname="MediaInfo" toolversion="22.09" executionTime="380" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="507" />
-    <tool toolname="Jhove" toolversion="1.24.9" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="3449" />
-    <tool toolname="Exiftool" toolversion="12.40" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="499" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="3450" />
-    <tool toolname="Tika" toolversion="2.3.0" status="did not run" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="322" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="186" />
+    <tool toolname="Exiftool" toolversion="12.50" status="did not run" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="312" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="83" />
+    <tool toolname="Tika" toolversion="2.6.0" status="did not run" />
   </statistics>
 </fits>

--- a/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4-default_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4-default_XmlUnitExpectedOutput.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="6/27/22, 11:46 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:06 AM">
   <identification>
     <identity format="MPEG-4" mimetype="video/mp4" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="MediaInfo" toolversion="21.09" />
+      <tool toolname="MediaInfo" toolversion="22.09" />
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="file utility" toolversion="5.41" />
+      <tool toolname="file utility" toolversion="5.43" />
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/199</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4</filepath>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4</filename>
-    <size toolname="MediaInfo" toolversion="21.09">9093784</size>
+    <size toolname="MediaInfo" toolversion="22.09">9093784</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">61c4efc89a4acfb9db38edcdd6c39379</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1439308612000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186680</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <video>
-      <location toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">/fits/testfiles/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4</location>
-      <mimeType toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">video/quicktime</mimeType>
-      <format toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">MPEG-4</format>
-      <formatProfile toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">Base Media / Version 2</formatProfile>
-      <duration toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">4137</duration>
-      <bitRate toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">17585272</bitRate>
-      <dateCreated toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">UTC 2015-03-13 19:21:21</dateCreated>
-      <dateModified toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">UTC 2015-08-11 15:56:52</dateModified>
-      <track type="video" id="1" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
+      <location toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">/fits/testfiles/input/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4</location>
+      <mimeType toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">video/quicktime</mimeType>
+      <format toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">MPEG-4</format>
+      <formatProfile toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">Base Media / Version 2</formatProfile>
+      <duration toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">4137</duration>
+      <bitRate toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">17585272</bitRate>
+      <dateCreated toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">UTC 2015-03-13 19:21:21</dateCreated>
+      <dateModified toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">UTC 2023-01-10 13:43:06</dateModified>
+      <track type="video" id="1" toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">
         <videoDataEncoding>avc1</videoDataEncoding>
         <codecId>avc1</codecId>
         <codecCC>avc1</codecCC>
@@ -52,7 +52,7 @@
         <colorspace>YUV</colorspace>
         <broadcastStandard>NTSC</broadcastStandard>
       </track>
-      <track type="audio" id="2" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
+      <track type="audio" id="2" toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">
         <audioDataEncoding>AAC LC</audioDataEncoding>
         <codecId>mp4a-40-2</codecId>
         <codecFamily>AAC</codecFamily>
@@ -68,21 +68,21 @@
       </track>
     </video>
   </metadata>
-  <statistics fitsExecutionTime="206">
-    <tool toolname="MediaInfo" toolversion="21.09" executionTime="193" />
+  <statistics fitsExecutionTime="324">
+    <tool toolname="MediaInfo" toolversion="22.09" executionTime="318" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="47" />
-    <tool toolname="Jhove" toolversion="1.24.9" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="182" />
-    <tool toolname="Exiftool" toolversion="12.40" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="123" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="69" />
-    <tool toolname="Tika" toolversion="2.3.0" status="did not run" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="304" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="197" />
+    <tool toolname="Exiftool" toolversion="12.50" status="did not run" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="202" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="120" />
+    <tool toolname="Tika" toolversion="2.6.0" status="did not run" />
   </statistics>
 </fits>

--- a/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4-no-md5_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4-no-md5_XmlUnitExpectedOutput.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="6/27/22, 11:47 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:07 AM">
   <identification>
     <identity format="MPEG-4" mimetype="video/mp4" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="MediaInfo" toolversion="21.09" />
+      <tool toolname="MediaInfo" toolversion="22.09" />
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="file utility" toolversion="5.41" />
+      <tool toolname="file utility" toolversion="5.43" />
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/199</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4</filepath>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4</filename>
-    <size toolname="MediaInfo" toolversion="21.09">9093784</size>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1439308612000</fslastmodified>
+    <size toolname="MediaInfo" toolversion="22.09">9093784</size>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186680</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <video>
-      <location toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">/fits/testfiles/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4</location>
-      <mimeType toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">video/quicktime</mimeType>
-      <format toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">MPEG-4</format>
-      <formatProfile toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">Base Media / Version 2</formatProfile>
-      <duration toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">4137</duration>
-      <bitRate toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">17585272</bitRate>
-      <dateCreated toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">UTC 2015-03-13 19:21:21</dateCreated>
-      <dateModified toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">UTC 2015-08-11 15:56:52</dateModified>
-      <track type="video" id="1" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
+      <location toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">/fits/testfiles/input/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_3_1.mp4</location>
+      <mimeType toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">video/quicktime</mimeType>
+      <format toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">MPEG-4</format>
+      <formatProfile toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">Base Media / Version 2</formatProfile>
+      <duration toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">4137</duration>
+      <bitRate toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">17585272</bitRate>
+      <dateCreated toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">UTC 2015-03-13 19:21:21</dateCreated>
+      <dateModified toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">UTC 2023-01-10 13:43:06</dateModified>
+      <track type="video" id="1" toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">
         <videoDataEncoding>avc1</videoDataEncoding>
         <codecId>avc1</codecId>
         <codecCC>avc1</codecCC>
@@ -51,7 +51,7 @@
         <colorspace>YUV</colorspace>
         <broadcastStandard>NTSC</broadcastStandard>
       </track>
-      <track type="audio" id="2" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
+      <track type="audio" id="2" toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">
         <audioDataEncoding>AAC LC</audioDataEncoding>
         <codecId>mp4a-40-2</codecId>
         <codecFamily>AAC</codecFamily>
@@ -67,20 +67,20 @@
       </track>
     </video>
   </metadata>
-  <statistics fitsExecutionTime="1862">
-    <tool toolname="MediaInfo" toolversion="21.09" executionTime="231" />
+  <statistics fitsExecutionTime="1892">
+    <tool toolname="MediaInfo" toolversion="22.09" executionTime="141" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="212" />
-    <tool toolname="Jhove" toolversion="1.24.9" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="158" />
-    <tool toolname="Exiftool" toolversion="12.40" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="1855" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="14" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="93" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="799" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="190" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="98" />
+    <tool toolname="Exiftool" toolversion="12.50" status="did not run" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="1886" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="32" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="72" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="417" />
   </statistics>
 </fits>

--- a/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov_XmlUnitExpectedOutput.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="6/27/22, 11:47 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:07 AM">
   <identification>
     <identity format="Quicktime" mimetype="video/quicktime" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="MediaInfo" toolversion="21.09" />
+      <tool toolname="MediaInfo" toolversion="22.09" />
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="file utility" toolversion="5.41" />
+      <tool toolname="file utility" toolversion="5.43" />
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/384</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov</filepath>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov</filename>
-    <size toolname="MediaInfo" toolversion="21.09">1235897</size>
+    <size toolname="MediaInfo" toolversion="22.09">1235897</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">d7e04890d435bc9a8e967f6b1054bb69</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1469037260000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186695</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <video>
-      <location toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">/fits/testfiles/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov</location>
-      <mimeType toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">video/quicktime</mimeType>
-      <format toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">Quicktime</format>
-      <formatProfile toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">QuickTime</formatProfile>
-      <duration toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">4200</duration>
-      <bitRate toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">2354090</bitRate>
-      <dateModified toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">UTC 2016-07-20 17:54:20</dateModified>
-      <track type="video" id="1" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
+      <location toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">/fits/testfiles/input/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov</location>
+      <mimeType toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">video/quicktime</mimeType>
+      <format toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">Quicktime</format>
+      <formatProfile toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">QuickTime</formatProfile>
+      <duration toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">4200</duration>
+      <bitRate toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">2354090</bitRate>
+      <dateModified toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">UTC 2023-01-10 13:43:06</dateModified>
+      <track type="video" id="1" toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">
         <videoDataEncoding>m2v1</videoDataEncoding>
         <codecId>m2v1</codecId>
         <codecCC>m2v1</codecCC>
@@ -52,7 +52,7 @@
         <colorspace>YUV</colorspace>
         <broadcastStandard>NTSC</broadcastStandard>
       </track>
-      <track type="audio" id="2" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
+      <track type="audio" id="2" toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">
         <audioDataEncoding>.mp2</audioDataEncoding>
         <codecId>.mp2</codecId>
         <codecFamily>.mp2</codecFamily>
@@ -143,30 +143,30 @@
                 <ebucore:editUnitNumber editRate="1000" factorNumerator="1" factorDenominator="1">4200</ebucore:editUnitNumber>
               </ebucore:duration>
               <ebucore:mimeType typeLabel="video/quicktime" />
-              <ebucore:locator>/fits/testfiles/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov</ebucore:locator>
+              <ebucore:locator>/fits/testfiles/input/FITS-SAMPLE-44_1_1_4_4_4_6_1_1_2_4_8_1_2_1_1.mov</ebucore:locator>
               <ebucore:technicalAttributeString typeLabel="overallBitRate">2354090</ebucore:technicalAttributeString>
-              <ebucore:dateModified startTime="17:54:20Z" startDate="2016-07-20" />
+              <ebucore:dateModified startTime="13:43:06Z" startDate="2023-01-10" />
             </ebucore:format>
           </ebucore:coreMetadata>
         </ebucore:ebuCoreMain>
       </standard>
     </video>
   </metadata>
-  <statistics fitsExecutionTime="128">
-    <tool toolname="MediaInfo" toolversion="21.09" executionTime="121" />
+  <statistics fitsExecutionTime="123">
+    <tool toolname="MediaInfo" toolversion="22.09" executionTime="97" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="55" />
-    <tool toolname="Jhove" toolversion="1.24.9" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="119" />
-    <tool toolname="Exiftool" toolversion="12.40" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="64" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="62" />
-    <tool toolname="Tika" toolversion="2.3.0" status="did not run" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="82" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="117" />
+    <tool toolname="Exiftool" toolversion="12.50" status="did not run" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="66" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="69" />
+    <tool toolname="Tika" toolversion="2.6.0" status="did not run" />
   </statistics>
 </fits>

--- a/testfiles/output/GLOBE1.JPG_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/GLOBE1.JPG_XmlUnitExpectedOutput.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="7/14/22, 4:03 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
     <identity format="JPEG File Interchange Format" mimetype="image/jpeg" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="Jhove" toolversion="1.26.0" />
-      <tool toolname="file utility" toolversion="5.41" />
-      <tool toolname="Exiftool" toolversion="12.40" />
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <version toolname="Droid" toolversion="6.5.2">1.01</version>
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/43</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.26.0">49220</size>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/GLOBE1.JPG</filepath>
+    <size toolname="Jhove" toolversion="1.26.1">49220</size>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/GLOBE1.JPG</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">GLOBE1.JPG</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">97a5f169b4e0db02a982af7fcc5433de</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1488467748000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186697</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <image>
-      <byteOrder toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">big endian</byteOrder>
-      <compressionScheme toolname="Jhove" toolversion="1.26.0">JPEG</compressionScheme>
-      <imageWidth toolname="Jhove" toolversion="1.26.0">582</imageWidth>
-      <imageHeight toolname="Jhove" toolversion="1.26.0">597</imageHeight>
-      <colorSpace toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">YCbCr</colorSpace>
-      <YCbCrSubSampling toolname="Exiftool" toolversion="12.40" status="SINGLE_RESULT">2 2</YCbCrSubSampling>
-      <samplingFrequencyUnit toolname="Jhove" toolversion="1.26.0">no absolute unit of measurement</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Exiftool" toolversion="12.40">1</xSamplingFrequency>
-      <ySamplingFrequency toolname="Exiftool" toolversion="12.40">1</ySamplingFrequency>
-      <bitsPerSample toolname="Jhove" toolversion="1.26.0">8 8 8</bitsPerSample>
-      <samplesPerPixel toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">3</samplesPerPixel>
+      <byteOrder toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">big endian</byteOrder>
+      <compressionScheme toolname="Jhove" toolversion="1.26.1">JPEG</compressionScheme>
+      <imageWidth toolname="Jhove" toolversion="1.26.1">582</imageWidth>
+      <imageHeight toolname="Jhove" toolversion="1.26.1">597</imageHeight>
+      <colorSpace toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">YCbCr</colorSpace>
+      <YCbCrSubSampling toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2 2</YCbCrSubSampling>
+      <samplingFrequencyUnit toolname="Jhove" toolversion="1.26.1">no absolute unit of measurement</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Exiftool" toolversion="12.50">1</xSamplingFrequency>
+      <ySamplingFrequency toolname="Exiftool" toolversion="12.50">1</ySamplingFrequency>
+      <bitsPerSample toolname="Jhove" toolversion="1.26.1">8 8 8</bitsPerSample>
+      <samplesPerPixel toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">3</samplesPerPixel>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -86,22 +86,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="333">
-    <tool toolname="MediaInfo" toolversion="21.09" status="did not run" />
+  <statistics fitsExecutionTime="288">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="56" />
-    <tool toolname="Jhove" toolversion="1.26.0" executionTime="129" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="117" />
-    <tool toolname="Exiftool" toolversion="12.40" executionTime="319" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="37" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="60" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="82" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="40" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="122" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="117" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="277" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="30" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="56" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="51" />
   </statistics>
 </fits>
-

--- a/testfiles/output/GeographyofBliss_oneChapter.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/GeographyofBliss_oneChapter.epub_XmlUnitExpectedOutput.xml
@@ -40,6 +40,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.4" executionTime="17" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="78" />
@@ -49,7 +50,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="18" />
     <tool toolname="Tika" toolversion="1.21" executionTime="29" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/HasAnnotations.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/HasAnnotations.pdf_XmlUnitExpectedOutput.xml
@@ -76,6 +76,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="37" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.26.0" executionTime="198" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="150" />
@@ -85,7 +86,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="69" />
     <tool toolname="Tika" toolversion="2.3.0" executionTime="167" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/HasChangeHistory.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/HasChangeHistory.pdf_XmlUnitExpectedOutput.xml
@@ -76,6 +76,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="29" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.26.0" executionTime="266" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="133" />
@@ -85,7 +86,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="59" />
     <tool toolname="Tika" toolversion="2.3.0" executionTime="490" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/ICFA.KC.BIA.1524-small.jpg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/ICFA.KC.BIA.1524-small.jpg_XmlUnitExpectedOutput.xml
@@ -1,65 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="12/6/21 3:32 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
-    <identity format="JPEG EXIF" mimetype="image/jpeg" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="Jhove" toolversion="1.20.1" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="11.54" />
-      <version toolname="Droid" toolversion="6.4" status="CONFLICT">2.2.1</version>
-      <version toolname="file utility" toolversion="5.39" status="CONFLICT">16</version>
-      <version toolname="Exiftool" toolversion="11.54" status="CONFLICT">5.5</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">fmt/645</externalIdentifier>
+    <identity format="JPEG EXIF" mimetype="image/jpeg" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <version toolname="Droid" toolversion="6.5.2" status="CONFLICT">2.2.1</version>
+      <version toolname="file utility" toolversion="5.43" status="CONFLICT">012</version>
+      <version toolname="Exiftool" toolversion="12.50" status="CONFLICT">5.5</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/645</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.20.1">38829</size>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Canon EOS 5D Mark II</creatingApplicationName>
+    <size toolname="Jhove" toolversion="1.26.1">38829</size>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Canon EOS 5D Mark II</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="12.50">2017-01-30T11:39:51</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40">2010-07-07T14:22:53</created>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/ICFA.KC.BIA.1524-small.jpg</filepath>
+    <created toolname="Exiftool" toolversion="12.50">2010-07-07T14:22:53</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/ICFA.KC.BIA.1524-small.jpg</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">ICFA.KC.BIA.1524-small.jpg</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">0108175c9153da1d41278066a2e3c1a2</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186701</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">true</valid>
-    <message toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">Value offset not word-aligned: 239 severity=info offset=126</message>
-    <message toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">Value offset not word-aligned: 247 severity=info offset=138</message>
-    <message toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">Value offset not word-aligned: 255 severity=info offset=174</message>
-    <message toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">Value offset not word-aligned: 285 severity=info offset=186</message>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
+    <message toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Value offset not word-aligned: 239 severity=info offset=126</message>
+    <message toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Value offset not word-aligned: 247 severity=info offset=138</message>
+    <message toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Value offset not word-aligned: 255 severity=info offset=174</message>
+    <message toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Value offset not word-aligned: 285 severity=info offset=186</message>
   </filestatus>
   <metadata>
     <image>
-      <byteOrder toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">big endian</byteOrder>
-      <compressionScheme toolname="Jhove" toolversion="1.20.1">JPEG</compressionScheme>
-      <imageWidth toolname="Jhove" toolversion="1.20.1">109</imageWidth>
-      <imageHeight toolname="Jhove" toolversion="1.20.1">150</imageHeight>
-      <colorSpace toolname="Jhove" toolversion="1.24.9" status="CONFLICT">YCbCr</colorSpace>
-      <colorSpace toolname="Exiftool" toolversion="12.40" status="CONFLICT">RGB</colorSpace>
-      <iccProfileName toolname="Jhove" toolversion="1.20.1">Adobe RGB (1998)</iccProfileName>
-      <YCbCrSubSampling toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1 1</YCbCrSubSampling>
-      <orientation toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">normal*</orientation>
-      <samplingFrequencyUnit toolname="Jhove" toolversion="1.20.1">in.</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Jhove" toolversion="1.20.1">350</xSamplingFrequency>
-      <ySamplingFrequency toolname="Jhove" toolversion="1.20.1">350</ySamplingFrequency>
-      <bitsPerSample toolname="Jhove" toolversion="1.20.1">8 8 8</bitsPerSample>
-      <samplesPerPixel toolname="Jhove" toolversion="1.20.1">3</samplesPerPixel>
-      <scanningSoftwareName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Adobe Photoshop CS6 (Windows)</scanningSoftwareName>
-      <digitalCameraModelName toolname="Jhove" toolversion="1.20.1">Canon EOS 5D Mark II</digitalCameraModelName>
-      <fNumber toolname="Jhove" toolversion="1.20.1">11</fNumber>
-      <exposureTime toolname="Jhove" toolversion="1.20.1">0.125</exposureTime>
-      <isoSpeedRating toolname="Jhove" toolversion="1.20.1">100</isoSpeedRating>
-      <exposureBiasValue toolname="Jhove" toolversion="1.20.1">0</exposureBiasValue>
-      <flash toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">Flash did not fire, compulsory flash mode</flash>
-      <focalLength toolname="Jhove" toolversion="1.20.1">50</focalLength>
-      <iccProfileVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
-      <digitalCameraManufacturer toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Canon</digitalCameraManufacturer>
-      <exifVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">0221</exifVersion>
-      <shutterSpeedValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1/8</shutterSpeedValue>
-      <apertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">11.0</apertureValue>
-      <maxApertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.5</maxApertureValue>
+      <byteOrder toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">big endian</byteOrder>
+      <compressionScheme toolname="Jhove" toolversion="1.26.1">JPEG</compressionScheme>
+      <imageWidth toolname="Jhove" toolversion="1.26.1">109</imageWidth>
+      <imageHeight toolname="Jhove" toolversion="1.26.1">150</imageHeight>
+      <colorSpace toolname="Jhove" toolversion="1.26.1" status="CONFLICT">YCbCr</colorSpace>
+      <colorSpace toolname="Exiftool" toolversion="12.50" status="CONFLICT">RGB</colorSpace>
+      <iccProfileName toolname="Jhove" toolversion="1.26.1">Adobe RGB (1998)</iccProfileName>
+      <YCbCrSubSampling toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">1 1</YCbCrSubSampling>
+      <orientation toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">normal*</orientation>
+      <samplingFrequencyUnit toolname="Jhove" toolversion="1.26.1">in.</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Jhove" toolversion="1.26.1">350</xSamplingFrequency>
+      <ySamplingFrequency toolname="Jhove" toolversion="1.26.1">350</ySamplingFrequency>
+      <bitsPerSample toolname="Jhove" toolversion="1.26.1">8 8 8</bitsPerSample>
+      <samplesPerPixel toolname="Jhove" toolversion="1.26.1">3</samplesPerPixel>
+      <scanningSoftwareName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Adobe Photoshop CS6 (Windows)</scanningSoftwareName>
+      <digitalCameraModelName toolname="Jhove" toolversion="1.26.1">Canon EOS 5D Mark II</digitalCameraModelName>
+      <fNumber toolname="Jhove" toolversion="1.26.1">11</fNumber>
+      <exposureTime toolname="Jhove" toolversion="1.26.1">0.125</exposureTime>
+      <isoSpeedRating toolname="Jhove" toolversion="1.26.1">100</isoSpeedRating>
+      <exposureBiasValue toolname="Jhove" toolversion="1.26.1">0</exposureBiasValue>
+      <flash toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Flash did not fire, compulsory flash mode</flash>
+      <focalLength toolname="Jhove" toolversion="1.26.1">50</focalLength>
+      <iccProfileVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
+      <digitalCameraManufacturer toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Canon</digitalCameraManufacturer>
+      <exifVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">0221</exifVersion>
+      <shutterSpeedValue toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">1/8</shutterSpeedValue>
+      <apertureValue toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">11.0</apertureValue>
+      <maxApertureValue toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.5</maxApertureValue>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -158,22 +158,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="415">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="638">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="80" />
-    <tool toolname="Jhove" toolversion="1.20.1" executionTime="104" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="45" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="401" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="5" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="10" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="289" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="201" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="282" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="104" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="512" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="35" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="74" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="622" />
   </statistics>
 </fits>
-

--- a/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/JPEGTest_20170591--JPEGTest_20170591.jpeg_XmlUnitExpectedOutput.xml
@@ -1,70 +1,70 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="12/6/21 3:32 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
-    <identity format="JPEG EXIF" mimetype="image/jpeg" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="Jhove" toolversion="1.20.1" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="11.54" />
-      <version toolname="Droid" toolversion="6.4" status="CONFLICT">2.2.1</version>
-      <version toolname="file utility" toolversion="5.39" status="CONFLICT">16</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">fmt/645</externalIdentifier>
+    <identity format="JPEG EXIF" mimetype="image/jpeg" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <version toolname="Droid" toolversion="6.5.2" status="CONFLICT">2.2.1</version>
+      <version toolname="file utility" toolversion="5.43" status="CONFLICT">012</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/645</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.20.1">4324778</size>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">HERO3+ Black Edition</creatingApplicationName>
+    <size toolname="Jhove" toolversion="1.26.1">4324778</size>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">HERO3+ Black Edition</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="12.50">2015-06-25T11:03:38</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40">2014-10-27T12:34:43</created>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/JPEGTest_20170591--JPEGTest_20170591.jpeg</filepath>
+    <created toolname="Exiftool" toolversion="12.50">2014-10-27T12:34:43</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/JPEGTest_20170591--JPEGTest_20170591.jpeg</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">JPEGTest_20170591--JPEGTest_20170591.jpeg</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">3c5a86c471809d347e99d19c51bd1b94</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186740</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <image>
-      <byteOrder toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">big endian</byteOrder>
-      <compressionScheme toolname="Jhove" toolversion="1.20.1">JPEG</compressionScheme>
-      <imageWidth toolname="Jhove" toolversion="1.20.1">3920</imageWidth>
-      <imageHeight toolname="Jhove" toolversion="1.20.1">2160</imageHeight>
-      <colorSpace toolname="Jhove" toolversion="1.24.9">RGB</colorSpace>
-      <iccProfileName toolname="Jhove" toolversion="1.20.1">sRGB IEC61966-2.1</iccProfileName>
-      <YCbCrSubSampling toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1 1</YCbCrSubSampling>
-      <YCbCrPositioning toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1</YCbCrPositioning>
-      <orientation toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">normal*</orientation>
-      <samplingFrequencyUnit toolname="Jhove" toolversion="1.20.1">in.</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Jhove" toolversion="1.20.1">72</xSamplingFrequency>
-      <ySamplingFrequency toolname="Jhove" toolversion="1.20.1">72</ySamplingFrequency>
-      <bitsPerSample toolname="Jhove" toolversion="1.20.1">8 8 8</bitsPerSample>
-      <samplesPerPixel toolname="Jhove" toolversion="1.20.1">3</samplesPerPixel>
-      <scanningSoftwareName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Adobe Photoshop CS6 (Macintosh)</scanningSoftwareName>
-      <digitalCameraModelName toolname="Jhove" toolversion="1.20.1">HERO3+ Black Edition</digitalCameraModelName>
-      <fNumber toolname="Jhove" toolversion="1.20.1">2.8</fNumber>
-      <exposureTime toolname="Jhove" toolversion="1.20.1" status="CONFLICT">0.008</exposureTime>
-      <exposureTime toolname="Exiftool" toolversion="11.54" status="CONFLICT">0.0083</exposureTime>
-      <isoSpeedRating toolname="Jhove" toolversion="1.20.1">142</isoSpeedRating>
-      <exposureBiasValue toolname="Jhove" toolversion="1.20.1">0</exposureBiasValue>
-      <lightSource toolname="Jhove" toolversion="1.20.1">unknown</lightSource>
-      <subjectDistance toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">undef</subjectDistance>
-      <meteringMode toolname="Jhove" toolversion="1.20.1">Center weighted average</meteringMode>
-      <flash toolname="Jhove" toolversion="1.20.1">No flash function</flash>
-      <focalLength toolname="Jhove" toolversion="1.20.1" status="CONFLICT">2.77</focalLength>
-      <focalLength toolname="Exiftool" toolversion="11.54" status="CONFLICT">2.8</focalLength>
-      <exposureIndex toolname="Jhove" toolversion="1.20.1" status="CONFLICT">NaN</exposureIndex>
-      <exposureIndex toolname="Exiftool" toolversion="11.54" status="CONFLICT">undef</exposureIndex>
-      <iccProfileVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
-      <captureDevice toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">digital still camera</captureDevice>
-      <digitalCameraManufacturer toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">GoPro</digitalCameraManufacturer>
-      <exposureProgram toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Normal program</exposureProgram>
-      <exifVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">0221</exifVersion>
-      <shutterSpeedValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1/120</shutterSpeedValue>
-      <apertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.8</apertureValue>
-      <maxApertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.8</maxApertureValue>
-      <sensingMethod toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">One-chip color area sensor</sensingMethod>
+      <byteOrder toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">big endian</byteOrder>
+      <compressionScheme toolname="Jhove" toolversion="1.26.1">JPEG</compressionScheme>
+      <imageWidth toolname="Jhove" toolversion="1.26.1">3920</imageWidth>
+      <imageHeight toolname="Jhove" toolversion="1.26.1">2160</imageHeight>
+      <colorSpace toolname="Jhove" toolversion="1.26.1">RGB</colorSpace>
+      <iccProfileName toolname="Jhove" toolversion="1.26.1">sRGB IEC61966-2.1</iccProfileName>
+      <YCbCrSubSampling toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">1 1</YCbCrSubSampling>
+      <YCbCrPositioning toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">1</YCbCrPositioning>
+      <orientation toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">normal*</orientation>
+      <samplingFrequencyUnit toolname="Jhove" toolversion="1.26.1">in.</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Jhove" toolversion="1.26.1">72</xSamplingFrequency>
+      <ySamplingFrequency toolname="Jhove" toolversion="1.26.1">72</ySamplingFrequency>
+      <bitsPerSample toolname="Jhove" toolversion="1.26.1">8 8 8</bitsPerSample>
+      <samplesPerPixel toolname="Jhove" toolversion="1.26.1">3</samplesPerPixel>
+      <scanningSoftwareName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Adobe Photoshop CS6 (Macintosh)</scanningSoftwareName>
+      <digitalCameraModelName toolname="Jhove" toolversion="1.26.1">HERO3+ Black Edition</digitalCameraModelName>
+      <fNumber toolname="Jhove" toolversion="1.26.1">2.8</fNumber>
+      <exposureTime toolname="Jhove" toolversion="1.26.1" status="CONFLICT">0.008</exposureTime>
+      <exposureTime toolname="Exiftool" toolversion="12.50" status="CONFLICT">0.0083</exposureTime>
+      <isoSpeedRating toolname="Jhove" toolversion="1.26.1">142</isoSpeedRating>
+      <exposureBiasValue toolname="Jhove" toolversion="1.26.1">0</exposureBiasValue>
+      <lightSource toolname="Jhove" toolversion="1.26.1">unknown</lightSource>
+      <subjectDistance toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">undef</subjectDistance>
+      <meteringMode toolname="Jhove" toolversion="1.26.1">Center weighted average</meteringMode>
+      <flash toolname="Jhove" toolversion="1.26.1">No flash function</flash>
+      <focalLength toolname="Jhove" toolversion="1.26.1" status="CONFLICT">2.77</focalLength>
+      <focalLength toolname="Exiftool" toolversion="12.50" status="CONFLICT">2.8</focalLength>
+      <exposureIndex toolname="Jhove" toolversion="1.26.1" status="CONFLICT">NaN</exposureIndex>
+      <exposureIndex toolname="Exiftool" toolversion="12.50" status="CONFLICT">undef</exposureIndex>
+      <iccProfileVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
+      <captureDevice toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">digital still camera</captureDevice>
+      <digitalCameraManufacturer toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">GoPro</digitalCameraManufacturer>
+      <exposureProgram toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Normal program</exposureProgram>
+      <exifVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">0221</exifVersion>
+      <shutterSpeedValue toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">1/120</shutterSpeedValue>
+      <apertureValue toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.8</apertureValue>
+      <maxApertureValue toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.8</maxApertureValue>
+      <sensingMethod toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">One-chip color area sensor</sensingMethod>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -168,22 +168,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="361">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="469">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="58" />
-    <tool toolname="Jhove" toolversion="1.20.1" executionTime="219" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="53" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="352" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="49" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="6" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="91" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="158" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="393" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="201" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="457" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="142" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="106" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="189" />
   </statistics>
 </fits>
-

--- a/testfiles/output/Jess26676_Pugua.mp3_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Jess26676_Pugua.mp3_XmlUnitExpectedOutput.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.3.0" timestamp="7/26/18 10:55 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:04 AM">
   <identification>
-    <identity format="MPEG 1/2 Audio Layer 3" mimetype="audio/mpeg" toolname="FITS" toolversion="1.3.0">
-      <tool toolname="Droid" toolversion="6.3" />
-      <tool toolname="Exiftool" toolversion="10.00" />
+    <identity format="MPEG 1/2 Audio Layer 3" mimetype="audio/mpeg" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.10" />
+      <tool toolname="Tika" toolversion="2.6.0" />
       <version toolname="NLNZ Metadata Extractor" toolversion="3.6GA">1</version>
-      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">fmt/134</externalIdentifier>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/134</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/Documents/FITS-WP-test/input/Jess26676_Pugua.mp3</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Jess26676_Pugua.mp3</filename>
-    <size toolname="OIS File Information" toolversion="0.2">1720048</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">50ed497b874395b36be63cbe1f82bcc2</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1242226524000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/Jess26676_Pugua.mp3</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">Jess26676_Pugua.mp3</filename>
+    <size toolname="OIS File Information" toolversion="1.0">1720048</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">50ed497b874395b36be63cbe1f82bcc2</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186750</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <audio>
       <duration toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">0:2:23:321</duration>
-      <bitRate toolname="Exiftool" toolversion="10.00" status="CONFLICT">96 kbps</bitRate>
+      <bitRate toolname="Exiftool" toolversion="12.50" status="CONFLICT">96 kbps</bitRate>
       <bitRate toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">96000</bitRate>
-      <sampleRate toolname="Exiftool" toolversion="10.00">44100</sampleRate>
-      <channels toolname="Exiftool" toolversion="10.00">2</channels>
+      <sampleRate toolname="Exiftool" toolversion="12.50">44100</sampleRate>
+      <channels toolname="Exiftool" toolversion="12.50">2</channels>
       <milliseconds toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">143321</milliseconds>
-      <sampleRate toolname="Tika" toolversion="1.10" status="SINGLE_RESULT">44100</sampleRate>
+      <sampleRate toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">44100</sampleRate>
       <standard>
-        <aes:audioObject xmlns:aes="http://www.aes.org/audioObject" xsi:schemaLocation="http://www.aes.org/audioObject http://www.aes.org/standards/schemas/aes57-2011-08-27.xsd" ID="AUDIO_OBJECT_08d9de0f-f7d7-469e-abfc-82b91e7809b3" analogDigitalFlag="FILE_DIGITAL" schemaVersion="1.0.0" disposition="">
+        <aes:audioObject xmlns:aes="http://www.aes.org/audioObject" xsi:schemaLocation="http://www.aes.org/audioObject http://www.aes.org/standards/schemas/aes57-2011-08-27.xsd" disposition="" schemaVersion="1.0.0" analogDigitalFlag="FILE_DIGITAL" ID="AUDIO_OBJECT_bac40f72-0764-40fc-bc70-ec5e96476134">
           <aes:format specificationVersion="1">MPEG 1/2 Audio Layer 3</aes:format>
           <aes:use useType="OTHER" otherType="unknown" />
           <aes:primaryIdentifier identifierType="FILE_NAME">Jess26676_Pugua.mp3</aes:primaryIdentifier>
-          <aes:face audioObjectRef="AUDIO_OBJECT_c8a1acf9-d308-444b-8f51-d748eb7bcd55" label="face 1" ID="FACE_7c47762a-a854-4855-91df-a8cb681300f0" direction="NONE">
+          <aes:face audioObjectRef="AUDIO_OBJECT_bac40f72-0764-40fc-bc70-ec5e96476134" label="face 1" ID="FACE_6e3edd9a-c035-450f-b463-bd7bff493be9" direction="NONE">
             <aes:timeline>
               <aes:startTime editRate="1">0</aes:startTime>
               <aes:duration editRate="1000">143321</aes:duration>
             </aes:timeline>
-            <aes:region faceRef="FACE_7c47762a-a854-4855-91df-a8cb681300f0" formatRef="FORMAT_REGION_580f7a46-c1f0-4207-a36c-4b2ba69c6ef2" ID="REGION_b6452f41-23e7-4db2-b09d-6f94c6225141" label="region 1">
+            <aes:region faceRef="FACE_6e3edd9a-c035-450f-b463-bd7bff493be9" formatRef="FORMAT_REGION_f3f1577d-8236-471c-ab54-99288b7fe044" ID="REGION_820c2f13-00cf-4f52-8f3c-4db756c0d0c1" label="region 1">
               <aes:timeRange>
                 <aes:startTime editRate="1">0</aes:startTime>
                 <aes:duration editRate="1000">143321</aes:duration>
               </aes:timeRange>
               <aes:numChannels>2</aes:numChannels>
-              <aes:stream ID="STREAM_848890c6-2824-4a9f-a543-9f43751b6c84" label="stream 0" faceRegionRef="REGION_13c2d25b-d1cc-42b9-9fbd-f7e297d5b97b">
-                <aes:channelAssignment frontRearPosition="0.0" channelNum="0" leftRightPosition="0.0" />
+              <aes:stream ID="STREAM_85574492-886d-4ee2-8ec1-394dbfcbba2e" label="stream 0" faceRegionRef="REGION_820c2f13-00cf-4f52-8f3c-4db756c0d0c1">
+                <aes:channelAssignment leftRightPosition="0.0" channelNum="0" frontRearPosition="0.0" />
               </aes:stream>
-              <aes:stream ID="STREAM_b2acf795-df5a-4068-b923-c2795e4188b8" label="stream 1" faceRegionRef="REGION_13c2d25b-d1cc-42b9-9fbd-f7e297d5b97b">
-                <aes:channelAssignment frontRearPosition="0.0" channelNum="1" leftRightPosition="0.0" />
+              <aes:stream ID="STREAM_e688cbde-6415-4224-b827-c3b7cdde57f5" label="stream 1" faceRegionRef="REGION_820c2f13-00cf-4f52-8f3c-4db756c0d0c1">
+                <aes:channelAssignment leftRightPosition="0.0" channelNum="1" frontRearPosition="0.0" />
               </aes:stream>
             </aes:region>
           </aes:face>
           <aes:formatList>
-            <aes:formatRegion ID="FORMAT_REGION_f40fd99f-83cc-47d2-a078-5c7f9d298bd3" ownerRef="REGION_13c2d25b-d1cc-42b9-9fbd-f7e297d5b97b" label="format region 1" xsi:type="aes:formatRegionType">
+            <aes:formatRegion ownerRef="REGION_820c2f13-00cf-4f52-8f3c-4db756c0d0c1" xsi:type="aes:formatRegionType" ID="FORMAT_REGION_f3f1577d-8236-471c-ab54-99288b7fe044" label="format region 1">
               <aes:sampleRate>44100.0</aes:sampleRate>
               <aes:soundField>STEREO</aes:soundField>
               <aes:bitrateReduction>
@@ -71,22 +71,21 @@
       </standard>
     </audio>
   </metadata>
-  <statistics fitsExecutionTime="3144">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="858">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.3" executionTime="156" />
-    <tool toolname="Jhove" toolversion="1.20" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="187" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="379" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="61" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="13" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="24" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="24" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="393" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="199" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="533" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="849" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="117" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="121" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="533" />
   </statistics>
 </fits>
-

--- a/testfiles/output/KXXJXH4YTGWQ68W.kml_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/KXXJXH4YTGWQ68W.kml_XmlUnitExpectedOutput.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="7/14/22, 4:04 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
     <identity format="Keyhole Markup Language" mimetype="application/vnd.google-earth.kml+xml" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="Tika" toolversion="2.3.0" />
+      <tool toolname="Tika" toolversion="2.6.0" />
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/244</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.26.0">36669</size>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/KXXJXH4YTGWQ68W.kml</filepath>
+    <size toolname="Jhove" toolversion="1.26.1">36669</size>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/KXXJXH4YTGWQ68W.kml</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">KXXJXH4YTGWQ68W.kml</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">ec82a6c4853cfb5a3728ab15105cb189</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1656019415028</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186755</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <text>
-      <charset toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">UTF-8</charset>
-      <markupBasis toolname="Jhove" toolversion="1.26.0">XML</markupBasis>
-      <markupBasisVersion toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">1.0</markupBasisVersion>
+      <charset toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">UTF-8</charset>
+      <markupBasis toolname="Jhove" toolversion="1.26.1">XML</markupBasis>
+      <markupBasisVersion toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">1.0</markupBasisVersion>
       <standard>
         <textMD:textMD xmlns:textMD="info:lc/xmlns/textMD-v3">
           <textMD:character_info>
@@ -33,22 +33,21 @@
       </standard>
     </text>
   </metadata>
-  <statistics fitsExecutionTime="350">
-    <tool toolname="MediaInfo" toolversion="21.09" status="did not run" />
+  <statistics fitsExecutionTime="331">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="61" />
-    <tool toolname="Jhove" toolversion="1.26.0" executionTime="106" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="99" />
-    <tool toolname="Exiftool" toolversion="12.40" executionTime="344" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="26" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="53" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="91" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="71" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="111" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="124" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="324" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="29" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="66" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="97" />
   </statistics>
 </fits>
-

--- a/testfiles/output/LibreODT-Ur-doc.odt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/LibreODT-Ur-doc.odt_XmlUnitExpectedOutput.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.3.1" timestamp="9/18/18 4:42 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="OpenDocument Text" mimetype="application/vnd.oasis.opendocument.text" toolname="FITS" toolversion="1.3.1">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.01" />
+    <identity format="OpenDocument Text" mimetype="application/vnd.oasis.opendocument.text" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
-      <tool toolname="Tika" toolversion="1.18" />
-      <version toolname="Droid" toolversion="6.5">1.2</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/291</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">1.2</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/291</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <created toolname="Tika" toolversion="2.2.1" status="SINGLE_RESULT">2015-09-21T11:45:06.295000000</created>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.01">LibreOffice/5.0.1.2$Windows_x86 LibreOffice_project/81898c9f5c0d43f3473ba111d7b351050be20261</creatingApplicationName>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/LibreODT-Ur-doc.odt</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">LibreODT-Ur-doc.odt</filename>
-    <size toolname="OIS File Information" toolversion="0.2">25372</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">a7054b796a98100e06028cd69d163581</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1453908574000</fslastmodified>
-    <lastmodified toolname="Tika" toolversion="1.18" status="SINGLE_RESULT">2015-09-21T12:27:51.129000000</lastmodified>
+    <created toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">2015-09-21T11:45:06.295</created>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50">LibreOffice/5.0.1.2$Windows_x86 LibreOffice_project/81898c9f5c0d43f3473ba111d7b351050be20261</creatingApplicationName>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/LibreODT-Ur-doc.odt</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">LibreODT-Ur-doc.odt</filename>
+    <size toolname="OIS File Information" toolversion="1.0">25372</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">a7054b796a98100e06028cd69d163581</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186756</fslastmodified>
+    <lastmodified toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">2015-09-21T12:27:51.129</lastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.01">8</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.01">4525</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.01">23631</characterCount>
-      <paragraphCount toolname="Exiftool" toolversion="11.01">7</paragraphCount>
-      <tableCount toolname="Exiftool" toolversion="11.01">0</tableCount>
-      <graphicsCount toolname="Exiftool" toolversion="11.01">0</graphicsCount>
-      <description toolname="Tika" toolversion="1.18" status="SINGLE_RESULT">0</description>
+      <pageCount toolname="Exiftool" toolversion="12.50">8</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">4525</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">23631</characterCount>
+      <paragraphCount toolname="Exiftool" toolversion="12.50">7</paragraphCount>
+      <tableCount toolname="Exiftool" toolversion="12.50">0</tableCount>
+      <graphicsCount toolname="Exiftool" toolversion="12.50">0</graphicsCount>
+      <description toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">0</description>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>8</docmd:PageCount>
@@ -43,22 +43,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="264">
-    <tool toolname="MediaInfo" toolversion="18.08.1" status="did not run" />
+  <statistics fitsExecutionTime="696">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="6" />
-    <tool toolname="Jhove" toolversion="1.20" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="54" />
-    <tool toolname="Exiftool" toolversion="11.01" executionTime="260" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="41" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="3" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="7" />
-    <tool toolname="Tika" toolversion="1.18" executionTime="89" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="232" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="231" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="684" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="175" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="28" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="55" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="261" />
   </statistics>
 </fits>
-

--- a/testfiles/output/LibreODT-hasTables.odt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/LibreODT-hasTables.odt_XmlUnitExpectedOutput.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.3.1" timestamp="9/18/18 4:42 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="OpenDocument Text" mimetype="application/vnd.oasis.opendocument.text" toolname="FITS" toolversion="1.3.1">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.01" />
+    <identity format="OpenDocument Text" mimetype="application/vnd.oasis.opendocument.text" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
-      <tool toolname="Tika" toolversion="1.18" />
-      <version toolname="Droid" toolversion="6.5">1.2</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/291</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">1.2</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/291</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <created toolname="Tika" toolversion="2.2.1" status="SINGLE_RESULT">2015-09-21T11:45:06.295000000</created>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.01">LibreOffice/5.0.1.2$Windows_x86 LibreOffice_project/81898c9f5c0d43f3473ba111d7b351050be20261</creatingApplicationName>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/LibreODT-hasTables.odt</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">LibreODT-hasTables.odt</filename>
-    <size toolname="OIS File Information" toolversion="0.2">24346</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">e1ac7119f6590ad1a11c6aa341c6dfbe</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
-    <lastmodified toolname="Tika" toolversion="1.18" status="SINGLE_RESULT">2015-09-21T12:11:26.720000000</lastmodified>
+    <created toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">2015-09-21T11:45:06.295</created>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50">LibreOffice/5.0.1.2$Windows_x86 LibreOffice_project/81898c9f5c0d43f3473ba111d7b351050be20261</creatingApplicationName>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/LibreODT-hasTables.odt</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">LibreODT-hasTables.odt</filename>
+    <size toolname="OIS File Information" toolversion="1.0">24346</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">e1ac7119f6590ad1a11c6aa341c6dfbe</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186756</fslastmodified>
+    <lastmodified toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">2015-09-21T12:11:26.72</lastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.01">4</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.01">1172</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.01">6278</characterCount>
-      <paragraphCount toolname="Exiftool" toolversion="11.01">27</paragraphCount>
-      <tableCount toolname="Exiftool" toolversion="11.01">1</tableCount>
-      <graphicsCount toolname="Exiftool" toolversion="11.01">0</graphicsCount>
-      <description toolname="Tika" toolversion="1.18" status="SINGLE_RESULT">0</description>
+      <pageCount toolname="Exiftool" toolversion="12.50">4</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">1172</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">6278</characterCount>
+      <paragraphCount toolname="Exiftool" toolversion="12.50">27</paragraphCount>
+      <tableCount toolname="Exiftool" toolversion="12.50">1</tableCount>
+      <graphicsCount toolname="Exiftool" toolversion="12.50">0</graphicsCount>
+      <description toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">0</description>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>4</docmd:PageCount>
@@ -43,22 +43,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="548">
-    <tool toolname="MediaInfo" toolversion="18.08.1" status="did not run" />
+  <statistics fitsExecutionTime="589">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="6" />
-    <tool toolname="Jhove" toolversion="1.20" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="545" />
-    <tool toolname="Exiftool" toolversion="11.01" executionTime="242" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="29" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="4" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="7" />
-    <tool toolname="Tika" toolversion="1.18" executionTime="33" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="26" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="172" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="558" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="120" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="19" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="57" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="66" />
   </statistics>
 </fits>
-

--- a/testfiles/output/LibreODTwFormulas.odt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/LibreODTwFormulas.odt_XmlUnitExpectedOutput.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.3.1" timestamp="9/18/18 4:42 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="OpenDocument Text" mimetype="application/vnd.oasis.opendocument.text" toolname="FITS" toolversion="1.3.1">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.01" />
+    <identity format="OpenDocument Text" mimetype="application/vnd.oasis.opendocument.text" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
-      <tool toolname="Tika" toolversion="1.18" />
-      <version toolname="Droid" toolversion="6.5">1.2</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/291</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">1.2</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/291</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <created toolname="Tika" toolversion="2.2.1" status="SINGLE_RESULT">2015-09-21T11:42:44.173000000</created>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.01">LibreOffice/5.0.1.2$Windows_x86 LibreOffice_project/81898c9f5c0d43f3473ba111d7b351050be20261</creatingApplicationName>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/LibreODTwFormulas.odt</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">LibreODTwFormulas.odt</filename>
-    <size toolname="OIS File Information" toolversion="0.2">20133</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">fed4921e096db80dcaab1dd5cb490915</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
-    <lastmodified toolname="Tika" toolversion="1.18" status="SINGLE_RESULT">2015-09-21T11:44:36.875000000</lastmodified>
+    <created toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">2015-09-21T11:42:44.173</created>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50">LibreOffice/5.0.1.2$Windows_x86 LibreOffice_project/81898c9f5c0d43f3473ba111d7b351050be20261</creatingApplicationName>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/LibreODTwFormulas.odt</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">LibreODTwFormulas.odt</filename>
+    <size toolname="OIS File Information" toolversion="1.0">20133</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">fed4921e096db80dcaab1dd5cb490915</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186757</fslastmodified>
+    <lastmodified toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">2015-09-21T11:44:36.875</lastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.01">1</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.01">0</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.01">0</characterCount>
-      <paragraphCount toolname="Exiftool" toolversion="11.01">2</paragraphCount>
-      <hasEmbeddedResources toolname="Exiftool" toolversion="11.01">yes</hasEmbeddedResources>
-      <tableCount toolname="Exiftool" toolversion="11.01">0</tableCount>
-      <graphicsCount toolname="Exiftool" toolversion="11.01">0</graphicsCount>
-      <description toolname="Tika" toolversion="1.18" status="SINGLE_RESULT">yes</description>
+      <pageCount toolname="Exiftool" toolversion="12.50">1</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">0</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">0</characterCount>
+      <paragraphCount toolname="Exiftool" toolversion="12.50">2</paragraphCount>
+      <hasEmbeddedResources toolname="Exiftool" toolversion="12.50">yes</hasEmbeddedResources>
+      <tableCount toolname="Exiftool" toolversion="12.50">0</tableCount>
+      <graphicsCount toolname="Exiftool" toolversion="12.50">0</graphicsCount>
+      <description toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">yes</description>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>1</docmd:PageCount>
@@ -45,22 +45,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="541">
-    <tool toolname="MediaInfo" toolversion="18.08.1" status="did not run" />
+  <statistics fitsExecutionTime="462">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="4" />
-    <tool toolname="Jhove" toolversion="1.20" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="538" />
-    <tool toolname="Exiftool" toolversion="11.01" executionTime="519" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="16" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="3" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="6" />
-    <tool toolname="Tika" toolversion="1.18" executionTime="29" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="25" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="161" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="447" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="114" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="16" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="35" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="69" />
   </statistics>
 </fits>
-

--- a/testfiles/output/LibreOffice.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/LibreOffice.doc_XmlUnitExpectedOutput.xml
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="12/6/21 3:55 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification status="CONFLICT">
-    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="Droid" toolversion="6.4">97-2003</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">fmt/40</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">97-2003</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/40</externalIdentifier>
     </identity>
-    <identity format="Microsoft Excel" mimetype="application/vnd.ms-excel" toolname="FITS" toolversion="1.5.0">
+    <identity format="Microsoft Excel" mimetype="application/vnd.ms-excel" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="ffident" toolversion="0.2" />
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2016:01:15 20:03:34</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2016-01-15T20:03:34Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:12:14 16:12:58</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-12-14 11:12:58</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-12-14T16:12:58Z</created>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/LibreOffice.doc</filepath>
+    <lastmodified toolname="Exiftool" toolversion="12.50" status="CONFLICT">2016-01-15T20:03:34</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.6.0" status="CONFLICT">2016-01-15T20:03:34Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">2015-12-14T16:12:58</created>
+    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-12-14T11:12:58</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">2015-12-14T16:12:58Z</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/LibreOffice.doc</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">LibreOffice.doc</filename>
     <size toolname="OIS File Information" toolversion="1.0">10240</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">2520885e1d9e43b13d8dab9009393b56</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186758</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.54" status="CONFLICT">1</pageCount>
+      <pageCount toolname="Exiftool" toolversion="12.50" status="CONFLICT">1</pageCount>
       <pageCount toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">0</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.54" status="CONFLICT">13</wordCount>
+      <wordCount toolname="Exiftool" toolversion="12.50" status="CONFLICT">13</wordCount>
       <wordCount toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">0</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.54" status="CONFLICT">72</characterCount>
+      <characterCount toolname="Exiftool" toolversion="12.50" status="CONFLICT">72</characterCount>
       <characterCount toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">0</characterCount>
-      <author toolname="Exiftool" toolversion="11.54">David Neiman</author>
-      <lineCount toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">4</lineCount>
-      <paragraphCount toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">4</paragraphCount>
-      <language toolname="Exiftool" toolversion="11.54">U.S. English</language>
+      <author toolname="Exiftool" toolversion="12.50">David Neiman</author>
+      <lineCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">4</lineCount>
+      <paragraphCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">4</paragraphCount>
+      <language toolname="Exiftool" toolversion="12.50">U.S. English</language>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>1</docmd:PageCount>
@@ -51,22 +51,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="268">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="716">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="8" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="35" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="264" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="13" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="4" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="6" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="108" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="139" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="193" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="700" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="132" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="36" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="42" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="509" />
   </statistics>
 </fits>
-

--- a/testfiles/output/MMS-82A.08.12.02.ai-default_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/MMS-82A.08.12.02.ai-default_XmlUnitExpectedOutput.xml
@@ -1,44 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="7/14/22, 3:56 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:01 AM">
   <identification>
     <identity format="Adobe Illustrator" mimetype="application/postscript" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="Exiftool" toolversion="12.40" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <version toolname="Droid" toolversion="6.5.2">9.0</version>
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/558</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <created toolname="Exiftool" toolversion="12.40" status="SINGLE_RESULT">2002-08-10T18:43:47</created>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/MMS-82A.08.12.02.ai</filepath>
+    <created toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2002-08-10T18:43:47</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/MMS-82A.08.12.02.ai</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">MMS-82A.08.12.02.ai</filename>
     <size toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">561633</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">b09e1524642c0166da3566d4c7e03871</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1502905624000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186762</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <image>
-      <imageWidth toolname="Exiftool" toolversion="12.40" status="SINGLE_RESULT">315</imageWidth>
-      <imageHeight toolname="Exiftool" toolversion="12.40" status="SINGLE_RESULT">704</imageHeight>
+      <imageWidth toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">315</imageWidth>
+      <imageHeight toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">704</imageHeight>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="426">
-    <tool toolname="MediaInfo" toolversion="21.09" status="did not run" />
+  <statistics fitsExecutionTime="840">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="171" />
-    <tool toolname="Jhove" toolversion="1.26.0" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="147" />
-    <tool toolname="Exiftool" toolversion="12.40" executionTime="398" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="29" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="76" />
-    <tool toolname="Tika" toolversion="2.3.0" status="did not run" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="291" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="466" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="793" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="65" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="89" />
+    <tool toolname="Tika" toolversion="2.6.0" status="did not run" />
   </statistics>
 </fits>
-

--- a/testfiles/output/MacMSWORD_4-5.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/MacMSWORD_4-5.doc_XmlUnitExpectedOutput.xml
@@ -1,39 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.x" timestamp="2/2/18 4:13 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.2.x">
-      <tool toolname="Droid" toolversion="6.3" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Tika" toolversion="1.10" />
-      <version toolname="Droid" toolversion="6.3">4.0</version>
-      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">x-fmt/64</externalIdentifier>
+    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">4.0</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/64</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/MacMSWORD_4-5.doc</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">MacMSWORD_4-5.doc</filename>
-    <size toolname="OIS File Information" toolversion="0.2">2047</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">edc1036fd68b60ba62af22aa269fc0a8</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/MacMSWORD_4-5.doc</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">MacMSWORD_4-5.doc</filename>
+    <size toolname="OIS File Information" toolversion="1.0">2047</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">edc1036fd68b60ba62af22aa269fc0a8</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186763</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata />
-  <statistics fitsExecutionTime="168">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="428">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.3" executionTime="3" />
-    <tool toolname="Jhove" toolversion="1.16" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="37" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="166" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="51" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="2" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="4" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="4" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="22" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="130" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="416" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="259" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="38" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="47" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="43" />
   </statistics>
 </fits>
-

--- a/testfiles/output/NEWSSLID_Word2_0.DOC_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/NEWSSLID_Word2_0.DOC_XmlUnitExpectedOutput.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.x" timestamp="2/2/18 4:13 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.2.x">
-      <tool toolname="Droid" toolversion="6.3" />
-      <tool toolname="file utility" toolversion="5.31" />
+    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
-      <tool toolname="Tika" toolversion="1.10" />
-      <version toolname="Droid" toolversion="6.3">2.0</version>
-      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">fmt/38</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">2.0</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/38</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">Tue Mar 09 16:31:02 EST 1993</created>
+    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">Tue Mar 09 16:31:49 EST 1993</created>
     <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">Word 2.0</creatingApplicationName>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/NEWSSLID_Word2_0.DOC</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">NEWSSLID_Word2_0.DOC</filename>
-    <size toolname="OIS File Information" toolversion="0.2">10405</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">71649cd49b8cd0bc37f8643b2ee84c75</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/NEWSSLID_Word2_0.DOC</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">NEWSSLID_Word2_0.DOC</filename>
+    <size toolname="OIS File Information" toolversion="1.0">10405</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">71649cd49b8cd0bc37f8643b2ee84c75</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186764</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
@@ -38,22 +38,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="160">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="313">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.3" executionTime="4" />
-    <tool toolname="Jhove" toolversion="1.16" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="43" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="159" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="13" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="2" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="3" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="3" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="29" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="110" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="306" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="84" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="32" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="51" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="37" />
   </statistics>
 </fits>
-

--- a/testfiles/output/P3EKWCX2XYWWB8Y.xml_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/P3EKWCX2XYWWB8Y.xml_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="7/14/22, 4:04 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification status="SINGLE_RESULT">
     <identity format="TEI" mimetype="application/tei+xml" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="Droid" toolversion="6.5.2" />
@@ -8,21 +8,21 @@
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.26.0">235257</size>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/P3EKWCX2XYWWB8Y.xml</filepath>
+    <size toolname="Jhove" toolversion="1.26.1">235257</size>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/P3EKWCX2XYWWB8Y.xml</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">P3EKWCX2XYWWB8Y.xml</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">e4cf29a87057861c560d4d1f0f9491c2</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1656019415039</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186767</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <text>
-      <charset toolname="Jhove" toolversion="1.26.0">UTF-8</charset>
-      <markupBasis toolname="Jhove" toolversion="1.26.0">XML</markupBasis>
-      <markupBasisVersion toolname="Jhove" toolversion="1.26.0">1.0</markupBasisVersion>
+      <charset toolname="Jhove" toolversion="1.26.1">UTF-8</charset>
+      <markupBasis toolname="Jhove" toolversion="1.26.1">XML</markupBasis>
+      <markupBasisVersion toolname="Jhove" toolversion="1.26.1">1.0</markupBasisVersion>
       <standard>
         <textMD:textMD xmlns:textMD="info:lc/xmlns/textMD-v3">
           <textMD:character_info>
@@ -33,22 +33,21 @@
       </standard>
     </text>
   </metadata>
-  <statistics fitsExecutionTime="343">
-    <tool toolname="MediaInfo" toolversion="21.09" status="did not run" />
+  <statistics fitsExecutionTime="387">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="68" />
-    <tool toolname="Jhove" toolversion="1.26.0" executionTime="140" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="141" />
-    <tool toolname="Exiftool" toolversion="12.40" executionTime="337" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="332" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="58" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" executionTime="103" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="77" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="71" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="152" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="131" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="327" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="374" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="80" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" executionTime="77" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="59" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="62" />
   </statistics>
 </fits>
-

--- a/testfiles/output/PDFA_Document with tables.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFA_Document with tables.pdf_XmlUnitExpectedOutput.xml
@@ -79,6 +79,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="52" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.26.0" executionTime="174" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="135" />
@@ -88,7 +89,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="84" />
     <tool toolname="Tika" toolversion="2.3.0" executionTime="129" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDF_embedded_resources.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDF_embedded_resources.pdf_XmlUnitExpectedOutput.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="7/14/22, 3:58 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
     <identity format="Portable Document Format" mimetype="application/pdf" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="Jhove" toolversion="1.26.0" />
-      <tool toolname="file utility" toolversion="5.41" />
-      <tool toolname="Exiftool" toolversion="12.40" />
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="2.3.0" />
+      <tool toolname="Tika" toolversion="2.6.0" />
       <version toolname="Droid" toolversion="6.5.2" status="CONFLICT">1.6</version>
-      <version toolname="file utility" toolversion="5.41" status="CONFLICT">1.6 (zip deflate encoded)</version>
+      <version toolname="file utility" toolversion="5.43" status="CONFLICT">1.6 (zip deflate encoded)</version>
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/20</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.26.0">1113979</size>
-    <creatingApplicationName toolname="Exiftool" toolversion="12.40">Acrobat Distiller 8.1.0 (Windows)/Adobe PageMaker 6.52</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T20:17:32Z</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40">2008-09-24T19:27:24Z</created>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/PDF_embedded_resources.pdf</filepath>
+    <size toolname="Jhove" toolversion="1.26.1">1113979</size>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50">Acrobat Distiller 8.1.0 (Windows)/Adobe PageMaker 6.52</creatingApplicationName>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2015-08-19T20:17:32Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50">2008-09-24T19:27:24Z</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/PDF_embedded_resources.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">PDF_embedded_resources.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">dbfbf8c633100f5d4301fed7b65ad698</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1466791806000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186774</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <document>
-      <title toolname="Exiftool" toolversion="12.40">digibook</title>
-      <author toolname="Exiftool" toolversion="12.40">Harvard University Archives</author>
-      <pageCount toolname="Jhove" toolversion="1.26.0">52</pageCount>
-      <hasOutline toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">no</hasOutline>
-      <hasAnnotations toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">no</hasAnnotations>
-      <graphicsCount toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">433</graphicsCount>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <title toolname="Exiftool" toolversion="12.50">digibook</title>
+      <author toolname="Exiftool" toolversion="12.50">Harvard University Archives</author>
+      <pageCount toolname="Jhove" toolversion="1.26.1">52</pageCount>
+      <hasOutline toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">no</hasOutline>
+      <hasAnnotations toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">no</hasAnnotations>
+      <graphicsCount toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">433</graphicsCount>
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>BauerBodoniBT-Bold</fontName>
       </font>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>BauerBodoniBT-BoldItalic</fontName>
       </font>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>BauerBodoniBT-Italic</fontName>
       </font>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>BauerBodoniBT-Roman</fontName>
       </font>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>Charlesworth-Bold</fontName>
       </font>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>Charlesworth-Normal</fontName>
       </font>
-      <subject toolname="Exiftool" toolversion="12.40">booklet10</subject>
-      <description toolname="Exiftool" toolversion="12.40">booklet10</description>
+      <subject toolname="Exiftool" toolversion="12.50">booklet10</subject>
+      <description toolname="Exiftool" toolversion="12.50">booklet10</description>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>52</docmd:PageCount>
@@ -69,22 +69,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="1240">
-    <tool toolname="MediaInfo" toolversion="21.09" status="did not run" />
+  <statistics fitsExecutionTime="2197">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="59" />
-    <tool toolname="Jhove" toolversion="1.26.0" executionTime="657" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="102" />
-    <tool toolname="Exiftool" toolversion="12.40" executionTime="546" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="39" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="49" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="1229" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="162" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="1228" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="217" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="760" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="61" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="60" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="2101" />
   </statistics>
 </fits>
-

--- a/testfiles/output/PDF_eng.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDF_eng.pdf_XmlUnitExpectedOutput.xml
@@ -70,6 +70,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="34" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.26.0" executionTime="238" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="119" />
@@ -79,7 +80,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="47" />
     <tool toolname="Tika" toolversion="2.3.0" executionTime="297" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFa_embedded_resources.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_embedded_resources.pdf_XmlUnitExpectedOutput.xml
@@ -71,6 +71,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="80" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.26.0" executionTime="374" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="133" />
@@ -80,7 +81,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="67" />
     <tool toolname="Tika" toolversion="2.3.0" executionTime="490" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFa_equations.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_equations.pdf_XmlUnitExpectedOutput.xml
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="7/14/22, 3:59 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
     <identity format="PDF/A" mimetype="application/pdf" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="Exiftool" toolversion="12.40" />
-      <tool toolname="Tika" toolversion="2.3.0" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
       <version toolname="Droid" toolversion="6.5.2">1b</version>
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/354</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.26.0">105831</size>
-    <creatingApplicationName toolname="Jhove" toolversion="1.26.0">Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T23:13:22Z</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40">2015-08-19T23:12:42Z</created>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/PDFa_equations.pdf</filepath>
+    <size toolname="Jhove" toolversion="1.26.1">105831</size>
+    <creatingApplicationName toolname="Jhove" toolversion="1.26.1">Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word</creatingApplicationName>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2015-08-19T23:13:22Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50">2015-08-19T23:12:42Z</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/PDFa_equations.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">PDFa_equations.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">83fa9407b0ddf13a38579a18fe9f7734</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1456178059000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186783</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <document>
-      <author toolname="Jhove" toolversion="1.26.0">Zakuta, Vitaly</author>
-      <language toolname="Jhove" toolversion="1.26.0">EN-US</language>
-      <pageCount toolname="Jhove" toolversion="1.26.0">3</pageCount>
-      <isTagged toolname="Jhove" toolversion="1.26.0">yes</isTagged>
-      <hasOutline toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">no</hasOutline>
-      <hasAnnotations toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">no</hasAnnotations>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <author toolname="Jhove" toolversion="1.26.1">Zakuta, Vitaly</author>
+      <language toolname="Jhove" toolversion="1.26.1">EN-US</language>
+      <pageCount toolname="Jhove" toolversion="1.26.1">3</pageCount>
+      <isTagged toolname="Jhove" toolversion="1.26.1">yes</isTagged>
+      <hasOutline toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">no</hasOutline>
+      <hasAnnotations toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">no</hasAnnotations>
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>Calibri</fontName>
       </font>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>CambriaMath</fontName>
       </font>
       <standard>
@@ -48,22 +48,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="545">
-    <tool toolname="MediaInfo" toolversion="21.09" status="did not run" />
+  <statistics fitsExecutionTime="697">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="87" />
-    <tool toolname="Jhove" toolversion="1.26.0" executionTime="214" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="162" />
-    <tool toolname="Exiftool" toolversion="12.40" executionTime="537" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="31" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="103" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="318" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="83" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="308" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="189" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="665" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="22" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="66" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="366" />
   </statistics>
 </fits>
-

--- a/testfiles/output/PDFa_has_form.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_form.pdf_XmlUnitExpectedOutput.xml
@@ -61,6 +61,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="44" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.26.0" executionTime="148" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="140" />
@@ -70,7 +71,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="52" />
     <tool toolname="Tika" toolversion="2.3.0" executionTime="122" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFa_has_table_of_contents.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_table_of_contents.pdf_XmlUnitExpectedOutput.xml
@@ -87,6 +87,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="65" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.26.0" executionTime="268" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="206" />
@@ -96,7 +97,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="92" />
     <tool toolname="Tika" toolversion="2.3.0" executionTime="265" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFa_has_table_of_contents.pdf_no_consolidation_ExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_table_of_contents.pdf_no_consolidation_ExpectedOutput.xml
@@ -88,6 +88,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="114" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.24.9" executionTime="1269" />
     <tool toolname="file utility" toolversion="5.40" executionTime="1149" />
     <tool toolname="Exiftool" toolversion="12.40" executionTime="1164" />
@@ -96,7 +97,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="996" />
     <tool toolname="Tika" toolversion="2.3.0" executionTime="1333" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFa_has_tables.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_has_tables.pdf_XmlUnitExpectedOutput.xml
@@ -77,6 +77,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="40" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.26.0" executionTime="168" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="131" />
@@ -86,7 +87,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="80" />
     <tool toolname="Tika" toolversion="2.3.0" executionTime="161" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFa_multiplefonts.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFa_multiplefonts.pdf_XmlUnitExpectedOutput.xml
@@ -67,6 +67,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="48" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.26.0" executionTime="144" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="128" />
@@ -76,7 +77,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="70" />
     <tool toolname="Tika" toolversion="2.3.0" executionTime="106" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/PDFx3.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/PDFx3.pdf_XmlUnitExpectedOutput.xml
@@ -56,6 +56,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.5.2" executionTime="54" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.26.0" executionTime="182" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.41" executionTime="138" />
@@ -65,7 +66,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" executionTime="69" />
     <tool toolname="Tika" toolversion="2.3.0" executionTime="153" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/T-350_036_Archival_Side_1.adl_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/T-350_036_Archival_Side_1.adl_XmlUnitExpectedOutput.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0-SNAPSHOT" timestamp="8/14/19 10:44 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:01 AM">
   <identification status="SINGLE_RESULT">
-    <identity format="Audio Decision List" mimetype="text/x-adl" toolname="FITS" toolversion="1.5.0-SNAPSHOT">
+    <identity format="Audio Decision List" mimetype="text/x-adl" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="ADL Tool" toolversion="0.1" />
       <version toolname="ADL Tool" toolversion="0.1">01.01.00.00.03</version>
     </identity>
@@ -9,11 +9,11 @@
   <fileinfo>
     <creatingApplicationName toolname="ADL Tool" toolversion="0.1" status="SINGLE_RESULT">"Steinberg AES31 Filter"</creatingApplicationName>
     <creatingApplicationVersion toolname="ADL Tool" toolversion="0.1" status="SINGLE_RESULT">03.00.02.35</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/T-350_036_Archival_Side_1.adl</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">T-350_036_Archival_Side_1.adl</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">3211</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">0bbf80e4ee1843f887c297afa9fe0809</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1565793061000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/T-350_036_Archival_Side_1.adl</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">T-350_036_Archival_Side_1.adl</filename>
+    <size toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">3211</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">0bbf80e4ee1843f887c297afa9fe0809</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186791</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
@@ -27,22 +27,21 @@
       </standard>
     </text>
   </metadata>
-  <statistics fitsExecutionTime="582">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="253">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
-    <tool toolname="ADL Tool" toolversion="0.1" executionTime="100" />
+    <tool toolname="ADL Tool" toolversion="0.1" executionTime="244" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="98" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" status="did not run" />
-    <tool toolname="Exiftool" toolversion="11.54" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="98" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="570" />
-    <tool toolname="Tika" toolversion="2.2.1" status="did not run" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="155" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" status="did not run" />
+    <tool toolname="Exiftool" toolversion="12.50" status="did not run" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="59" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="66" />
+    <tool toolname="Tika" toolversion="2.6.0" status="did not run" />
   </statistics>
 </fits>
-

--- a/testfiles/output/TestDoc.rtf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/TestDoc.rtf_XmlUnitExpectedOutput.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.3.1" timestamp="9/18/18 3:35 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Rich Text Format (RTF)" mimetype="application/rtf" toolname="FITS" toolversion="1.3.1">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.01" />
-      <tool toolname="Tika" toolversion="1.18" />
-      <version toolname="Droid" toolversion="6.4">1.9</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">fmt/355</externalIdentifier>
+    <identity format="Rich Text Format (RTF)" mimetype="application/rtf" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">1.9</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/355</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">2015:08:05 09:25:00</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:05 09:25:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-05T13:25:00Z</created>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/TestDoc.rtf</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">TestDoc.rtf</filename>
-    <size toolname="OIS File Information" toolversion="0.2">29650</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">7ef9fd20c3545d3f29a79a9d77d85a03</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <lastmodified toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2015-08-05T09:25:00</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">2015-08-05T09:25:00</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">2015-08-05T13:25:00Z</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/TestDoc.rtf</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">TestDoc.rtf</filename>
+    <size toolname="OIS File Information" toolversion="1.0">29650</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">7ef9fd20c3545d3f29a79a9d77d85a03</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186791</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.01">1</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.01">8</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.01">52</characterCount>
-      <author toolname="Exiftool" toolversion="11.01">Neiman David</author>
+      <pageCount toolname="Exiftool" toolversion="12.50">1</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">8</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">52</characterCount>
+      <author toolname="Exiftool" toolversion="12.50">Neiman David</author>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>1</docmd:PageCount>
@@ -36,22 +36,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="155">
-    <tool toolname="MediaInfo" toolversion="18.08.1" status="did not run" />
+  <statistics fitsExecutionTime="385">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="7" />
-    <tool toolname="Jhove" toolversion="1.20" status="did not run" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="26" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="49" />
-    <tool toolname="Exiftool" toolversion="11.01" executionTime="153" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="127" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="353" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="2" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="21" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
     <tool toolname="ffident" toolversion="0.2" status="did not run" />
-    <tool toolname="Tika" toolversion="1.18" executionTime="40" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="228" />
   </statistics>
 </fits>
-

--- a/testfiles/output/UnparseableDate.odt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/UnparseableDate.odt_XmlUnitExpectedOutput.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.3.1" timestamp="9/18/18 4:42 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="OpenDocument Text" mimetype="application/vnd.oasis.opendocument.text" toolname="FITS" toolversion="1.3.1">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.01" />
+    <identity format="OpenDocument Text" mimetype="application/vnd.oasis.opendocument.text" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
-      <tool toolname="Tika" toolversion="1.18" />
-      <version toolname="Droid" toolversion="6.4">1.2</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">fmt/291</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">1.2</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/291</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <created toolname="Tika" toolversion="2.2.1" status="SINGLE_RESULT">2015-08-05T08:25:00</created>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.01">OpenOffice/4.1.1$Unix OpenOffice.org_project/411m6$Build-9775</creatingApplicationName>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/UnparseableDate.odt</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">UnparseableDate.odt</filename>
-    <size toolname="OIS File Information" toolversion="0.2">14422</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">2989e29ad588371b48a0eef61029d086</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1453908574000</fslastmodified>
-    <lastmodified toolname="Tika" toolversion="1.18" status="SINGLE_RESULT">2015-08-05T08:25:00</lastmodified>
+    <created toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">2015-08-05T08:25:00</created>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50">OpenOffice/4.1.1$Unix OpenOffice.org_project/411m6$Build-9775</creatingApplicationName>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/UnparseableDate.odt</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">UnparseableDate.odt</filename>
+    <size toolname="OIS File Information" toolversion="1.0">14422</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">2989e29ad588371b48a0eef61029d086</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186792</fslastmodified>
+    <lastmodified toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">2015-08-05T08:25:00</lastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.01">1</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.01">16</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.01">88</characterCount>
-      <author toolname="Exiftool" toolversion="11.01">Neiman David</author>
-      <paragraphCount toolname="Exiftool" toolversion="11.01">6</paragraphCount>
-      <tableCount toolname="Exiftool" toolversion="11.01">0</tableCount>
-      <graphicsCount toolname="Exiftool" toolversion="11.01">2</graphicsCount>
-      <description toolname="Tika" toolversion="1.18" status="SINGLE_RESULT">0</description>
+      <pageCount toolname="Exiftool" toolversion="12.50">1</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">16</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">88</characterCount>
+      <author toolname="Exiftool" toolversion="12.50">Neiman David</author>
+      <paragraphCount toolname="Exiftool" toolversion="12.50">6</paragraphCount>
+      <tableCount toolname="Exiftool" toolversion="12.50">0</tableCount>
+      <graphicsCount toolname="Exiftool" toolversion="12.50">2</graphicsCount>
+      <description toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">0</description>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>1</docmd:PageCount>
@@ -44,22 +44,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="243">
-    <tool toolname="MediaInfo" toolversion="18.08.1" status="did not run" />
+  <statistics fitsExecutionTime="545">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="5" />
-    <tool toolname="Jhove" toolversion="1.20" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="49" />
-    <tool toolname="Exiftool" toolversion="11.01" executionTime="240" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="20" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="3" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="5" />
-    <tool toolname="Tika" toolversion="1.18" executionTime="33" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="34" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="146" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="528" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="118" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="54" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="68" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="226" />
   </statistics>
 </fits>
-

--- a/testfiles/output/W00EGS1016782-I01JW30--I01JW300001__0001.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/W00EGS1016782-I01JW30--I01JW300001__0001.tif_XmlUnitExpectedOutput.xml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.3.1" timestamp="9/20/18 11:56 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
-    <identity format="Tagged Image File Format" mimetype="image/tiff" toolname="FITS" toolversion="1.5.2-SNAPSHOT">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="Jhove" toolversion="1.20.1" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="Tagged Image File Format" mimetype="image/tiff" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="Jhove" toolversion="1.20.1">5.0</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">fmt/353</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Jhove" toolversion="1.26.1">5.0</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/353</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.20">35130</size>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.01" status="SINGLE_RESULT">ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org</creatingApplicationName>
+    <size toolname="Jhove" toolversion="1.26.1">35130</size>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="12.50">2006-12-19T15:08:15</lastmodified>
-    <created toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">2006-12-19T15:08:15</created>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/W00EGS1016782-I01JW30--I01JW300001__0001.tif</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">W00EGS1016782-I01JW30--I01JW300001__0001.tif</filename>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">90f9a85c04e1bc2c5c1f689c110b1588</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1520876219000</fslastmodified>
+    <created toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">2006-12-19T15:08:15</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/W00EGS1016782-I01JW30--I01JW300001__0001.tif</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">W00EGS1016782-I01JW30--I01JW300001__0001.tif</filename>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">90f9a85c04e1bc2c5c1f689c110b1588</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186793</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <image>
-      <byteOrder toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">little endian</byteOrder>
-      <byteOrder toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">little endian</byteOrder>
-      <compressionScheme toolname="Jhove" toolversion="1.20.1" status="CONFLICT">Group 4 Fax</compressionScheme>
-      <compressionScheme toolname="Exiftool" toolversion="11.54" status="CONFLICT">T6/Group 4 Fax</compressionScheme>
-      <imageWidth toolname="Jhove" toolversion="1.20.1">2550</imageWidth>
-      <imageHeight toolname="Jhove" toolversion="1.20.1">3300</imageHeight>
-      <colorSpace toolname="Jhove" toolversion="1.20.1">WhiteIsZero</colorSpace>
-      <orientation toolname="Jhove" toolversion="1.20.1">normal*</orientation>
-      <samplingFrequencyUnit toolname="Jhove" toolversion="1.20.1">in.</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Jhove" toolversion="1.20.1">300</xSamplingFrequency>
-      <ySamplingFrequency toolname="Jhove" toolversion="1.20.1">300</ySamplingFrequency>
-      <bitsPerSample toolname="Jhove" toolversion="1.20.1" status="CONFLICT">1 1</bitsPerSample>
-      <bitsPerSample toolname="Exiftool" toolversion="11.54" status="CONFLICT">1</bitsPerSample>
-      <samplesPerPixel toolname="Jhove" toolversion="1.20.1" status="CONFLICT">1 1</samplesPerPixel>
-      <samplesPerPixel toolname="Exiftool" toolversion="11.54" status="CONFLICT">1</samplesPerPixel>
-      <scanningSoftwareName toolname="Jhove" toolversion="1.20.1" status="CONFLICT">ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org</scanningSoftwareName>
-      <scanningSoftwareName toolname="Exiftool" toolversion="11.54" status="CONFLICT">ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org</scanningSoftwareName>
+      <byteOrder toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">little endian</byteOrder>
+      <byteOrder toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">little endian</byteOrder>
+      <compressionScheme toolname="Jhove" toolversion="1.26.1" status="CONFLICT">Group 4 Fax</compressionScheme>
+      <compressionScheme toolname="Exiftool" toolversion="12.50" status="CONFLICT">T6/Group 4 Fax</compressionScheme>
+      <imageWidth toolname="Jhove" toolversion="1.26.1">2550</imageWidth>
+      <imageHeight toolname="Jhove" toolversion="1.26.1">3300</imageHeight>
+      <colorSpace toolname="Jhove" toolversion="1.26.1">WhiteIsZero</colorSpace>
+      <orientation toolname="Jhove" toolversion="1.26.1">normal*</orientation>
+      <samplingFrequencyUnit toolname="Jhove" toolversion="1.26.1">in.</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Jhove" toolversion="1.26.1">300</xSamplingFrequency>
+      <ySamplingFrequency toolname="Jhove" toolversion="1.26.1">300</ySamplingFrequency>
+      <bitsPerSample toolname="Jhove" toolversion="1.26.1" status="CONFLICT">1 1</bitsPerSample>
+      <bitsPerSample toolname="Exiftool" toolversion="12.50" status="CONFLICT">1</bitsPerSample>
+      <samplesPerPixel toolname="Jhove" toolversion="1.26.1" status="CONFLICT">1 1</samplesPerPixel>
+      <samplesPerPixel toolname="Exiftool" toolversion="12.50" status="CONFLICT">1</samplesPerPixel>
+      <scanningSoftwareName toolname="Jhove" toolversion="1.26.1" status="CONFLICT">ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org</scanningSoftwareName>
+      <scanningSoftwareName toolname="Exiftool" toolversion="12.50" status="CONFLICT">ImageMagick 6.5.4-9 2009-09-15 Q16 http://www.imagemagick.org</scanningSoftwareName>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -96,22 +96,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="169">
-    <tool toolname="MediaInfo" toolversion="18.08.1" status="did not run" />
+  <statistics fitsExecutionTime="313">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="6" />
-    <tool toolname="Jhove" toolversion="1.20" executionTime="33" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="49" />
-    <tool toolname="Exiftool" toolversion="11.01" executionTime="164" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="3" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="5" />
-    <tool toolname="Tika" toolversion="1.18" executionTime="15" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="48" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="112" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="129" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="295" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="43" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="76" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="83" />
   </statistics>
 </fits>
-

--- a/testfiles/output/Winnie-the-Pooh-protected.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Winnie-the-Pooh-protected.epub_XmlUnitExpectedOutput.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.11.0" timestamp="2/12/16 10:01 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="EPUB" mimetype="application/epub+zip" toolname="FITS" toolversion="0.11.0">
-      <tool toolname="Droid" toolversion="6.5" />
-      <tool toolname="Exiftool" toolversion="10.00" />
-      <tool toolname="Tika" toolversion="1.10" />
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/483</externalIdentifier>
+    <identity format="EPUB" mimetype="application/epub+zip" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/483</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <created toolname="Tika" toolversion="2.2.1" status="SINGLE_RESULT">1954</created>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Winnie-the-Pooh-protected.epub</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Winnie-the-Pooh-protected.epub</filename>
-    <size toolname="OIS File Information" toolversion="0.2">15107043</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">4ccb561ddebda70324926895899cd27c</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1453908574000</fslastmodified>
+    <created toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">1954</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/Winnie-the-Pooh-protected.epub</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">Winnie-the-Pooh-protected.epub</filename>
+    <size toolname="OIS File Information" toolversion="1.0">15107043</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">4ccb561ddebda70324926895899cd27c</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186885</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <title toolname="Exiftool" toolversion="10.00">Winnie-the-Pooh</title>
-      <author toolname="Exiftool" toolversion="10.00">A. A. Milne</author>
-      <isRightsManaged toolname="Exiftool" toolversion="10.00">yes</isRightsManaged>
-      <identifier toolname="Exiftool" toolversion="10.00">1-101-15893-X</identifier>
-      <language toolname="Exiftool" toolversion="10.00">en</language>
+      <title toolname="Exiftool" toolversion="12.50">Winnie-the-Pooh</title>
+      <author toolname="Exiftool" toolversion="12.50">A. A. Milne</author>
+      <isRightsManaged toolname="Exiftool" toolversion="12.50">yes</isRightsManaged>
+      <identifier toolname="Exiftool" toolversion="12.50">1-101-15893-X</identifier>
+      <language toolname="Exiftool" toolversion="12.50">en</language>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:Language>en</docmd:Language>
@@ -31,22 +31,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="234">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="486">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="70" />
-    <tool toolname="Jhove" toolversion="1.11" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="108" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="228" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="68" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="8" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="101" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="81" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="128" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="477" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="83" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="55" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="98" />
   </statistics>
 </fits>
-

--- a/testfiles/output/Word2003PasswordProtected.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2003PasswordProtected.doc_XmlUnitExpectedOutput.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="12/6/21 3:55 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.5" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="Droid" toolversion="6.5">97-2003</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/754</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">97-2003</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/754</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">35357:01:04 01:57:19</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2015-08-20T15:45:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:20 15:44:00</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-08-20 11:44:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-20T15:44:00Z</created>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54">Microsoft Office Word</creatingApplicationName>
-    <creatingApplicationVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2003PasswordProtected.doc</filepath>
+    <lastmodified toolname="Exiftool" toolversion="12.50" status="CONFLICT">35357:01:04 01:57:19</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.6.0" status="CONFLICT">2015-08-20T15:45:00Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">2015-08-20T15:44:00</created>
+    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-08-20T11:44:00</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">2015-08-20T15:44:00Z</created>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50">Microsoft Office Word</creatingApplicationName>
+    <creatingApplicationVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/Word2003PasswordProtected.doc</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">Word2003PasswordProtected.doc</filename>
     <size toolname="OIS File Information" toolversion="1.0">243712</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">e40cc3565482b4cef61a00c198e4e68b</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1453908574000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186892</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.54">15</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.54">3573</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.54">20370</characterCount>
-      <author toolname="Exiftool" toolversion="11.54">k05higgi</author>
-      <lineCount toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">169</lineCount>
-      <paragraphCount toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">47</paragraphCount>
-      <isProtected toolname="Exiftool" toolversion="11.54">yes</isProtected>
-      <language toolname="Exiftool" toolversion="11.54">U.S. English</language>
+      <pageCount toolname="Exiftool" toolversion="12.50">15</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">3573</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">20370</characterCount>
+      <author toolname="Exiftool" toolversion="12.50">k05higgi</author>
+      <lineCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">169</lineCount>
+      <paragraphCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">47</paragraphCount>
+      <isProtected toolname="Exiftool" toolversion="12.50">yes</isProtected>
+      <language toolname="Exiftool" toolversion="12.50">U.S. English</language>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>15</docmd:PageCount>
@@ -49,22 +49,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="264">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="501">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="27" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="40" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="261" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="23" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="7" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="15" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="22" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="149" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="183" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="476" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="121" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="33" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="72" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="99" />
   </statistics>
 </fits>
-

--- a/testfiles/output/Word2003_has_URLs_has_embedded_resources.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2003_has_URLs_has_embedded_resources.doc_XmlUnitExpectedOutput.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.4.0-SNAPSHOT" timestamp="10/24/18 4:42 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.4.0-SNAPSHOT">
-      <tool toolname="Droid" toolversion="6.5" />
-      <tool toolname="Exiftool" toolversion="11.14" />
+    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.19.1" />
-      <version toolname="Droid" toolversion="6.5">97-2003</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/40</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">97-2003</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/40</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="11.14" status="CONFLICT">2010:11:01 16:50:42</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.19.1" status="CONFLICT">2010-11-01T16:50:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.14" status="CONFLICT">2010:03:18 17:36:00</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2010-03-18 13:36:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2010-03-18T17:36:00Z</created>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.14">Microsoft Office Word</creatingApplicationName>
-    <creatingApplicationVersion toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">12.0000</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2003_has_URLs_has_embedded_resources.doc</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Word2003_has_URLs_has_embedded_resources.doc</filename>
-    <size toolname="OIS File Information" toolversion="0.2">1554944</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">ebfe839dc828089505ec2490f5dfac63</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <lastmodified toolname="Exiftool" toolversion="12.50" status="CONFLICT">2010-11-01T16:50:42</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.6.0" status="CONFLICT">2010-11-01T16:50:00Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">2010-03-18T17:36:00</created>
+    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2010-03-18T13:36:00</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">2010-03-18T17:36:00Z</created>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50">Microsoft Office Word</creatingApplicationName>
+    <creatingApplicationVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">12.0000</creatingApplicationVersion>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/Word2003_has_URLs_has_embedded_resources.doc</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">Word2003_has_URLs_has_embedded_resources.doc</filename>
+    <size toolname="OIS File Information" toolversion="1.0">1554944</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">ebfe839dc828089505ec2490f5dfac63</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186903</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.14">78</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.14">21525</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.14">122694</characterCount>
-      <title toolname="Exiftool" toolversion="11.14">Batch Builder User Guide</title>
-      <author toolname="Exiftool" toolversion="11.14">jwetherill</author>
-      <lineCount toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">1022</lineCount>
-      <paragraphCount toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">287</paragraphCount>
-      <hasHyperlinks toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">yes</hasHyperlinks>
-      <language toolname="Exiftool" toolversion="11.14">U.S. English</language>
+      <pageCount toolname="Exiftool" toolversion="12.50">78</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">21525</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">122694</characterCount>
+      <title toolname="Exiftool" toolversion="12.50">Batch Builder User Guide</title>
+      <author toolname="Exiftool" toolversion="12.50">jwetherill</author>
+      <lineCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">1022</lineCount>
+      <paragraphCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">287</paragraphCount>
+      <hasHyperlinks toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">yes</hasHyperlinks>
+      <language toolname="Exiftool" toolversion="12.50">U.S. English</language>
       <hasPictures toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">yes</hasPictures>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
@@ -51,22 +51,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="810">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="1603">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="29" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="586" />
-    <tool toolname="Exiftool" toolversion="11.14" executionTime="768" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="32" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="20" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="8" />
-    <tool toolname="Tika" toolversion="1.19.1" executionTime="242" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="206" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="213" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="775" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="182" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="120" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="105" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="1561" />
   </statistics>
 </fits>
-

--- a/testfiles/output/Word2003_has_table_of_contents.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2003_has_table_of_contents.doc_XmlUnitExpectedOutput.xml
@@ -1,43 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="12/6/21 3:56 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.5" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="Droid" toolversion="6.5">97-2003</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/40</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">97-2003</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/40</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:20 15:59:10</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2015-08-20T15:59:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:20 15:59:00</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-08-20 11:59:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-20T15:59:00Z</created>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54">Microsoft Office Word</creatingApplicationName>
-    <creatingApplicationVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2003_has_table_of_contents.doc</filepath>
+    <lastmodified toolname="Exiftool" toolversion="12.50" status="CONFLICT">2015-08-20T15:59:10</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.6.0" status="CONFLICT">2015-08-20T15:59:00Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">2015-08-20T15:59:00</created>
+    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-08-20T11:59:00</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">2015-08-20T15:59:00Z</created>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50">Microsoft Office Word</creatingApplicationName>
+    <creatingApplicationVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/Word2003_has_table_of_contents.doc</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">Word2003_has_table_of_contents.doc</filename>
     <size toolname="OIS File Information" toolversion="1.0">99328</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">afb707e78e777bebf7563534f2d51762</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186904</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.54">5</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.54">1341</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.54">7646</characterCount>
-      <title toolname="Exiftool" toolversion="11.54">Digital Repository Services (DRS) User Manual for Data Loading</title>
-      <author toolname="Exiftool" toolversion="11.54">viz765</author>
-      <lineCount toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">63</lineCount>
-      <paragraphCount toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">17</paragraphCount>
-      <hasHyperlinks toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">yes</hasHyperlinks>
-      <language toolname="Exiftool" toolversion="11.54">U.S. English</language>
+      <pageCount toolname="Exiftool" toolversion="12.50">5</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">1341</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">7646</characterCount>
+      <title toolname="Exiftool" toolversion="12.50">Digital Repository Services (DRS) User Manual for Data Loading</title>
+      <author toolname="Exiftool" toolversion="12.50">viz765</author>
+      <lineCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">63</lineCount>
+      <paragraphCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">17</paragraphCount>
+      <hasHyperlinks toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">yes</hasHyperlinks>
+      <language toolname="Exiftool" toolversion="12.50">U.S. English</language>
       <hasPictures toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">yes</hasPictures>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
@@ -52,22 +52,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="292">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="433">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="8" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="38" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="290" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="12" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="5" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="5" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="38" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="45" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="112" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="423" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="75" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="31" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="56" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="85" />
   </statistics>
 </fits>
-

--- a/testfiles/output/Word2003_many_graphics.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2003_many_graphics.doc_XmlUnitExpectedOutput.xml
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="12/6/21 3:55 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.5" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="Droid" toolversion="6.5">97-2003</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/40</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">97-2003</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/40</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2016:01:19 20:30:43</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2016-01-19T20:30:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:08:20 21:23:10</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-08-20 17:22:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-08-20T21:22:00Z</created>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54">Microsoft Macintosh Word</creatingApplicationName>
-    <creatingApplicationVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2003_many_graphics.doc</filepath>
+    <lastmodified toolname="Exiftool" toolversion="12.50" status="CONFLICT">2016-01-19T20:30:43</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.6.0" status="CONFLICT">2016-01-19T20:30:00Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">2015-08-20T21:23:10</created>
+    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-08-20T17:22:00</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">2015-08-20T21:22:00Z</created>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50">Microsoft Macintosh Word</creatingApplicationName>
+    <creatingApplicationVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/Word2003_many_graphics.doc</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">Word2003_many_graphics.doc</filename>
     <size toolname="OIS File Information" toolversion="1.0">528896</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">f2b172182cb10edc2c1d65dd44a7b9e0</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186907</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.54">7</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.54">2567</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.54">14633</characterCount>
-      <author toolname="Exiftool" toolversion="11.54">Zakuta, Vitaly</author>
-      <lineCount toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">121</lineCount>
-      <paragraphCount toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">34</paragraphCount>
-      <language toolname="Exiftool" toolversion="11.54">U.S. English</language>
+      <pageCount toolname="Exiftool" toolversion="12.50">7</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">2567</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">14633</characterCount>
+      <author toolname="Exiftool" toolversion="12.50">Zakuta, Vitaly</author>
+      <lineCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">121</lineCount>
+      <paragraphCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">34</paragraphCount>
+      <language toolname="Exiftool" toolversion="12.50">U.S. English</language>
       <hasPictures toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">yes</hasPictures>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
@@ -49,22 +49,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="293">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="1537">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="18" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="40" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="289" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="17" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="7" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="5" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="199" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="97" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="227" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="652" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="142" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="61" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="76" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="1466" />
   </statistics>
 </fits>
-

--- a/testfiles/output/Word2011_Has_Outline.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word2011_Has_Outline.doc_XmlUnitExpectedOutput.xml
@@ -1,45 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="12/6/21 3:56 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.5" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="Droid" toolversion="6.5">97-2003</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/40</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">97-2003</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/40</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:12:18 15:11:12</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2015-12-18T15:11:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:12:11 15:05:00</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-12-11 10:05:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-12-11T15:05:00Z</created>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54">Microsoft Macintosh Word</creatingApplicationName>
-    <creatingApplicationVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word2011_Has_Outline.doc</filepath>
+    <lastmodified toolname="Exiftool" toolversion="12.50" status="CONFLICT">2015-12-18T15:11:12</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.6.0" status="CONFLICT">2015-12-18T15:11:00Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">2015-12-11T15:05:00</created>
+    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-12-11T10:05:00</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">2015-12-11T15:05:00Z</created>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50">Microsoft Macintosh Word</creatingApplicationName>
+    <creatingApplicationVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/Word2011_Has_Outline.doc</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">Word2011_Has_Outline.doc</filename>
     <size toolname="OIS File Information" toolversion="1.0">28672</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">c5dd4b2ac16c2d192ee36303f7b13ab6</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186908</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.54">1</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.54">30</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.54">167</characterCount>
-      <title toolname="Exiftool" toolversion="11.54">This is the Title</title>
-      <author toolname="Exiftool" toolversion="11.54">Neiman David</author>
-      <lineCount toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">27</lineCount>
-      <paragraphCount toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">21</paragraphCount>
-      <subject toolname="Exiftool" toolversion="11.54" status="CONFLICT">This is the Subject</subject>
-      <subject toolname="Tika" toolversion="2.2.1" status="CONFLICT">Outline, Table</subject>
-      <category toolname="Exiftool" toolversion="11.54">This is a Category</category>
-      <language toolname="Exiftool" toolversion="11.54">U.S. English</language>
+      <pageCount toolname="Exiftool" toolversion="12.50">1</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">30</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">167</characterCount>
+      <title toolname="Exiftool" toolversion="12.50">This is the Title</title>
+      <author toolname="Exiftool" toolversion="12.50">Neiman David</author>
+      <lineCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">27</lineCount>
+      <paragraphCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">21</paragraphCount>
+      <subject toolname="Exiftool" toolversion="12.50" status="CONFLICT">This is the Subject</subject>
+      <subject toolname="Tika" toolversion="2.6.0" status="CONFLICT">Outline, Table</subject>
+      <category toolname="Exiftool" toolversion="12.50">This is a Category</category>
+      <language toolname="Exiftool" toolversion="12.50">U.S. English</language>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>1</docmd:PageCount>
@@ -52,22 +52,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="241">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="419">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="6" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="34" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="239" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="10" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="3" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="4" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="28" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="52" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="134" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="399" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="83" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="52" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="43" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="61" />
   </statistics>
 </fits>
-

--- a/testfiles/output/WordPasswordProtected.docx_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPasswordProtected.docx_XmlUnitExpectedOutput.xml
@@ -1,46 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="7/14/22, 3:59 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification status="CONFLICT">
     <identity format="OLE 2 Compound Document, v3.62, SecID 0x1, 11 FAT sectors, Mini FAT start sector 0x2 : UNKNOWN with names EncryptedPackage \006DataSpaces Version" mimetype="application/x-ole-storage" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="file utility" toolversion="5.41" />
+      <tool toolname="file utility" toolversion="5.43" />
     </identity>
     <identity format="Office Open XML Document" mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="Exiftool" toolversion="12.40" />
+      <tool toolname="Exiftool" toolversion="12.50" />
     </identity>
     <identity format="Microsoft Excel" mimetype="application/vnd.ms-excel" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="ffident" toolversion="0.2" />
     </identity>
     <identity format="Password Protected OOXML File" mimetype="application/x-tika-ooxml-protected" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="Tika" toolversion="2.3.0" />
+      <tool toolname="Tika" toolversion="2.6.0" />
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/WordPasswordProtected.docx</filepath>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/WordPasswordProtected.docx</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">WordPasswordProtected.docx</filename>
     <size toolname="OIS File Information" toolversion="1.0">242176</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">bfc6125db60e834e6b9e7210970a6233</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1466791807000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186909</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document />
   </metadata>
-  <statistics fitsExecutionTime="300">
-    <tool toolname="MediaInfo" toolversion="21.09" status="did not run" />
+  <statistics fitsExecutionTime="349">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="28" />
-    <tool toolname="Jhove" toolversion="1.26.0" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="75" />
-    <tool toolname="Exiftool" toolversion="12.40" executionTime="287" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="23" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="45" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="117" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="61" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="117" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="328" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="35" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="70" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="208" />
   </statistics>
 </fits>
-

--- a/testfiles/output/WordPerfect4_2.wp_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPerfect4_2.wp_XmlUnitExpectedOutput.xml
@@ -1,39 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.0" timestamp="6/26/17 2:07 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification status="SINGLE_RESULT">
-    <identity format="WordPerfect Document" mimetype="application/vnd.wordperfect" toolname="FITS" toolversion="1.2.0">
-      <tool toolname="Droid" toolversion="6.3" />
-      <version toolname="Droid" toolversion="6.3" status="CONFLICT">5.2</version>
-      <version toolname="Droid" toolversion="6.3" status="CONFLICT">6 onwards</version>
-      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">x-fmt/203</externalIdentifier>
-      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">fmt/892</externalIdentifier>
+    <identity format="WordPerfect Document" mimetype="application/vnd.wordperfect" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <version toolname="Droid" toolversion="6.5.2" status="CONFLICT">5.2</version>
+      <version toolname="Droid" toolversion="6.5.2" status="CONFLICT">6 onwards</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/203</externalIdentifier>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/892</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/WordPerfect4_2.wp</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">WordPerfect4_2.wp</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">2677</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">a83edcaa67ad6338bbfee877815df532</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1464898750000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/WordPerfect4_2.wp</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">WordPerfect4_2.wp</filename>
+    <size toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">2677</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">a83edcaa67ad6338bbfee877815df532</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186909</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata />
-  <statistics fitsExecutionTime="2225">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="560">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.3" executionTime="2224" />
-    <tool toolname="Jhove" toolversion="1.16" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="47" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="185" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="138" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="2" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="4" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="88" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="30" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="230" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="416" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="545" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="39" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="60" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="55" />
   </statistics>
 </fits>
-

--- a/testfiles/output/WordPerfect5_0.wp_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPerfect5_0.wp_XmlUnitExpectedOutput.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.x" timestamp="2/2/18 5:12 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 11:24 AM">
   <identification>
-    <identity format="WordPerfect Document" mimetype="application/vnd.wordperfect" toolname="FITS" toolversion="1.2.x">
-      <tool toolname="Droid" toolversion="6.3" />
+    <identity format="WordPerfect Document" mimetype="application/vnd.wordperfect" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
       <tool toolname="file utility" toolversion="5.43" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
-      <version toolname="Droid" toolversion="6.3">5.0</version>
-      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">x-fmt/393</externalIdentifier>
+      <version toolname="Droid" toolversion="6.5.2">5.0</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/393</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
     <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">WordPerfect</creatingApplicationName>
     <creatingApplicationVersion toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">5.0</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/WordPerfect5_0.wp</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">WordPerfect5_0.wp</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">3329</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">dd08b1df84b3d38736ac777795566b42</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/WordPerfect5_0.wp</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">WordPerfect5_0.wp</filename>
+    <size toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">3329</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">dd08b1df84b3d38736ac777795566b42</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186909</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
@@ -28,22 +28,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="125">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="274">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.3" executionTime="12" />
-    <tool toolname="Jhove" toolversion="1.16" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="49" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="163" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="35" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="3" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="7" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="6" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="16" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="86" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="258" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="77" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="17" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="40" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="72" />
   </statistics>
 </fits>
-

--- a/testfiles/output/WordPerfect5_2.wp_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPerfect5_2.wp_XmlUnitExpectedOutput.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.11.0" timestamp="3/22/16 12:31 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 11:24 AM">
   <identification>
-    <identity format="WordPerfect Document" mimetype="application/vnd.wordperfect" toolname="FITS" toolversion="1.2.x">
-      <tool toolname="Droid" toolversion="6.3" />
+    <identity format="WordPerfect Document" mimetype="application/vnd.wordperfect" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
       <tool toolname="file utility" toolversion="5.43" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
-      <version toolname="Droid" toolversion="6.3">5.1</version>
-      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">x-fmt/394</externalIdentifier>
+      <version toolname="Droid" toolversion="6.5.2">5.1</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/394</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
     <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">WordPerfect</creatingApplicationName>
     <creatingApplicationVersion toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">5.1</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/WordPerfect5_2.wp</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">WordPerfect5_2.wp</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">3395</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">6262360df874988574fdcf0d31369494</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/WordPerfect5_2.wp</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">WordPerfect5_2.wp</filename>
+    <size toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">3395</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">6262360df874988574fdcf0d31369494</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186910</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
@@ -28,22 +28,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="120">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="265">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.3" executionTime="11" />
-    <tool toolname="Jhove" toolversion="1.16" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="46" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="152" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="19" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="15" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="23" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="32" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="21" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="114" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="258" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="85" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="16" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="45" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="47" />
   </statistics>
 </fits>
-

--- a/testfiles/output/WordPerfect6-7.wpd_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPerfect6-7.wpd_XmlUnitExpectedOutput.xml
@@ -1,43 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.11.0" timestamp="3/22/16 12:31 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 11:46 AM">
   <identification>
-    <identity format="WordPerfect Document" mimetype="application/vnd.wordperfect" toolname="FITS" toolversion="0.11.0">
-      <tool toolname="Droid" toolversion="6.1.5" />
-      <tool toolname="file utility" toolversion="5.04" />
+    <identity format="WordPerfect Document" mimetype="application/vnd.wordperfect" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
-      <version toolname="Droid" toolversion="6.1.5">6.0</version>
-      <externalIdentifier toolname="Droid" toolversion="6.1.5" type="puid">x-fmt/44</externalIdentifier>
+      <version toolname="Droid" toolversion="6.5.2">6.0</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/44</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
     <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">WordPerfect</creatingApplicationName>
     <creatingApplicationVersion toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">7.1</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/WordPerfect6-7.wpd</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">WordPerfect6-7.wpd</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">9122</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">12a73e2a0645548d48a7e3c97002aac2</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1454956776000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/WordPerfect6-7.wpd</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">WordPerfect6-7.wpd</filename>
+    <size toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">9122</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">12a73e2a0645548d48a7e3c97002aac2</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186910</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document />
   </metadata>
-  <statistics fitsExecutionTime="138">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="718">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="5" />
-    <tool toolname="Jhove" toolversion="1.11" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="31" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="134" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="15" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="2" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="7" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="6" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="34" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="257" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="689" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="183" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="60" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="97" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="162" />
   </statistics>
 </fits>
-

--- a/testfiles/output/Word_has_index.docx_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word_has_index.docx_XmlUnitExpectedOutput.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.x" timestamp="2/2/18 2:46 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Office Open XML Document" mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document" toolname="FITS" toolversion="1.2.x">
-      <tool toolname="Droid" toolversion="6.3" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="10.00" />
-      <tool toolname="Tika" toolversion="1.10" />
-      <version toolname="Droid" toolversion="6.3">2007 onwards</version>
-      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">fmt/412</externalIdentifier>
+    <identity format="Office Open XML Document" mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">2007 onwards</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/412</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="12.40">2015-08-19T23:04:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40">2015-08-19T23:03:00Z</created>
-    <creatingApplicationName toolname="Tika" toolversion="1.10" status="SINGLE_RESULT">Microsoft Office Word</creatingApplicationName>
-    <creatingApplicationVersion toolname="Exiftool" toolversion="10.00">14.0000</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/Word_has_index.docx</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Word_has_index.docx</filename>
-    <size toolname="OIS File Information" toolversion="0.2">39310</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">915d4914b6516586a4e05d32ccb27b35</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1455055714000</fslastmodified>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2015-08-19T23:04:00Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50">2015-08-19T23:03:00Z</created>
+    <creatingApplicationName toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">Microsoft Office Word</creatingApplicationName>
+    <creatingApplicationVersion toolname="Exiftool" toolversion="12.50">14.0000</creatingApplicationVersion>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/Word_has_index.docx</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">Word_has_index.docx</filename>
+    <size toolname="OIS File Information" toolversion="1.0">39310</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">915d4914b6516586a4e05d32ccb27b35</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186911</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="10.00">10</pageCount>
-      <wordCount toolname="Exiftool" toolversion="10.00">1347</wordCount>
-      <characterCount toolname="Exiftool" toolversion="10.00">7682</characterCount>
-      <author toolname="Exiftool" toolversion="10.00">Zakuta, Vitaly</author>
-      <lineCount toolname="Exiftool" toolversion="10.00">64</lineCount>
-      <paragraphCount toolname="Exiftool" toolversion="10.00">18</paragraphCount>
+      <pageCount toolname="Exiftool" toolversion="12.50">10</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">1347</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">7682</characterCount>
+      <author toolname="Exiftool" toolversion="12.50">Zakuta, Vitaly</author>
+      <lineCount toolname="Exiftool" toolversion="12.50">64</lineCount>
+      <paragraphCount toolname="Exiftool" toolversion="12.50">18</paragraphCount>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>10</docmd:PageCount>
@@ -41,22 +41,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="279">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="874">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="7" />
-    <tool toolname="Jhove" toolversion="1.11" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="24" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="191" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="3" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="6" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="270" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="23" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="107" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="598" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="16" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="36" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="840" />
   </statistics>
 </fits>
-

--- a/testfiles/output/Word_protected_encrypted.doc_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Word_protected_encrypted.doc_XmlUnitExpectedOutput.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="12/6/21 3:34 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.5" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="Microsoft Word Binary File Format" mimetype="application/msword" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="Droid" toolversion="6.5">97-2003</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/754</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">97-2003</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/754</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:12:17 17:46:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.21" status="CONFLICT">2015-12-17T17:46:00Z</lastmodified>
-    <created toolname="Exiftool" toolversion="11.54" status="CONFLICT">2015:12:17 17:35:00</created>
-    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-12-17 12:35:00</created>
-    <created toolname="Tika" toolversion="2.2.1" status="CONFLICT">2015-12-17T17:35:00Z</created>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54">Microsoft Office Word</creatingApplicationName>
-    <creatingApplicationVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/Word_protected_encrypted.doc</filepath>
+    <lastmodified toolname="Exiftool" toolversion="12.50" status="CONFLICT">2015-12-17T17:46:00</lastmodified>
+    <lastmodified toolname="Tika" toolversion="2.6.0" status="CONFLICT">2015-12-17T17:46:00Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">2015-12-17T17:35:00</created>
+    <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2015-12-17T12:35:00</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">2015-12-17T17:35:00Z</created>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50">Microsoft Office Word</creatingApplicationName>
+    <creatingApplicationVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">14.0000</creatingApplicationVersion>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/Word_protected_encrypted.doc</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">Word_protected_encrypted.doc</filename>
     <size toolname="OIS File Information" toolversion="1.0">22528</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1a83eafb0583f1a719bfbe1b87c19df6</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186913</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Exiftool" toolversion="11.54">1</pageCount>
-      <wordCount toolname="Exiftool" toolversion="11.54">10</wordCount>
-      <characterCount toolname="Exiftool" toolversion="11.54">60</characterCount>
-      <author toolname="Exiftool" toolversion="11.54">David Neiman</author>
-      <lineCount toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1</lineCount>
-      <paragraphCount toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1</paragraphCount>
-      <isProtected toolname="Exiftool" toolversion="11.54">yes</isProtected>
-      <language toolname="Exiftool" toolversion="11.54">U.S. English</language>
+      <pageCount toolname="Exiftool" toolversion="12.50">1</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">10</wordCount>
+      <characterCount toolname="Exiftool" toolversion="12.50">60</characterCount>
+      <author toolname="Exiftool" toolversion="12.50">David Neiman</author>
+      <lineCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">1</lineCount>
+      <paragraphCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">1</paragraphCount>
+      <isProtected toolname="Exiftool" toolversion="12.50">yes</isProtected>
+      <language toolname="Exiftool" toolversion="12.50">U.S. English</language>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>1</docmd:PageCount>
@@ -49,22 +49,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="379">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="1139">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="49" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="36" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="344" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="156" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="3" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="7" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="372" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="619" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="162" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="733" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="1106" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="40" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="83" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="1122" />
   </statistics>
 </fits>
-

--- a/testfiles/output/aletrek-rle.mov_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/aletrek-rle.mov_XmlUnitExpectedOutput.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="11/1/22, 8:25 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:07 AM">
   <identification>
     <identity format="QuickTime" mimetype="video/quicktime" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="MediaInfo" toolversion="21.09" />
+      <tool toolname="MediaInfo" toolversion="22.09" />
       <tool toolname="Droid" toolversion="6.5.2" />
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/384</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <creatingApplicationName toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">Apple QuickTime</creatingApplicationName>
+    <creatingApplicationName toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">Apple QuickTime</creatingApplicationName>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/aletrek-rle.mov</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">aletrek-rle.mov</filename>
-    <size toolname="MediaInfo" toolversion="21.09">236367</size>
+    <size toolname="MediaInfo" toolversion="22.09">236367</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">00abffdd789c30a654e66068c3eb3171</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1667346566771</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186915</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <video>
-      <location toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">/fits/testfiles/input/aletrek-rle.mov</location>
-      <mimeType toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">video/quicktime</mimeType>
-      <format toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">QuickTime</format>
-      <duration toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">3333</duration>
-      <bitRate toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">567338</bitRate>
-      <dateCreated toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">UTC 2002-10-18 17:15:11</dateCreated>
-      <dateModified toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">UTC 2022-11-01 23:49:26</dateModified>
-      <track type="video" id="1" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
+      <location toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">/fits/testfiles/input/aletrek-rle.mov</location>
+      <mimeType toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">video/quicktime</mimeType>
+      <format toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">QuickTime</format>
+      <duration toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">3333</duration>
+      <bitRate toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">567338</bitRate>
+      <dateCreated toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">UTC 2002-10-18 17:15:11</dateCreated>
+      <dateModified toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">UTC 2023-01-10 13:43:06</dateModified>
+      <track type="video" id="1" toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">
         <videoDataEncoding>rle </videoDataEncoding>
         <codecId>rle </codecId>
         <codecCC>rle </codecCC>
@@ -87,28 +87,28 @@
               <ebucore:mimeType typeLabel="video/quicktime" />
               <ebucore:locator>/fits/testfiles/input/aletrek-rle.mov</ebucore:locator>
               <ebucore:technicalAttributeString typeLabel="overallBitRate">567338</ebucore:technicalAttributeString>
-              <ebucore:dateModified startTime="23:49:26Z" startDate="2022-11-01" />
+              <ebucore:dateModified startTime="13:43:06Z" startDate="2023-01-10" />
             </ebucore:format>
           </ebucore:coreMetadata>
         </ebucore:ebuCoreMain>
       </standard>
     </video>
   </metadata>
-  <statistics fitsExecutionTime="35">
-    <tool toolname="MediaInfo" toolversion="21.09" executionTime="22" />
+  <statistics fitsExecutionTime="88">
+    <tool toolname="MediaInfo" toolversion="22.09" executionTime="81" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="5" />
-    <tool toolname="Jhove" toolversion="1.26.0" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="33" />
-    <tool toolname="Exiftool" toolversion="12.42" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="2" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="6" />
-    <tool toolname="Tika" toolversion="2.3.0" status="did not run" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="69" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="81" />
+    <tool toolname="Exiftool" toolversion="12.50" status="did not run" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="24" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="35" />
+    <tool toolname="Tika" toolversion="2.6.0" status="did not run" />
   </statistics>
 </fits>

--- a/testfiles/output/aliceDynamic_images_metadata_tableOfContents.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/aliceDynamic_images_metadata_tableOfContents.epub_XmlUnitExpectedOutput.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.11.0" timestamp="2/12/16 10:01 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 11:24 AM">
   <identification>
-    <identity format="EPUB" mimetype="application/epub+zip" toolname="FITS" toolversion="1.5.2-SNAPSHOT">
-      <tool toolname="Exiftool" toolversion="12.40" />
-      <tool toolname="Tika" toolversion="2.3.0" />
+    <identity format="EPUB" mimetype="application/epub+zip" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
     </identity>
   </identification>
   <fileinfo>
-    <created toolname="Tika" toolversion="2.2.1" status="SINGLE_RESULT">1865-07-04</created>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/aliceDynamic_images_metadata_tableOfContents.epub</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">aliceDynamic_images_metadata_tableOfContents.epub</filename>
-    <size toolname="OIS File Information" toolversion="0.2">1135531</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">4fce60e013fbb16c67514ae5bfd9b846</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1454956776000</fslastmodified>
+    <created toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">1865-07-04</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/aliceDynamic_images_metadata_tableOfContents.epub</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">aliceDynamic_images_metadata_tableOfContents.epub</filename>
+    <size toolname="OIS File Information" toolversion="1.0">1135531</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">4fce60e013fbb16c67514ae5bfd9b846</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186923</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <isRightsManaged toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">yes</isRightsManaged>
-      <subject toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">fiction</subject>
-      <identifier toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">urn:uuid:1a16ce38-82bd-4e9b-861e-773c2e787a50</identifier>
-      <language toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">en-GB</language>
-      <author toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">Lewis Carroll</author>
-      <title toolname="Tika" toolversion="2.3.0" status="SINGLE_RESULT">Alice's Adventures in Wonderland</title>
+      <isRightsManaged toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">yes</isRightsManaged>
+      <subject toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">fiction</subject>
+      <identifier toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">urn:uuid:1a16ce38-82bd-4e9b-861e-773c2e787a50</identifier>
+      <language toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">en-GB</language>
+      <author toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">Lewis Carroll</author>
+      <title toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">Alice's Adventures in Wonderland</title>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:Language>en-GB</docmd:Language>
@@ -30,22 +30,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="191">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="386">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="32" />
-    <tool toolname="Jhove" toolversion="1.11" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="75" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="186" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="32" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="27" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="161" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="68" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="94" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="378" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="67" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="78" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="87" />
   </statistics>
 </fits>
-

--- a/testfiles/output/altona_technical_1v2_x3_has_annotations.pdf_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/altona_technical_1v2_x3_has_annotations.pdf_XmlUnitExpectedOutput.xml
@@ -1,55 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="7/14/22, 3:59 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
     <identity format="PDF/X" mimetype="application/pdf" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="Jhove" toolversion="1.26.0" />
-      <tool toolname="Exiftool" toolversion="12.40" />
-      <tool toolname="Tika" toolversion="2.3.0" />
-      <version toolname="Jhove" toolversion="1.26.0">3:2003</version>
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Jhove" toolversion="1.26.1">3:2003</version>
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/158</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.26.0">4274074</size>
-    <creatingApplicationName toolname="Jhove" toolversion="1.26.0">Acrobat Distiller 5.0.5 f.r Macintosh/QuarkXPress(R) 4.04</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="12.40">2004-05-09T12:07:13Z</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40">2002-09-21T19:25:36Z</created>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/altona_technical_1v2_x3_has_annotations.pdf</filepath>
+    <size toolname="Jhove" toolversion="1.26.1">4274074</size>
+    <creatingApplicationName toolname="Jhove" toolversion="1.26.1">Acrobat Distiller 5.0.5 f.r Macintosh/QuarkXPress(R) 4.04</creatingApplicationName>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2004-05-09T12:07:13Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50">2002-09-21T19:25:36Z</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/altona_technical_1v2_x3_has_annotations.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">altona_technical_1v2_x3_has_annotations.pdf</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">c524ab2cd02240b12eab3ee9f8887a9f</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1466791807000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358186943</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <document>
-      <title toolname="Jhove" toolversion="1.26.0">Altona_Technical_1v2_x3.pdf</title>
-      <author toolname="Jhove" toolversion="1.26.0">ECI (www.eci.org), bvdm (www.bvdm-online.de), FOGRA (www.fogra.org), ugra (www.ugra.ch)</author>
-      <pageCount toolname="Jhove" toolversion="1.26.0">1</pageCount>
-      <hasOutline toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">no</hasOutline>
-      <hasAnnotations toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">yes</hasAnnotations>
-      <graphicsCount toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">44</graphicsCount>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <title toolname="Jhove" toolversion="1.26.1">Altona_Technical_1v2_x3.pdf</title>
+      <author toolname="Jhove" toolversion="1.26.1">ECI (www.eci.org), bvdm (www.bvdm-online.de), FOGRA (www.fogra.org), ugra (www.ugra.ch)</author>
+      <pageCount toolname="Jhove" toolversion="1.26.1">1</pageCount>
+      <hasOutline toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">no</hasOutline>
+      <hasAnnotations toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">yes</hasAnnotations>
+      <graphicsCount toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">44</graphicsCount>
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>Courier-Oblique</fontName>
       </font>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>Helvetica</fontName>
       </font>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>Helvetica-Bold</fontName>
       </font>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>Metabook01</fontName>
       </font>
-      <font toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">
+      <font toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">
         <fontName>Metanormal01-Bold</fontName>
       </font>
-      <subject toolname="Exiftool" toolversion="12.40" status="CONFLICT">Altona Test Suite – Online Version</subject>
-      <subject toolname="Tika" toolversion="2.3.0" status="CONFLICT">PDF/X-3 (ISO 15930-3), ICC Color Management, Standard Printing Conditions: Offset printing, according to ISO/DIS 12647-2:2003, OFCOM,  paper type 1+2 = coated art, 115 g/m2, screen ruling 60 cm-1, positive-acting plates (FOGRA27L)</subject>
-      <description toolname="Exiftool" toolversion="12.40">Altona Test Suite – Online Version</description>
+      <subject toolname="Exiftool" toolversion="12.50" status="CONFLICT">Altona Test Suite – Online Version</subject>
+      <subject toolname="Tika" toolversion="2.6.0" status="CONFLICT">PDF/X-3 (ISO 15930-3), ICC Color Management, Standard Printing Conditions: Offset printing, according to ISO/DIS 12647-2:2003, OFCOM,  paper type 1+2 = coated art, 115 g/m2, screen ruling 60 cm-1, positive-acting plates (FOGRA27L)</subject>
+      <description toolname="Exiftool" toolversion="12.50">Altona Test Suite – Online Version</description>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>1</docmd:PageCount>
@@ -64,22 +64,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="475">
-    <tool toolname="MediaInfo" toolversion="21.09" status="did not run" />
+  <statistics fitsExecutionTime="1121">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="109" />
-    <tool toolname="Jhove" toolversion="1.26.0" executionTime="227" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="124" />
-    <tool toolname="Exiftool" toolversion="12.40" executionTime="463" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="68" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="49" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="419" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="430" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="800" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="423" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="891" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="208" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="148" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="1000" />
   </statistics>
 </fits>
-

--- a/testfiles/output/assorted-files.zip-default_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/assorted-files.zip-default_XmlUnitExpectedOutput.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0-SNAPSHOT" timestamp="7/10/19 9:19 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:07 AM">
   <identification>
-    <identity format="ZIP Format" mimetype="application/zip" toolname="FITS" toolversion="1.5.0-SNAPSHOT">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="ZIP Format" mimetype="application/zip" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="file utility" toolversion="5.31">1.0</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">x-fmt/263</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="file utility" toolversion="5.43">1.0</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/263</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/assorted-files.zip</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">assorted-files.zip</filename>
-    <size toolname="OIS File Information" toolversion="0.2">30400659</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">381dd28336fef8e188ebec5c6c29c596</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/assorted-files.zip</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">assorted-files.zip</filename>
+    <size toolname="OIS File Information" toolversion="1.0">30400659</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">381dd28336fef8e188ebec5c6c29c596</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187041</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <container>
-      <originalSize toolname="Droid" toolversion="6.4" status="SINGLE_RESULT">34318329</originalSize>
-      <compressionMethod toolname="Droid" toolversion="6.4" status="SINGLE_RESULT">deflate</compressionMethod>
-      <entries totalEntries="16" toolname="Droid" toolversion="6.4" status="SINGLE_RESULT">
+      <originalSize toolname="Droid" toolversion="6.5.2" status="SINGLE_RESULT">34318329</originalSize>
+      <compressionMethod toolname="Droid" toolversion="6.5.2" status="SINGLE_RESULT">deflate</compressionMethod>
+      <entries totalEntries="16" toolname="Droid" toolversion="6.5.2" status="SINGLE_RESULT">
         <format name="EPUB" number="1" />
         <format name="Extensible Markup Language" number="1" />
         <format name="Graphics Interchange Format" number="1" />
@@ -43,22 +43,21 @@
       </entries>
     </container>
   </metadata>
-  <statistics fitsExecutionTime="1013">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="4642">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="794" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="568" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="263" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="142" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="11" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="1005" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="1227" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="173" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="777" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="710" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="87" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="4624" />
   </statistics>
 </fits>
-

--- a/testfiles/output/binary.jp2_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/binary.jp2_XmlUnitExpectedOutput.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="11/12/22, 9:17 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:04 AM">
   <identification>
     <identity format="JPEG 2000 JP2" mimetype="image/jp2" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="Tika" toolversion="2.3.0" />
       <tool toolname="jpylyzer" toolversion="2.1.0" />
+      <tool toolname="Tika" toolversion="2.6.0" />
     </identity>
   </identification>
   <fileinfo>
@@ -11,28 +11,28 @@
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">binary.jp2</filename>
     <size toolname="OIS File Information" toolversion="1.0">1024</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">b40da7703d70dd7c71918802f56c5067</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1668265534429</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187045</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="jpylyzer" toolversion="2.1.0" status="SINGLE_RESULT">false</well-formed>
     <valid toolname="jpylyzer" toolversion="2.1.0" status="SINGLE_RESULT">false</valid>
   </filestatus>
   <metadata />
-  <statistics fitsExecutionTime="221">
+  <statistics fitsExecutionTime="323">
     <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="13" />
-    <tool toolname="Jhove" toolversion="1.26.1" executionTime="79" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="45" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="180" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="123" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="91" />
-    <tool toolname="Exiftool" toolversion="12.42" executionTime="208" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="126" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="317" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="12" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="38" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="30" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="214" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="104" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="67" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="59" />
   </statistics>
 </fits>

--- a/testfiles/output/compressed-encrypted.zip_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/compressed-encrypted.zip_XmlUnitExpectedOutput.xml
@@ -1,41 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0-SNAPSHOT" timestamp="7/10/19 9:19 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:07 AM">
   <identification>
-    <identity format="ZIP Format" mimetype="application/zip" toolname="FITS" toolversion="1.5.0-SNAPSHOT">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="ZIP Format" mimetype="application/zip" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="file utility" toolversion="5.31">2.0</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">x-fmt/263</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="file utility" toolversion="5.43">2.0</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/263</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/compressed-encrypted.zip</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">compressed-encrypted.zip</filename>
-    <size toolname="OIS File Information" toolversion="0.2">18284445</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">3f3d6583101f3967ad285c8064bf746f</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/compressed-encrypted.zip</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">compressed-encrypted.zip</filename>
+    <size toolname="OIS File Information" toolversion="1.0">18284445</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">3f3d6583101f3967ad285c8064bf746f</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187083</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata />
-  <statistics fitsExecutionTime="887">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="693">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="434" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="864" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="860" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="308" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="806" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="430" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="687" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="149" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="608" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="394" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="87" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="496" />
   </statistics>
 </fits>
-

--- a/testfiles/output/epub30-test-font-embedding-obfuscation.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/epub30-test-font-embedding-obfuscation.epub_XmlUnitExpectedOutput.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.11.0" timestamp="2/12/16 10:01 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 11:24 AM">
   <identification>
-    <identity format="EPUB" mimetype="application/epub+zip" toolname="FITS" toolversion="0.11.0">
-      <tool toolname="Droid" toolversion="6.1.5" />
-      <tool toolname="file utility" toolversion="5.41" />
-      <tool toolname="Exiftool" toolversion="10.00" />
-      <tool toolname="Tika" toolversion="1.10" />
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/483</externalIdentifier>
+    <identity format="EPUB" mimetype="application/epub+zip" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/483</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/epub30-test-font-embedding-obfuscation.epub</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">epub30-test-font-embedding-obfuscation.epub</filename>
-    <size toolname="OIS File Information" toolversion="0.2">1176408</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">8fcf4ac8f3ba4670ff204b200d1a910e</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1454956776000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/epub30-test-font-embedding-obfuscation.epub</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">epub30-test-font-embedding-obfuscation.epub</filename>
+    <size toolname="OIS File Information" toolversion="1.0">1176408</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">8fcf4ac8f3ba4670ff204b200d1a910e</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187089</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <title toolname="Exiftool" toolversion="10.00">EPUBTEST 0103 - Font Embedding and Obfuscation Tests</title>
-      <author toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">Markus Gylling, Vincent Gros, Toshiaki Koike, Marisa DeMeglio, Matt Garrish, Ori Idan</author>
-      <isRightsManaged toolname="Exiftool" toolversion="10.00">yes</isRightsManaged>
-      <description toolname="Exiftool" toolversion="10.00">Tests for Font Embedding and Obfuscation [UNDER CONSTRUCTION]</description>
-      <identifier toolname="Exiftool" toolversion="10.00">com.github.epub-testsuite.epub30-test-0103</identifier>
-      <language toolname="Exiftool" toolversion="10.00">en</language>
+      <title toolname="Exiftool" toolversion="12.50">EPUBTEST 0103 - Font Embedding and Obfuscation Tests</title>
+      <author toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Markus Gylling, Vincent Gros, Toshiaki Koike, Marisa DeMeglio, Matt Garrish, Ori Idan</author>
+      <isRightsManaged toolname="Exiftool" toolversion="12.50">yes</isRightsManaged>
+      <description toolname="Exiftool" toolversion="12.50">Tests for Font Embedding and Obfuscation [UNDER CONSTRUCTION]</description>
+      <identifier toolname="Exiftool" toolversion="12.50">com.github.epub-testsuite.epub30-test-0103</identifier>
+      <language toolname="Exiftool" toolversion="12.50">en</language>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:Language>en</docmd:Language>
@@ -32,22 +32,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="190">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="497">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="24" />
-    <tool toolname="Jhove" toolversion="1.11" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="112" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="182" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="28" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="20" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="48" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="57" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="169" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="477" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="53" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="48" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="162" />
   </statistics>
 </fits>
-

--- a/testfiles/output/freeMXF-mxf1a.mxf-default_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/freeMXF-mxf1a.mxf-default_XmlUnitExpectedOutput.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="6/27/22, 11:46 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:06 AM">
   <identification>
     <identity format="Material Exchange Format (MXF)" mimetype="application/mxf" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="MediaInfo" toolversion="21.09" />
+      <tool toolname="MediaInfo" toolversion="22.09" />
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="file utility" toolversion="5.41" />
+      <tool toolname="file utility" toolversion="5.43" />
       <version toolname="Droid" toolversion="6.5.2">Operational Pattern 1a</version>
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/200</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/freeMXF-mxf1a.mxf</filepath>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/freeMXF-mxf1a.mxf</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">freeMXF-mxf1a.mxf</filename>
-    <size toolname="MediaInfo" toolversion="21.09">623664</size>
+    <size toolname="MediaInfo" toolversion="22.09">623664</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">6ed70658f07daccac680a52fe2273b71</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1457973381000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187150</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <video>
-      <location toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">/fits/testfiles/freeMXF-mxf1a.mxf</location>
-      <mimeType toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">application/mxf</mimeType>
-      <format toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">Material Exchange Format (MXF)</format>
-      <formatProfile toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">OP-1a</formatProfile>
-      <duration toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">10640</duration>
-      <timecodeStart toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">00:00:00:00</timecodeStart>
-      <bitRate toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">468920</bitRate>
-      <dateCreated toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">2006-01-11 18:59:25.708</dateCreated>
-      <dateModified toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">UTC 2016-03-14 16:36:21</dateModified>
-      <track type="video" id="2" toolname="MediaInfo" toolversion="21.09" status="SINGLE_RESULT">
+      <location toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">/fits/testfiles/input/freeMXF-mxf1a.mxf</location>
+      <mimeType toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">application/mxf</mimeType>
+      <format toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">Material Exchange Format (MXF)</format>
+      <formatProfile toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">OP-1a</formatProfile>
+      <duration toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">10640</duration>
+      <timecodeStart toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">00:00:00:00</timecodeStart>
+      <bitRate toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">468920</bitRate>
+      <dateCreated toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">2006-01-11 18:59:25.708</dateCreated>
+      <dateModified toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">UTC 2023-01-10 13:43:07</dateModified>
+      <track type="video" id="2" toolname="MediaInfo" toolversion="22.09" status="SINGLE_RESULT">
         <videoDataEncoding>0D01030102046001</videoDataEncoding>
         <codecId>0D01030102046001</codecId>
         <codecVersion>Main@Main</codecVersion>
@@ -54,21 +54,21 @@
       </track>
     </video>
   </metadata>
-  <statistics fitsExecutionTime="157">
-    <tool toolname="MediaInfo" toolversion="21.09" executionTime="141" />
+  <statistics fitsExecutionTime="128">
+    <tool toolname="MediaInfo" toolversion="22.09" executionTime="122" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="52" />
-    <tool toolname="Jhove" toolversion="1.24.9" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="146" />
-    <tool toolname="Exiftool" toolversion="12.40" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="58" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="72" />
-    <tool toolname="Tika" toolversion="2.3.0" status="did not run" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="72" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="103" />
+    <tool toolname="Exiftool" toolversion="12.50" status="did not run" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="70" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="59" />
+    <tool toolname="Tika" toolversion="2.6.0" status="did not run" />
   </statistics>
 </fits>

--- a/testfiles/output/gps.jpg_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/gps.jpg_XmlUnitExpectedOutput.xml
@@ -1,77 +1,77 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="12/6/21 3:32 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
-    <identity format="JPEG EXIF" mimetype="image/jpeg" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="Jhove" toolversion="1.20.1" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="11.54" />
-      <version toolname="Droid" toolversion="6.4" status="CONFLICT">2.2.1</version>
-      <version toolname="Jhove" toolversion="1.20.1" status="CONFLICT">1.01</version>
-      <version toolname="file utility" toolversion="5.39" status="CONFLICT">13</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">fmt/645</externalIdentifier>
+    <identity format="JPEG EXIF" mimetype="image/jpeg" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <version toolname="Droid" toolversion="6.5.2" status="CONFLICT">2.2.1</version>
+      <version toolname="Jhove" toolversion="1.26.1" status="CONFLICT">1.01</version>
+      <version toolname="file utility" toolversion="5.43" status="CONFLICT">012</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/645</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.20.1">41851</size>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">FinePix F30</creatingApplicationName>
+    <size toolname="Jhove" toolversion="1.26.1">41851</size>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">FinePix F30</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="12.50">2006-11-03T02:26:02</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40">2006-11-03T07:14:39</created>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/gps.jpg</filepath>
+    <created toolname="Exiftool" toolversion="12.50">2006-11-03T07:14:39</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/gps.jpg</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">gps.jpg</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">201f1db44775631d307b3ffd62acb3ac</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1516117983000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187151</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">true</valid>
-    <message toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">Unknown TIFF IFD tag: 50341 severity=info offset=278</message>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
+    <message toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Unknown TIFF IFD tag: 50341 severity=info offset=278</message>
   </filestatus>
   <metadata>
     <image>
-      <byteOrder toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">big endian</byteOrder>
-      <compressionScheme toolname="Jhove" toolversion="1.20.1">JPEG</compressionScheme>
-      <imageWidth toolname="Jhove" toolversion="1.20.1">600</imageWidth>
-      <imageHeight toolname="Jhove" toolversion="1.20.1">800</imageHeight>
-      <colorSpace toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">YCbCr</colorSpace>
-      <YCbCrSubSampling toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2 2</YCbCrSubSampling>
-      <YCbCrPositioning toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2</YCbCrPositioning>
-      <orientation toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">normal*</orientation>
-      <samplingFrequencyUnit toolname="Jhove" toolversion="1.20.1">in.</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Exiftool" toolversion="11.54">72</xSamplingFrequency>
-      <ySamplingFrequency toolname="Exiftool" toolversion="11.54">72</ySamplingFrequency>
-      <bitsPerSample toolname="Jhove" toolversion="1.20.1">8 8 8</bitsPerSample>
-      <samplesPerPixel toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">3</samplesPerPixel>
-      <scanningSoftwareName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Digital Camera FinePix F30     Ver1.02</scanningSoftwareName>
-      <digitalCameraModelName toolname="Jhove" toolversion="1.26.0">FinePix F30</digitalCameraModelName>
-      <fNumber toolname="Jhove" toolversion="1.20.1">2.8</fNumber>
-      <exposureTime toolname="Jhove" toolversion="1.20.1" status="CONFLICT">0.008</exposureTime>
-      <exposureTime toolname="Exiftool" toolversion="11.54" status="CONFLICT">0.0083</exposureTime>
-      <isoSpeedRating toolname="Jhove" toolversion="1.20.1">400</isoSpeedRating>
-      <brightnessValue toolname="Jhove" toolversion="1.24.9" status="CONFLICT">302100</brightnessValue>
-      <brightnessValue toolname="Exiftool" toolversion="12.40" status="CONFLICT">3.02</brightnessValue>
-      <exposureBiasValue toolname="Jhove" toolversion="1.20.1">0</exposureBiasValue>
-      <lightSource toolname="Jhove" toolversion="1.20.1">unknown</lightSource>
-      <meteringMode toolname="Jhove" toolversion="1.20.1">Pattern</meteringMode>
-      <flash toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">Flash did not fire, compulsory flash mode</flash>
-      <focalLength toolname="Jhove" toolversion="1.20.1">8</focalLength>
-      <captureDevice toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">digital still camera</captureDevice>
-      <digitalCameraManufacturer toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">FUJIFILM</digitalCameraManufacturer>
-      <exposureProgram toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Normal program</exposureProgram>
-      <exifVersion toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">0221</exifVersion>
-      <shutterSpeedValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">1/124</shutterSpeedValue>
-      <apertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.8</apertureValue>
-      <maxApertureValue toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.8</maxApertureValue>
-      <sensingMethod toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">One-chip color area sensor</sensingMethod>
-      <gpsVersionID toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2.2.0.0</gpsVersionID>
-      <gpsLatitudeRef toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">N</gpsLatitudeRef>
-      <gpsLatitude toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">33 deg 24' 51.80" N</gpsLatitude>
-      <gpsLongitudeRef toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">E</gpsLongitudeRef>
-      <gpsLongitude toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">130 deg 33' 31.40" E</gpsLongitude>
-      <gpsTimeStamp toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">22:14:39</gpsTimeStamp>
-      <gpsStatus toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">A</gpsStatus>
-      <gpsMapDatum toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">WGS-84</gpsMapDatum>
-      <gpsDateStamp toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">2006-11-02</gpsDateStamp>
+      <byteOrder toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">big endian</byteOrder>
+      <compressionScheme toolname="Jhove" toolversion="1.26.1">JPEG</compressionScheme>
+      <imageWidth toolname="Jhove" toolversion="1.26.1">600</imageWidth>
+      <imageHeight toolname="Jhove" toolversion="1.26.1">800</imageHeight>
+      <colorSpace toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">YCbCr</colorSpace>
+      <YCbCrSubSampling toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2 2</YCbCrSubSampling>
+      <YCbCrPositioning toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2</YCbCrPositioning>
+      <orientation toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">normal*</orientation>
+      <samplingFrequencyUnit toolname="Jhove" toolversion="1.26.1">in.</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Exiftool" toolversion="12.50">72</xSamplingFrequency>
+      <ySamplingFrequency toolname="Exiftool" toolversion="12.50">72</ySamplingFrequency>
+      <bitsPerSample toolname="Jhove" toolversion="1.26.1">8 8 8</bitsPerSample>
+      <samplesPerPixel toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">3</samplesPerPixel>
+      <scanningSoftwareName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Digital Camera FinePix F30     Ver1.02</scanningSoftwareName>
+      <digitalCameraModelName toolname="Jhove" toolversion="1.26.1">FinePix F30</digitalCameraModelName>
+      <fNumber toolname="Jhove" toolversion="1.26.1">2.8</fNumber>
+      <exposureTime toolname="Jhove" toolversion="1.26.1" status="CONFLICT">0.008</exposureTime>
+      <exposureTime toolname="Exiftool" toolversion="12.50" status="CONFLICT">0.0083</exposureTime>
+      <isoSpeedRating toolname="Jhove" toolversion="1.26.1">400</isoSpeedRating>
+      <brightnessValue toolname="Jhove" toolversion="1.26.1" status="CONFLICT">302100</brightnessValue>
+      <brightnessValue toolname="Exiftool" toolversion="12.50" status="CONFLICT">3.02</brightnessValue>
+      <exposureBiasValue toolname="Jhove" toolversion="1.26.1">0</exposureBiasValue>
+      <lightSource toolname="Jhove" toolversion="1.26.1">unknown</lightSource>
+      <meteringMode toolname="Jhove" toolversion="1.26.1">Pattern</meteringMode>
+      <flash toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Flash did not fire, compulsory flash mode</flash>
+      <focalLength toolname="Jhove" toolversion="1.26.1">8</focalLength>
+      <captureDevice toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">digital still camera</captureDevice>
+      <digitalCameraManufacturer toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">FUJIFILM</digitalCameraManufacturer>
+      <exposureProgram toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Normal program</exposureProgram>
+      <exifVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">0221</exifVersion>
+      <shutterSpeedValue toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">1/124</shutterSpeedValue>
+      <apertureValue toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.8</apertureValue>
+      <maxApertureValue toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.8</maxApertureValue>
+      <sensingMethod toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">One-chip color area sensor</sensingMethod>
+      <gpsVersionID toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.2.0.0</gpsVersionID>
+      <gpsLatitudeRef toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">N</gpsLatitudeRef>
+      <gpsLatitude toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">33 deg 24' 51.80" N</gpsLatitude>
+      <gpsLongitudeRef toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">E</gpsLongitudeRef>
+      <gpsLongitude toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">130 deg 33' 31.40" E</gpsLongitude>
+      <gpsTimeStamp toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">22:14:39</gpsTimeStamp>
+      <gpsStatus toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">A</gpsStatus>
+      <gpsMapDatum toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">WGS-84</gpsMapDatum>
+      <gpsDateStamp toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2006-11-02</gpsDateStamp>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -210,22 +210,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="262">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="326">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="7" />
-    <tool toolname="Jhove" toolversion="1.20.1" executionTime="38" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="41" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="251" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="2" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="6" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="22" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="50" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="114" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="113" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="314" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="47" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="57" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="100" />
   </statistics>
 </fits>
-

--- a/testfiles/output/is_jpeg.jp2_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/is_jpeg.jp2_XmlUnitExpectedOutput.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="11/12/22, 9:17 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:04 AM">
   <identification status="CONFLICT">
     <identity format="JPEG File Interchange Format" mimetype="image/jpeg" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="Droid" toolversion="6.5.2" />
       <tool toolname="Jhove" toolversion="1.26.1" />
-      <tool toolname="file utility" toolversion="5.41" />
-      <tool toolname="Exiftool" toolversion="12.42" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <version toolname="Droid" toolversion="6.5.2">1.01</version>
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/43</externalIdentifier>
     </identity>
@@ -18,13 +18,13 @@
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/is_jpeg.jp2</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">is_jpeg.jp2</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">e18e7de3859dd8194f5d4c4763e413ad</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1668263538178</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187161</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.26.1" status="CONFLICT">true</well-formed>
     <well-formed toolname="jpylyzer" toolversion="2.1.0" status="CONFLICT">false</well-formed>
-    <valid toolname="Jhove" toolversion="1.26.1" status="CONFLICT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="CONFLICT">true</well-formed>
     <valid toolname="jpylyzer" toolversion="2.1.0" status="CONFLICT">false</valid>
+    <valid toolname="Jhove" toolversion="1.26.1" status="CONFLICT">true</valid>
   </filestatus>
   <metadata>
     <image>
@@ -33,10 +33,10 @@
       <imageWidth toolname="Jhove" toolversion="1.26.1">2717</imageWidth>
       <imageHeight toolname="Jhove" toolversion="1.26.1">3701</imageHeight>
       <colorSpace toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">YCbCr</colorSpace>
-      <YCbCrSubSampling toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">2 2</YCbCrSubSampling>
+      <YCbCrSubSampling toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2 2</YCbCrSubSampling>
       <samplingFrequencyUnit toolname="Jhove" toolversion="1.26.1">in.</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Exiftool" toolversion="12.42">72</xSamplingFrequency>
-      <ySamplingFrequency toolname="Exiftool" toolversion="12.42">72</ySamplingFrequency>
+      <xSamplingFrequency toolname="Exiftool" toolversion="12.50">72</xSamplingFrequency>
+      <ySamplingFrequency toolname="Exiftool" toolversion="12.50">72</ySamplingFrequency>
       <bitsPerSample toolname="Jhove" toolversion="1.26.1">8 8 8</bitsPerSample>
       <samplesPerPixel toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">3</samplesPerPixel>
       <standard>
@@ -91,21 +91,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="1548">
+  <statistics fitsExecutionTime="475">
     <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="22" />
-    <tool toolname="Jhove" toolversion="1.26.1" executionTime="149" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="136" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="285" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="244" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="71" />
-    <tool toolname="Exiftool" toolversion="12.42" executionTime="269" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="187" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="458" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="6" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="104" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="20" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="1522" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="136" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="127" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="317" />
   </statistics>
 </fits>

--- a/testfiles/output/multiple-file-types-and-folders.zip_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/multiple-file-types-and-folders.zip_XmlUnitExpectedOutput.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0-SNAPSHOT" timestamp="7/10/19 9:19 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:07 AM">
   <identification>
-    <identity format="ZIP Format" mimetype="application/zip" toolname="FITS" toolversion="1.5.0-SNAPSHOT">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="ZIP Format" mimetype="application/zip" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="file utility" toolversion="5.31">2.0</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">x-fmt/263</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="file utility" toolversion="5.43">2.0</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/263</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/multiple-file-types-and-folders.zip</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">multiple-file-types-and-folders.zip</filename>
-    <size toolname="OIS File Information" toolversion="0.2">2210087</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">48ab8c8077485276e99b7d0e58ccc2e8</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1554302812000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/multiple-file-types-and-folders.zip</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">multiple-file-types-and-folders.zip</filename>
+    <size toolname="OIS File Information" toolversion="1.0">2210087</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">48ab8c8077485276e99b7d0e58ccc2e8</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187174</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <container>
-      <originalSize toolname="Droid" toolversion="6.4" status="SINGLE_RESULT">2766149</originalSize>
-      <compressionMethod toolname="Droid" toolversion="6.4" status="SINGLE_RESULT">deflate</compressionMethod>
-      <entries totalEntries="15" toolname="Droid" toolversion="6.4" status="SINGLE_RESULT">
+      <originalSize toolname="Droid" toolversion="6.5.2" status="SINGLE_RESULT">2766149</originalSize>
+      <compressionMethod toolname="Droid" toolversion="6.5.2" status="SINGLE_RESULT">deflate</compressionMethod>
+      <entries totalEntries="15" toolname="Droid" toolversion="6.5.2" status="SINGLE_RESULT">
         <format name="Digital Negative (DNG)" number="1" />
         <format name="Markdown" number="1" />
         <format name="Portable Document Format" number="2" />
@@ -50,22 +50,21 @@
       </standard>
     </container>
   </metadata>
-  <statistics fitsExecutionTime="1012">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="1963">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="84" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="69" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="285" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="17" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="11" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="1008" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="169" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="132" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="579" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="108" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="88" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="1955" />
   </statistics>
 </fits>
-

--- a/testfiles/output/plain-text.txt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/plain-text.txt_XmlUnitExpectedOutput.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.3.0" timestamp="5/15/18 11:05 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
-    <identity format="Plain text" mimetype="text/plain" toolname="FITS" toolversion="1.3.0">
-      <tool toolname="Droid" toolversion="6.3" />
-      <tool toolname="Jhove" toolversion="1.20" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="12.29" />
-      <tool toolname="Tika" toolversion="2.2.1" />
-      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">x-fmt/111</externalIdentifier>
+    <identity format="Plain text" mimetype="text/plain" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/111</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.20">42</size>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/plain-text.txt</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">plain-text.txt</filename>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">b5b143e235cb5328a0f284679ed93a6e</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1526312227000</fslastmodified>
+    <size toolname="Jhove" toolversion="1.26.1">42</size>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/plain-text.txt</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">plain-text.txt</filename>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">b5b143e235cb5328a0f284679ed93a6e</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187174</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.20" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.20" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <text>
-      <linebreak toolname="Jhove" toolversion="1.20.1">LF</linebreak>
-      <charset toolname="Jhove" toolversion="1.20.1" status="CONFLICT">US-ASCII</charset>
-      <charset toolname="Tika" toolversion="2.3.0" status="CONFLICT">ISO-8859-1</charset>
-      <lineCount toolname="Exiftool" toolversion="12.40" status="SINGLE_RESULT">1</lineCount>
-      <wordCount toolname="Exiftool" toolversion="12.40" status="SINGLE_RESULT">7</wordCount>
+      <linebreak toolname="Jhove" toolversion="1.26.1">LF</linebreak>
+      <charset toolname="Jhove" toolversion="1.26.1" status="CONFLICT">US-ASCII</charset>
+      <charset toolname="Tika" toolversion="2.6.0" status="CONFLICT">ISO-8859-1</charset>
+      <lineCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">1</lineCount>
+      <wordCount toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">7</wordCount>
       <standard>
         <textMD:textMD xmlns:textMD="info:lc/xmlns/textMD-v3">
           <textMD:character_info>
@@ -38,22 +38,21 @@
       </standard>
     </text>
   </metadata>
-  <statistics fitsExecutionTime="1192">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="357">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.3" executionTime="146" />
-    <tool toolname="Jhove" toolversion="1.20" executionTime="1005" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="1173" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="950" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="141" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="949" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="257" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="177" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="226" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="98" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="307" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="29" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="55" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="350" />
   </statistics>
 </fits>
-

--- a/testfiles/output/random_data.csv_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/random_data.csv_XmlUnitExpectedOutput.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.11.0" timestamp="3/1/16 4:36 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
-    <identity format="Comma-Separated Values (CSV)" mimetype="text/csv" toolname="FITS" toolversion="0.11.0">
-      <tool toolname="Droid" toolversion="6.1.5" />
-      <tool toolname="Exiftool" toolversion="12.29" />
-      <externalIdentifier toolname="Droid" toolversion="6.1.5" type="puid">x-fmt/18</externalIdentifier>
+    <identity format="Comma-Separated Values (CSV)" mimetype="text/csv" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/18</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/random_data.csv</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">random_data.csv</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">78</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">faa6fe81db027422d3ed3895e4afa5cc</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1456866565000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/random_data.csv</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">random_data.csv</filename>
+    <size toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">78</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">faa6fe81db027422d3ed3895e4afa5cc</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187174</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <text>
-      <charset toolname="Exiftool" toolversion="12.29" status="SINGLE_RESULT">us-ascii</charset>
-      <linebreak toolname="Exiftool" toolversion="12.29" status="SINGLE_RESULT">CR</linebreak>
+      <charset toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">us-ascii</charset>
+      <linebreak toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">CR</linebreak>
       <standard>
         <textMD:textMD xmlns:textMD="info:lc/xmlns/textMD-v3">
           <textMD:character_info>
@@ -29,22 +29,21 @@
       </standard>
     </text>
   </metadata>
-  <statistics fitsExecutionTime="425">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="224">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="69" />
-    <tool toolname="Jhove" toolversion="1.11" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.04" status="did not run" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="414" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="72" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="295" />
-    <tool toolname="Tika" toolversion="1.10" status="did not run" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="21" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" status="did not run" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="217" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="24" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="38" />
+    <tool toolname="Tika" toolversion="2.6.0" status="did not run" />
   </statistics>
 </fits>
-

--- a/testfiles/output/reference.jp2_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/reference.jp2_XmlUnitExpectedOutput.xml
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="11/12/22, 9:17 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:04 AM">
   <identification>
     <identity format="JPEG 2000 JP2" mimetype="image/jp2" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="Jhove" toolversion="1.26.1" />
-      <tool toolname="file utility" toolversion="5.41" />
-      <tool toolname="Exiftool" toolversion="12.42" />
-      <tool toolname="Tika" toolversion="2.3.0" />
       <tool toolname="jpylyzer" toolversion="2.1.0" />
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/392</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
     <size toolname="Jhove" toolversion="1.26.1">670265</size>
-    <lastmodified toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">2008-07-19T16:14:14</lastmodified>
-    <created toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">2008-07-19T23:14:14Z</created>
+    <lastmodified toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2008-07-19T16:14:14</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2008-07-19T23:14:14Z</created>
     <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/reference.jp2</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">reference.jp2</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">e2e918578d2a25fc6a6f377e4082d634</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1668263430500</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187183</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.26.1" status="CONFLICT">false</well-formed>
     <well-formed toolname="jpylyzer" toolversion="2.1.0" status="CONFLICT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.26.1" status="CONFLICT">false</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="CONFLICT">false</well-formed>
     <valid toolname="jpylyzer" toolversion="2.1.0" status="CONFLICT">true</valid>
+    <valid toolname="Jhove" toolversion="1.26.1" status="CONFLICT">false</valid>
     <message toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Incorrect Box size for UUID List Box severity=error offset=95</message>
   </filestatus>
   <metadata>
     <image>
-      <compressionScheme toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">JPEG 2000</compressionScheme>
-      <imageWidth toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">2717</imageWidth>
-      <imageHeight toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">3701</imageHeight>
-      <colorSpace toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">sRGB</colorSpace>
-      <samplingFrequencyUnit toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">2</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">72</xSamplingFrequency>
-      <ySamplingFrequency toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">72</ySamplingFrequency>
-      <samplesPerPixel toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">4</samplesPerPixel>
-      <scanningSoftwareName toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">Adobe Photoshop CS3 Windows</scanningSoftwareName>
-      <bitsPerSample toolname="Exiftool" toolversion="12.42" status="SINGLE_RESULT">8</bitsPerSample>
+      <compressionScheme toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">JPEG 2000</compressionScheme>
+      <imageWidth toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2717</imageWidth>
+      <imageHeight toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">3701</imageHeight>
+      <colorSpace toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">sRGB</colorSpace>
+      <samplingFrequencyUnit toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">72</xSamplingFrequency>
+      <ySamplingFrequency toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">72</ySamplingFrequency>
+      <samplesPerPixel toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">4</samplesPerPixel>
+      <scanningSoftwareName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Adobe Photoshop CS3 Windows</scanningSoftwareName>
+      <bitsPerSample toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">8</bitsPerSample>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -88,21 +88,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="243">
+  <statistics fitsExecutionTime="464">
     <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="10" />
-    <tool toolname="Jhove" toolversion="1.26.1" executionTime="90" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="36" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="256" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="250" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="57" />
-    <tool toolname="Exiftool" toolversion="12.42" executionTime="230" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="137" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="417" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="5" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="25" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="11" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="134" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="104" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="77" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="61" />
   </statistics>
 </fits>

--- a/testfiles/output/sample.m4a_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/sample.m4a_XmlUnitExpectedOutput.xml
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.4.1-SNAPSHOT" timestamp="2/5/19 11:05 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:04 AM">
   <identification status="SINGLE_RESULT">
-    <identity format="MPEG-4 Audio" mimetype="audio/mp4" toolname="FITS" toolversion="1.4.1-SNAPSHOT">
-      <tool toolname="Exiftool" toolversion="11.14" />
+    <identity format="MPEG-4 Audio" mimetype="audio/mp4" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Exiftool" toolversion="12.50" />
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">0000:00:00 00:00:00</lastmodified>
-    <created toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">0000:00:00 00:00:00</created>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/sample.m4a</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">sample.m4a</filename>
-    <size toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">34535</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">ece7c8360447c620faf055b20279f483</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1549382585000</fslastmodified>
+    <lastmodified toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">0000:00:00 00:00:00</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">0000:00:00 00:00:00</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/sample.m4a</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">sample.m4a</filename>
+    <size toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">34535</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">ece7c8360447c620faf055b20279f483</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187184</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <audio>
-      <duration toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">3.41 s</duration>
-      <bitDepth toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">16</bitDepth>
-      <sampleRate toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">44100</sampleRate>
-      <channels toolname="Exiftool" toolversion="11.14" status="SINGLE_RESULT">2</channels>
+      <duration toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">3.41 s</duration>
+      <bitDepth toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">16</bitDepth>
+      <sampleRate toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">44100</sampleRate>
+      <channels toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2</channels>
       <standard>
-        <aes:audioObject xmlns:aes="http://www.aes.org/audioObject" xsi:schemaLocation="http://www.aes.org/audioObject http://www.aes.org/standards/schemas/aes57-2011-08-27.xsd" disposition="" schemaVersion="1.0.0" analogDigitalFlag="FILE_DIGITAL" ID="AUDIO_OBJECT_38694746-aa2d-425a-a54e-265fd0489bc0">
+        <aes:audioObject xmlns:aes="http://www.aes.org/audioObject" xsi:schemaLocation="http://www.aes.org/audioObject http://www.aes.org/standards/schemas/aes57-2011-08-27.xsd" disposition="" schemaVersion="1.0.0" analogDigitalFlag="FILE_DIGITAL" ID="AUDIO_OBJECT_c2bcfe7b-9249-40f0-a3f9-11025ca66106">
           <aes:format>MPEG-4 Audio</aes:format>
           <aes:use useType="OTHER" otherType="unknown" />
           <aes:primaryIdentifier identifierType="FILE_NAME">sample.m4a</aes:primaryIdentifier>
-          <aes:face audioObjectRef="AUDIO_OBJECT_38694746-aa2d-425a-a54e-265fd0489bc0" label="face 1" ID="FACE_0a4244fb-583d-46fa-a201-650d9bc1dfcc" direction="NONE">
+          <aes:face audioObjectRef="AUDIO_OBJECT_c2bcfe7b-9249-40f0-a3f9-11025ca66106" label="face 1" ID="FACE_0c4e3d87-4e9a-4c5b-abf0-bcf49d809777" direction="NONE">
             <aes:timeline>
               <aes:startTime editRate="1">0</aes:startTime>
               <aes:duration editRate="1">0</aes:duration>
             </aes:timeline>
-            <aes:region faceRef="FACE_0a4244fb-583d-46fa-a201-650d9bc1dfcc" formatRef="FORMAT_REGION_b946c7b7-f856-430d-9389-b9d7c8bfa31e" ID="REGION_b8d8bfc2-90c1-4632-9566-8d222339e902" label="region 1">
+            <aes:region faceRef="FACE_0c4e3d87-4e9a-4c5b-abf0-bcf49d809777" formatRef="FORMAT_REGION_29b850ec-e63a-41a8-85a5-b1607b4cfce1" ID="REGION_25b1a8b3-e3b0-44b8-bf8d-a8154655dce1" label="region 1">
               <aes:timeRange>
                 <aes:startTime editRate="1">0</aes:startTime>
                 <aes:duration editRate="1">0</aes:duration>
               </aes:timeRange>
               <aes:numChannels>2</aes:numChannels>
-              <aes:stream ID="STREAM_c4562d04-79ba-4f58-9251-406d8259f712" label="stream 0" faceRegionRef="REGION_b8d8bfc2-90c1-4632-9566-8d222339e902">
+              <aes:stream ID="STREAM_78944dfe-9d7d-44cc-a657-a98a80a85aa2" label="stream 0" faceRegionRef="REGION_25b1a8b3-e3b0-44b8-bf8d-a8154655dce1">
                 <aes:channelAssignment leftRightPosition="0.0" channelNum="0" frontRearPosition="0.0" />
               </aes:stream>
-              <aes:stream ID="STREAM_1edaadb9-4966-4048-a72e-cce462d79d95" label="stream 1" faceRegionRef="REGION_b8d8bfc2-90c1-4632-9566-8d222339e902">
+              <aes:stream ID="STREAM_304b7912-5c34-4090-aec9-fc24df3d08ec" label="stream 1" faceRegionRef="REGION_25b1a8b3-e3b0-44b8-bf8d-a8154655dce1">
                 <aes:channelAssignment leftRightPosition="0.0" channelNum="1" frontRearPosition="0.0" />
               </aes:stream>
             </aes:region>
           </aes:face>
           <aes:formatList>
-            <aes:formatRegion ownerRef="REGION_b8d8bfc2-90c1-4632-9566-8d222339e902" xsi:type="aes:formatRegionType" ID="FORMAT_REGION_b946c7b7-f856-430d-9389-b9d7c8bfa31e" label="format region 1">
+            <aes:formatRegion ownerRef="REGION_25b1a8b3-e3b0-44b8-bf8d-a8154655dce1" xsi:type="aes:formatRegionType" ID="FORMAT_REGION_29b850ec-e63a-41a8-85a5-b1607b4cfce1" label="format region 1">
               <aes:bitDepth>16</aes:bitDepth>
               <aes:sampleRate>44100.0</aes:sampleRate>
               <aes:soundField>STEREO</aes:soundField>
@@ -56,22 +56,21 @@
       </standard>
     </audio>
   </metadata>
-  <statistics fitsExecutionTime="696">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="338">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" status="did not run" />
-    <tool toolname="Jhove" toolversion="1.20.1" executionTime="679" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" status="did not run" />
-    <tool toolname="Exiftool" toolversion="11.14" executionTime="680" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="189" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="677" />
-    <tool toolname="Tika" toolversion="1.19.1" executionTime="268" />
+    <tool toolname="Droid" toolversion="6.5.2" status="did not run" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="205" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" status="did not run" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="332" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="30" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="64" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="303" />
   </statistics>
 </fits>
-

--- a/testfiles/output/samplepptx.pptx_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/samplepptx.pptx_XmlUnitExpectedOutput.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="8/11/21, 10:17 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Office Open XML Presentation" mimetype="application/vnd.openxmlformats-officedocument.presentationml.presentation" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.5" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="12.29" />
-      <tool toolname="Tika" toolversion="2.0.0" />
-      <version toolname="Droid" toolversion="6.5">2007 onwards</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/215</externalIdentifier>
+    <identity format="Office Open XML Presentation" mimetype="application/vnd.openxmlformats-officedocument.presentationml.presentation" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">2007 onwards</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/215</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <lastmodified toolname="Exiftool" toolversion="12.40">2009-05-06T22:13:30Z</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40">2009-05-06T22:06:09Z</created>
-    <creatingApplicationName toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">Microsoft Office PowerPoint</creatingApplicationName>
-    <creatingApplicationVersion toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">12.0000</creatingApplicationVersion>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/home/winckles/workspace/3rd-party/fits/testfiles/samplepptx.pptx</filepath>
+    <lastmodified toolname="Exiftool" toolversion="12.50">2009-05-06T22:13:30Z</lastmodified>
+    <created toolname="Exiftool" toolversion="12.50">2009-05-06T22:06:09Z</created>
+    <creatingApplicationName toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">Microsoft Office PowerPoint</creatingApplicationName>
+    <creatingApplicationVersion toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">12.0000</creatingApplicationVersion>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/samplepptx.pptx</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">samplepptx.pptx</filename>
     <size toolname="OIS File Information" toolversion="1.0">413895</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">72432c9fb76cf45094c29fc92c4b16f0</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1509024961000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187187</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <pageCount toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">2</pageCount>
-      <wordCount toolname="Exiftool" toolversion="12.29">30</wordCount>
-      <title toolname="Exiftool" toolversion="12.29">Sample PowerPoint File</title>
-      <author toolname="Exiftool" toolversion="12.29">James Falkofske</author>
-      <paragraphCount toolname="Exiftool" toolversion="12.29">5</paragraphCount>
+      <pageCount toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">2</pageCount>
+      <wordCount toolname="Exiftool" toolversion="12.50">30</wordCount>
+      <title toolname="Exiftool" toolversion="12.50">Sample PowerPoint File</title>
+      <author toolname="Exiftool" toolversion="12.50">James Falkofske</author>
+      <paragraphCount toolname="Exiftool" toolversion="12.50">5</paragraphCount>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:PageCount>2</docmd:PageCount>
@@ -38,22 +38,21 @@
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="1898">
-    <tool toolname="MediaInfo" toolversion="21.03" status="did not run" />
+  <statistics fitsExecutionTime="1462">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5" executionTime="258" />
-    <tool toolname="Jhove" toolversion="1.24.0" executionTime="1099" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="1122" />
-    <tool toolname="Exiftool" toolversion="12.29" executionTime="1110" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="212" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="1037" />
-    <tool toolname="Tika" toolversion="2.0.0" executionTime="1836" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="73" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="458" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="204" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="837" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="33" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="52" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="1413" />
   </statistics>
 </fits>
-

--- a/testfiles/output/signature_corrupted.jp2_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/signature_corrupted.jp2_XmlUnitExpectedOutput.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="11/12/22, 9:17 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:04 AM">
   <identification>
     <identity format="JPEG 2000 JP2" mimetype="image/jp2" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
-      <tool toolname="Tika" toolversion="2.3.0" />
       <tool toolname="jpylyzer" toolversion="2.1.0" />
+      <tool toolname="Tika" toolversion="2.6.0" />
     </identity>
   </identification>
   <fileinfo>
@@ -11,28 +11,28 @@
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">signature_corrupted.jp2</filename>
     <size toolname="OIS File Information" toolversion="1.0">670265</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">700433e776859a8ceed3923c766d0f08</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1668263435491</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187189</fslastmodified>
   </fileinfo>
   <filestatus>
     <well-formed toolname="jpylyzer" toolversion="2.1.0" status="SINGLE_RESULT">false</well-formed>
     <valid toolname="jpylyzer" toolversion="2.1.0" status="SINGLE_RESULT">false</valid>
   </filestatus>
   <metadata />
-  <statistics fitsExecutionTime="618">
+  <statistics fitsExecutionTime="692">
     <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="59" />
-    <tool toolname="Jhove" toolversion="1.26.1" executionTime="598" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="256" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="241" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="680" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="542" />
-    <tool toolname="Exiftool" toolversion="12.42" executionTime="518" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="172" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="465" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="58" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="56" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="476" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="268" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="472" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="74" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="337" />
   </statistics>
 </fits>

--- a/testfiles/output/simple_webvtt.vtt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/simple_webvtt.vtt_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="7/14/22, 4:05 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:06 AM">
   <identification>
     <identity format="WebVTT" mimetype="text/vtt" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="VTT Tool" toolversion="0.1" />
@@ -9,20 +9,20 @@
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.26.0">488</size>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/simple_webvtt.vtt</filepath>
+    <size toolname="Jhove" toolversion="1.26.1">488</size>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/simple_webvtt.vtt</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">simple_webvtt.vtt</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">6fd0c9caa00b08305344cc42244666af</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1457973381000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187189</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <text>
-      <linebreak toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">LF</linebreak>
-      <charset toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">US-ASCII</charset>
+      <linebreak toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">LF</linebreak>
+      <charset toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">US-ASCII</charset>
       <standard>
         <textMD:textMD xmlns:textMD="info:lc/xmlns/textMD-v3">
           <textMD:character_info>
@@ -33,22 +33,21 @@
       </standard>
     </text>
   </metadata>
-  <statistics fitsExecutionTime="159">
-    <tool toolname="MediaInfo" toolversion="21.09" status="did not run" />
+  <statistics fitsExecutionTime="166">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="VTT Tool" toolversion="0.1" executionTime="22" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="126" />
-    <tool toolname="Jhove" toolversion="1.26.0" executionTime="155" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="90" />
-    <tool toolname="Exiftool" toolversion="12.40" status="did not run" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="23" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="59" />
-    <tool toolname="Tika" toolversion="2.3.0" status="did not run" />
+    <tool toolname="VTT Tool" toolversion="0.1" executionTime="17" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="136" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="161" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="69" />
+    <tool toolname="Exiftool" toolversion="12.50" status="did not run" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="19" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="54" />
+    <tool toolname="Tika" toolversion="2.6.0" status="did not run" />
   </statistics>
 </fits>
-

--- a/testfiles/output/test.flac_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/test.flac_XmlUnitExpectedOutput.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="12/21/22, 1:05 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:01 AM">
   <identification status="CONFLICT">
     <identity format="Free Lossless Audio Codec" mimetype="audio/x-flac" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="Droid" toolversion="6.5.2" />
@@ -17,7 +17,7 @@
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">test.flac</filename>
     <size toolname="OIS File Information" toolversion="1.0">1053366</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">4cb69c7c0902b0ac3223bc6f46ca62d4</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1671645291070</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187195</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
@@ -30,31 +30,31 @@
       <blockSizeMin toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">4608</blockSizeMin>
       <blockSizeMax toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">4608</blockSizeMax>
       <standard>
-        <aes:audioObject xmlns:aes="http://www.aes.org/audioObject" xsi:schemaLocation="http://www.aes.org/audioObject http://www.aes.org/standards/schemas/aes57-2011-08-27.xsd" disposition="" schemaVersion="1.0.0" analogDigitalFlag="FILE_DIGITAL" ID="AUDIO_OBJECT_b0fa20a1-e789-4e8d-b7e2-2602f7a44e03">
+        <aes:audioObject xmlns:aes="http://www.aes.org/audioObject" xsi:schemaLocation="http://www.aes.org/audioObject http://www.aes.org/standards/schemas/aes57-2011-08-27.xsd" disposition="" schemaVersion="1.0.0" analogDigitalFlag="FILE_DIGITAL" ID="AUDIO_OBJECT_e782b272-3c70-4bad-a9c3-558ee017fe63">
           <aes:format specificationVersion="1.2.1">Free Lossless Audio Codec</aes:format>
           <aes:use useType="OTHER" otherType="unknown" />
           <aes:primaryIdentifier identifierType="FILE_NAME">test.flac</aes:primaryIdentifier>
-          <aes:face audioObjectRef="AUDIO_OBJECT_b0fa20a1-e789-4e8d-b7e2-2602f7a44e03" label="face 1" ID="FACE_4a38c8c0-4bb1-435e-aa9f-621412f451a4" direction="NONE">
+          <aes:face audioObjectRef="AUDIO_OBJECT_e782b272-3c70-4bad-a9c3-558ee017fe63" label="face 1" ID="FACE_2191eed8-d827-41a2-a8ea-4920917bbd01" direction="NONE">
             <aes:timeline>
               <aes:startTime editRate="1">0</aes:startTime>
               <aes:duration editRate="44100">411840</aes:duration>
             </aes:timeline>
-            <aes:region faceRef="FACE_4a38c8c0-4bb1-435e-aa9f-621412f451a4" formatRef="FORMAT_REGION_0102af37-1caa-4c68-bcc4-f71f145a777c" ID="REGION_c7fc2205-96f2-46b7-a42d-76205f2b2d51" label="region 1">
+            <aes:region faceRef="FACE_2191eed8-d827-41a2-a8ea-4920917bbd01" formatRef="FORMAT_REGION_e0863ccd-93cd-4831-a62a-fbcfea27335d" ID="REGION_0e0aaa2c-3605-4796-9357-b0d0283bb194" label="region 1">
               <aes:timeRange>
                 <aes:startTime editRate="1">0</aes:startTime>
                 <aes:duration editRate="44100">411840</aes:duration>
               </aes:timeRange>
               <aes:numChannels>2</aes:numChannels>
-              <aes:stream ID="STREAM_bb1676fd-dc70-4bb5-a3dd-f588ee29d882" label="stream 0" faceRegionRef="REGION_c7fc2205-96f2-46b7-a42d-76205f2b2d51">
+              <aes:stream ID="STREAM_1a382b53-7107-42db-8a5e-621ddf2304f4" label="stream 0" faceRegionRef="REGION_0e0aaa2c-3605-4796-9357-b0d0283bb194">
                 <aes:channelAssignment leftRightPosition="0.0" channelNum="0" frontRearPosition="0.0" />
               </aes:stream>
-              <aes:stream ID="STREAM_b01a326b-1e3f-4ae0-94f7-f89d8352c66a" label="stream 1" faceRegionRef="REGION_c7fc2205-96f2-46b7-a42d-76205f2b2d51">
+              <aes:stream ID="STREAM_836da22c-9a01-401b-b218-8890d2315046" label="stream 1" faceRegionRef="REGION_0e0aaa2c-3605-4796-9357-b0d0283bb194">
                 <aes:channelAssignment leftRightPosition="0.0" channelNum="1" frontRearPosition="0.0" />
               </aes:stream>
             </aes:region>
           </aes:face>
           <aes:formatList>
-            <aes:formatRegion ownerRef="REGION_c7fc2205-96f2-46b7-a42d-76205f2b2d51" xsi:type="aes:formatRegionType" ID="FORMAT_REGION_0102af37-1caa-4c68-bcc4-f71f145a777c" label="format region 1">
+            <aes:formatRegion ownerRef="REGION_0e0aaa2c-3605-4796-9357-b0d0283bb194" xsi:type="aes:formatRegionType" ID="FORMAT_REGION_e0863ccd-93cd-4831-a62a-fbcfea27335d" label="format region 1">
               <aes:bitDepth>16</aes:bitDepth>
               <aes:sampleRate>44100.0</aes:sampleRate>
               <aes:soundField>STEREO</aes:soundField>
@@ -64,21 +64,21 @@
       </standard>
     </audio>
   </metadata>
-  <statistics fitsExecutionTime="629">
+  <statistics fitsExecutionTime="1580">
     <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="51" />
-    <tool toolname="Jhove" toolversion="1.26.1" executionTime="608" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.43" executionTime="362" />
-    <tool toolname="Exiftool" toolversion="12.50" executionTime="363" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="186" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="50" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="324" />
-    <tool toolname="Tika" toolversion="2.6.0" executionTime="105" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="291" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="1569" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="270" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="602" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="934" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="62" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="82" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="996" />
   </statistics>
 </fits>

--- a/testfiles/output/test.jp2_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/test.jp2_XmlUnitExpectedOutput.xml
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="12/6/21 3:32 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
-    <identity format="JPEG 2000 JP2" mimetype="image/jp2" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="Jhove" toolversion="1.20.1" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="11.54" />
-      <tool toolname="Tika" toolversion="1.21" />
+    <identity format="JPEG 2000 JP2" mimetype="image/jp2" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
       <tool toolname="jpylyzer" toolversion="2.1.0" />
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">x-fmt/392</externalIdentifier>
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/392</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.20.1">253214</size>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Photostation v1</creatingApplicationName>
-    <created toolname="Exiftool" toolversion="12.40" status="SINGLE_RESULT">2007-09-20T16:00:00Z</created>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/test.jp2</filepath>
+    <size toolname="Jhove" toolversion="1.26.1">253214</size>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Photostation v1</creatingApplicationName>
+    <created toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2007-09-20T16:00:00Z</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/test.jp2</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">test.jp2</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">a9f2c77997e438c97639ad3a843f4fdb</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1446674963000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187197</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.20.1">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.20.1">true</valid>
+    <well-formed toolname="jpylyzer" toolversion="2.1.0">true</well-formed>
+    <valid toolname="jpylyzer" toolversion="2.1.0">true</valid>
   </filestatus>
   <metadata>
     <image>
-      <byteOrder toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">big endian</byteOrder>
-      <compressionScheme toolname="Jhove" toolversion="1.20.1" status="CONFLICT">JPEG 2000 Lossy</compressionScheme>
-      <compressionScheme toolname="Exiftool" toolversion="11.54" status="CONFLICT">JPEG 2000</compressionScheme>
-      <imageWidth toolname="Jhove" toolversion="1.20.1">1542</imageWidth>
-      <imageHeight toolname="Jhove" toolversion="1.20.1">2464</imageHeight>
-      <colorSpace toolname="Jhove" toolversion="1.20.1">sRGB</colorSpace>
-      <tileWidth toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">1024</tileWidth>
-      <tileHeight toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">1024</tileHeight>
-      <qualityLayers toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">8</qualityLayers>
-      <resolutionLevels toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">5</resolutionLevels>
-      <orientation toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">normal*</orientation>
-      <samplingFrequencyUnit toolname="Jhove" toolversion="1.20.1" status="CONFLICT">cm</samplingFrequencyUnit>
-      <samplingFrequencyUnit toolname="Exiftool" toolversion="11.54" status="CONFLICT">0.1 mm</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Jhove" toolversion="1.20.1" status="CONFLICT">118</xSamplingFrequency>
-      <xSamplingFrequency toolname="Exiftool" toolversion="11.54" status="CONFLICT">1.181102</xSamplingFrequency>
-      <ySamplingFrequency toolname="Jhove" toolversion="1.20.1" status="CONFLICT">118</ySamplingFrequency>
-      <ySamplingFrequency toolname="Exiftool" toolversion="11.54" status="CONFLICT">1.181102</ySamplingFrequency>
-      <bitsPerSample toolname="Jhove" toolversion="1.20.1">8 8 8</bitsPerSample>
-      <samplesPerPixel toolname="Jhove" toolversion="1.20.1">3</samplesPerPixel>
-      <scannerManufacturer toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Google</scannerManufacturer>
-      <scannerModelName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Photostation v1</scannerModelName>
+      <byteOrder toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">big endian</byteOrder>
+      <compressionScheme toolname="Jhove" toolversion="1.26.1" status="CONFLICT">JPEG 2000 Lossy</compressionScheme>
+      <compressionScheme toolname="Exiftool" toolversion="12.50" status="CONFLICT">JPEG 2000</compressionScheme>
+      <imageWidth toolname="Jhove" toolversion="1.26.1">1542</imageWidth>
+      <imageHeight toolname="Jhove" toolversion="1.26.1">2464</imageHeight>
+      <colorSpace toolname="Jhove" toolversion="1.26.1">sRGB</colorSpace>
+      <tileWidth toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">1024</tileWidth>
+      <tileHeight toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">1024</tileHeight>
+      <qualityLayers toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">8</qualityLayers>
+      <resolutionLevels toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">5</resolutionLevels>
+      <orientation toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">normal*</orientation>
+      <samplingFrequencyUnit toolname="Jhove" toolversion="1.26.1" status="CONFLICT">cm</samplingFrequencyUnit>
+      <samplingFrequencyUnit toolname="Exiftool" toolversion="12.50" status="CONFLICT">0.1 mm</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Jhove" toolversion="1.26.1" status="CONFLICT">118</xSamplingFrequency>
+      <xSamplingFrequency toolname="Exiftool" toolversion="12.50" status="CONFLICT">1.181102</xSamplingFrequency>
+      <ySamplingFrequency toolname="Jhove" toolversion="1.26.1" status="CONFLICT">118</ySamplingFrequency>
+      <ySamplingFrequency toolname="Exiftool" toolversion="12.50" status="CONFLICT">1.181102</ySamplingFrequency>
+      <bitsPerSample toolname="Jhove" toolversion="1.26.1">8 8 8</bitsPerSample>
+      <samplesPerPixel toolname="Jhove" toolversion="1.26.1">3</samplesPerPixel>
+      <scannerManufacturer toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Google</scannerManufacturer>
+      <scannerModelName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Photostation v1</scannerModelName>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -114,22 +114,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="452">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="576">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="11" />
-    <tool toolname="Jhove" toolversion="1.20.1" executionTime="107" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="54" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="410" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="411" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="61" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="441" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="175" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="555" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="7" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="21" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="5" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="34" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" executionTime="63" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="47" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="53" />
   </statistics>
 </fits>
-

--- a/testfiles/output/test.wav-default_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/test.wav-default_XmlUnitExpectedOutput.xml
@@ -1,58 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.1.0" timestamp="4/6/17 12:11 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Waveform Audio" mimetype="audio/x-wave" toolname="FITS" toolversion="1.1.0">
+    <identity format="Waveform Audio" mimetype="audio/x-wave" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="OIS Audio Information" toolversion="0.1" />
-      <tool toolname="Droid" toolversion="6.1.5" />
-      <tool toolname="Jhove" toolversion="1.16" />
-      <tool toolname="file utility" toolversion="5.04" />
-      <tool toolname="Exiftool" toolversion="10.00" />
-      <version toolname="Droid" toolversion="6.1.5">0 PCM Encoding</version>
-      <externalIdentifier toolname="Droid" toolversion="6.1.5" type="puid">fmt/703</externalIdentifier>
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <version toolname="Droid" toolversion="6.5.2">0 PCM Encoding</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/703</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.16">898136</size>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/test.wav</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">test.wav</filename>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1446674963000</fslastmodified>
+    <size toolname="Jhove" toolversion="1.26.1">898136</size>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/test.wav</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">test.wav</filename>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187202</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <audio>
       <numSamples toolname="OIS Audio Information" toolversion="0.1" status="SINGLE_RESULT">299159</numSamples>
       <sampleRate toolname="OIS Audio Information" toolversion="0.1">96000</sampleRate>
       <audioDataEncoding toolname="OIS Audio Information" toolversion="0.1" status="CONFLICT">PCM</audioDataEncoding>
-      <audioDataEncoding toolname="Jhove" toolversion="1.16" status="CONFLICT">PCM audio in integer format</audioDataEncoding>
-      <audioDataEncoding toolname="Exiftool" toolversion="10.00" status="CONFLICT">Microsoft PCM</audioDataEncoding>
+      <audioDataEncoding toolname="Jhove" toolversion="1.26.1" status="CONFLICT">PCM audio in integer format</audioDataEncoding>
+      <audioDataEncoding toolname="Exiftool" toolversion="12.50" status="CONFLICT">Microsoft PCM</audioDataEncoding>
       <blockAlign toolname="OIS Audio Information" toolversion="0.1" status="SINGLE_RESULT">3</blockAlign>
       <time toolname="OIS Audio Information" toolversion="0.1" status="SINGLE_RESULT">458028579</time>
       <channels toolname="OIS Audio Information" toolversion="0.1">1</channels>
       <bitDepth toolname="OIS Audio Information" toolversion="0.1">24</bitDepth>
       <wordSize toolname="OIS Audio Information" toolversion="0.1" status="SINGLE_RESULT">3</wordSize>
       <offset toolname="OIS Audio Information" toolversion="0.1">46</offset>
-      <byteOrder toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">LITTLE_ENDIAN</byteOrder>
-      <duration toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">3.12 s</duration>
+      <byteOrder toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">LITTLE_ENDIAN</byteOrder>
+      <duration toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">3.12 s</duration>
     </audio>
   </metadata>
-  <statistics fitsExecutionTime="477">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
-    <tool toolname="OIS Audio Information" toolversion="0.1" executionTime="172" />
+  <statistics fitsExecutionTime="675">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
+    <tool toolname="OIS Audio Information" toolversion="0.1" executionTime="261" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="266" />
-    <tool toolname="Jhove" toolversion="1.16" executionTime="443" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="414" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="432" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="167" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="408" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="247" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="374" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="326" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="273" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="657" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="65" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="132" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="527" />
   </statistics>
 </fits>
-

--- a/testfiles/output/test.xml_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/test.xml_XmlUnitExpectedOutput.xml
@@ -39,6 +39,7 @@
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
     <tool toolname="Droid" toolversion="6.3" executionTime="270" />
+    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
     <tool toolname="Jhove" toolversion="1.20" executionTime="1386" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.31" executionTime="613" />
@@ -48,7 +49,6 @@
     <tool toolname="OIS XML Metadata" toolversion="0.2" executionTime="261" />
     <tool toolname="ffident" toolversion="0.2" executionTime="586" />
     <tool toolname="Tika" toolversion="1.10" executionTime="438" />
-    <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
   </statistics>
 </fits>
 

--- a/testfiles/output/testchunk.wav-default_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/testchunk.wav-default_XmlUnitExpectedOutput.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.2-SNAPSHOT" timestamp="3/22/22, 10:20 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Waveform Audio" mimetype="audio/x-wave" toolname="FITS" toolversion="1.5.2-SNAPSHOT">
+    <identity format="Waveform Audio" mimetype="audio/x-wave" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="OIS Audio Information" toolversion="0.1" />
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="Jhove" toolversion="1.24.9" />
-      <tool toolname="file utility" toolversion="5.41" />
-      <tool toolname="Exiftool" toolversion="12.40" />
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <version toolname="Droid" toolversion="6.5.2">2 PCM Encoding</version>
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/705</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.24.9">3986952</size>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/testchunk.wav</filepath>
+    <size toolname="Jhove" toolversion="1.26.1">3986952</size>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/testchunk.wav</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">testchunk.wav</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">2f3b3492bcce357f62f3ebee17f47830</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1443207946000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187238</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.24.9" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.24.9" status="SINGLE_RESULT">true</valid>
-    <message toolname="Jhove" toolversion="1.24.9" status="SINGLE_RESULT">Ignored unrecognized chunk: "FLLR" severity=info offset=902</message>
-    <message toolname="Jhove" toolversion="1.24.9" status="SINGLE_RESULT">Ignored unrecognized chunk: "MD5 " severity=info offset=3986302</message>
-    <message toolname="Jhove" toolversion="1.24.9" status="SINGLE_RESULT">Ignored unrecognized chunk: "axml" severity=info offset=3986358</message>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
+    <message toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Ignored unrecognized chunk: "FLLR" severity=info offset=902</message>
+    <message toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Ignored unrecognized chunk: "MD5 " severity=info offset=3986302</message>
+    <message toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">Ignored unrecognized chunk: "axml" severity=info offset=3986358</message>
   </filestatus>
   <metadata>
     <audio>
       <numSamples toolname="OIS Audio Information" toolversion="0.1" status="SINGLE_RESULT">1323000</numSamples>
       <sampleRate toolname="OIS Audio Information" toolversion="0.1">44100</sampleRate>
       <audioDataEncoding toolname="OIS Audio Information" toolversion="0.1" status="CONFLICT">PCM</audioDataEncoding>
-      <audioDataEncoding toolname="Jhove" toolversion="1.20" status="CONFLICT">PCM audio in integer format</audioDataEncoding>
-      <audioDataEncoding toolname="Exiftool" toolversion="10.00" status="CONFLICT">Microsoft PCM</audioDataEncoding>
+      <audioDataEncoding toolname="Jhove" toolversion="1.26.1" status="CONFLICT">PCM audio in integer format</audioDataEncoding>
+      <audioDataEncoding toolname="Exiftool" toolversion="12.50" status="CONFLICT">Microsoft PCM</audioDataEncoding>
       <blockAlign toolname="OIS Audio Information" toolversion="0.1" status="SINGLE_RESULT">3</blockAlign>
       <time toolname="OIS Audio Information" toolversion="0.1" status="SINGLE_RESULT">0</time>
       <channels toolname="OIS Audio Information" toolversion="0.1">1</channels>
       <bitDepth toolname="OIS Audio Information" toolversion="0.1">24</bitDepth>
       <wordSize toolname="OIS Audio Information" toolversion="0.1" status="SINGLE_RESULT">3</wordSize>
       <offset toolname="OIS Audio Information" toolversion="0.1">17302</offset>
-      <byteOrder toolname="Jhove" toolversion="1.24.9" status="SINGLE_RESULT">LITTLE_ENDIAN</byteOrder>
-      <duration toolname="Exiftool" toolversion="12.40" status="SINGLE_RESULT">0:00:30</duration>
+      <byteOrder toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">LITTLE_ENDIAN</byteOrder>
+      <duration toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">0:00:30</duration>
     </audio>
   </metadata>
-  <statistics fitsExecutionTime="563">
-    <tool toolname="MediaInfo" toolversion="21.09" status="did not run" />
-    <tool toolname="OIS Audio Information" toolversion="0.1" executionTime="44" />
+  <statistics fitsExecutionTime="456">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
+    <tool toolname="OIS Audio Information" toolversion="0.1" executionTime="59" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5.2" executionTime="466" />
-    <tool toolname="Jhove" toolversion="1.24.9" executionTime="365" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.41" executionTime="178" />
-    <tool toolname="Exiftool" toolversion="12.40" executionTime="547" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="75" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="140" />
-    <tool toolname="Tika" toolversion="2.3.0" executionTime="499" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="281" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="266" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="273" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="411" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="120" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="82" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="72" />
   </statistics>
 </fits>

--- a/testfiles/output/topazscanner.tif_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/topazscanner.tif_XmlUnitExpectedOutput.xml
@@ -1,50 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="6/11/22, 9:41 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
     <identity format="Tagged Image File Format" mimetype="image/tiff" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
       <tool toolname="Droid" toolversion="6.5.2" />
-      <tool toolname="Jhove" toolversion="1.26.0" />
-      <tool toolname="Exiftool" toolversion="12.40" />
+      <tool toolname="Jhove" toolversion="1.26.1" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="2.3.0" />
-      <version toolname="Jhove" toolversion="1.26.0">6.0</version>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Jhove" toolversion="1.26.1">6.0</version>
       <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/353</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.20.1">5146108</size>
-    <creatingApplicationName toolname="Exiftool" toolversion="11.54" status="SINGLE_RESULT">Adobe Photoshop CS Macintosh</creatingApplicationName>
+    <size toolname="Jhove" toolversion="1.26.1">5146108</size>
+    <creatingApplicationName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">Adobe Photoshop CS Macintosh</creatingApplicationName>
     <lastmodified toolname="Exiftool" toolversion="12.50">2006-11-28T13:30:06</lastmodified>
-    <created toolname="Exiftool" toolversion="12.40" status="CONFLICT">2006-11-28T17:22:59Z</created>
-    <created toolname="Tika" toolversion="2.3.0" status="CONFLICT">2006-11-28T13:30:06</created>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/topazscanner.tif</filepath>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">2006-11-28T17:22:59Z</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">2006-11-28T13:30:06</created>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/topazscanner.tif</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">topazscanner.tif</filename>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">c2c36f561b1da65ff74ea2b22fe3fba0</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1446674963000</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187284</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.20.1" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <image>
-      <byteOrder toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">big endian</byteOrder>
-      <compressionScheme toolname="Jhove" toolversion="1.26.0">Uncompressed</compressionScheme>
-      <imageWidth toolname="Jhove" toolversion="1.26.0">1060</imageWidth>
-      <imageHeight toolname="Jhove" toolversion="1.26.0">1611</imageHeight>
-      <colorSpace toolname="Jhove" toolversion="1.26.0">RGB</colorSpace>
-      <referenceBlackWhite toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">0 255 0 255 0 255</referenceBlackWhite>
-      <iccProfileName toolname="Jhove" toolversion="1.26.0">Adobe RGB (1998)</iccProfileName>
-      <orientation toolname="Jhove" toolversion="1.26.0" status="SINGLE_RESULT">normal*</orientation>
-      <samplingFrequencyUnit toolname="Jhove" toolversion="1.26.0">in.</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Jhove" toolversion="1.26.0">1200</xSamplingFrequency>
-      <ySamplingFrequency toolname="Jhove" toolversion="1.26.0">1200</ySamplingFrequency>
-      <bitsPerSample toolname="Jhove" toolversion="1.26.0">8 8 8</bitsPerSample>
-      <samplesPerPixel toolname="Jhove" toolversion="1.26.0">3</samplesPerPixel>
-      <scanningSoftwareName toolname="Jhove" toolversion="1.26.0">Adobe Photoshop CS Macintosh</scanningSoftwareName>
-      <iccProfileVersion toolname="Exiftool" toolversion="12.40" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
-      <scannerManufacturer toolname="Exiftool" toolversion="12.40" status="SINGLE_RESULT">HDPPKIEL</scannerManufacturer>
-      <scannerModelName toolname="Exiftool" toolversion="12.40" status="SINGLE_RESULT">TOPAZ iX Scanner</scannerModelName>
+      <byteOrder toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">big endian</byteOrder>
+      <compressionScheme toolname="Jhove" toolversion="1.26.1">Uncompressed</compressionScheme>
+      <imageWidth toolname="Jhove" toolversion="1.26.1">1060</imageWidth>
+      <imageHeight toolname="Jhove" toolversion="1.26.1">1611</imageHeight>
+      <colorSpace toolname="Jhove" toolversion="1.26.1">RGB</colorSpace>
+      <referenceBlackWhite toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">0 255 0 255 0 255</referenceBlackWhite>
+      <iccProfileName toolname="Jhove" toolversion="1.26.1">Adobe RGB (1998)</iccProfileName>
+      <orientation toolname="Jhove" toolversion="1.26.1" status="SINGLE_RESULT">normal*</orientation>
+      <samplingFrequencyUnit toolname="Jhove" toolversion="1.26.1">in.</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Jhove" toolversion="1.26.1">1200</xSamplingFrequency>
+      <ySamplingFrequency toolname="Jhove" toolversion="1.26.1">1200</ySamplingFrequency>
+      <bitsPerSample toolname="Jhove" toolversion="1.26.1">8 8 8</bitsPerSample>
+      <samplesPerPixel toolname="Jhove" toolversion="1.26.1">3</samplesPerPixel>
+      <scanningSoftwareName toolname="Jhove" toolversion="1.26.1">Adobe Photoshop CS Macintosh</scanningSoftwareName>
+      <iccProfileVersion toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
+      <scannerManufacturer toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">HDPPKIEL</scannerManufacturer>
+      <scannerModelName toolname="Exiftool" toolversion="12.50" status="SINGLE_RESULT">TOPAZ iX Scanner</scannerModelName>
       <standard>
         <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
           <mix:BasicDigitalObjectInformation>
@@ -144,22 +144,21 @@
       </standard>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="321">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="495">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="142" />
-    <tool toolname="Jhove" toolversion="1.20.1" executionTime="315" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="46" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="275" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="48" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="6" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="100" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="334" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="482" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="220" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="465" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="190" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="74" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="150" />
   </statistics>
 </fits>
-

--- a/testfiles/output/uncompressed-encrypted.zip_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/uncompressed-encrypted.zip_XmlUnitExpectedOutput.xml
@@ -1,41 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0-SNAPSHOT" timestamp="7/10/19 9:19 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:07 AM">
   <identification>
-    <identity format="ZIP Format" mimetype="application/zip" toolname="FITS" toolversion="1.5.0-SNAPSHOT">
-      <tool toolname="Droid" toolversion="6.4" />
-      <tool toolname="file utility" toolversion="5.31" />
-      <tool toolname="Exiftool" toolversion="11.54" />
+    <identity format="ZIP Format" mimetype="application/zip" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.21" />
-      <version toolname="file utility" toolversion="5.31">1.0</version>
-      <externalIdentifier toolname="Droid" toolversion="6.4" type="puid">x-fmt/263</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="file utility" toolversion="5.43">1.0</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/263</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/git-daveneiman/fits/testfiles/uncompressed-encrypted.zip</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">uncompressed-encrypted.zip</filename>
-    <size toolname="OIS File Information" toolversion="0.2">18851920</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">794d9bfc7a6743dbde2c04919136e152</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1516117984000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/uncompressed-encrypted.zip</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">uncompressed-encrypted.zip</filename>
+    <size toolname="OIS File Information" toolversion="1.0">18851920</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">794d9bfc7a6743dbde2c04919136e152</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187391</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata />
-  <statistics fitsExecutionTime="265">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="600">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.4" executionTime="92" />
-    <tool toolname="Jhove" toolversion="1.20.1" status="did not run" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.31" executionTime="117" />
-    <tool toolname="Exiftool" toolversion="11.54" executionTime="258" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="93" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="19" />
-    <tool toolname="Tika" toolversion="1.21" executionTime="54" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="595" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="195" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="553" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="385" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="71" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="124" />
   </statistics>
 </fits>
-

--- a/testfiles/output/utf16.txt_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/utf16.txt_XmlUnitExpectedOutput.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.11.0" timestamp="3/1/16 4:39 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:05 AM">
   <identification>
-    <identity format="Plain text" mimetype="text/plain" toolname="FITS" toolversion="0.11.0">
-      <tool toolname="Droid" toolversion="6.1.5" />
-      <tool toolname="file utility" toolversion="5.04" />
-      <tool toolname="Exiftool" toolversion="12.29" />
-      <tool toolname="Tika" toolversion="2.2.1" />
-      <externalIdentifier toolname="Droid" toolversion="6.1.5" type="puid">x-fmt/111</externalIdentifier>
+    <identity format="Plain text" mimetype="text/plain" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">x-fmt/111</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dan179/git/fits-daveneiman/fits/testfiles/utf16.txt</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">utf16.txt</filename>
-    <size toolname="OIS File Information" toolversion="0.2">30</size>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">fbb8ef84677fad5a798cef6cf69aef1d</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1446674963000</fslastmodified>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/utf16.txt</filepath>
+    <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">utf16.txt</filename>
+    <size toolname="OIS File Information" toolversion="1.0">30</size>
+    <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">fbb8ef84677fad5a798cef6cf69aef1d</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187394</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <text>
-      <charset toolname="file utility" toolversion="5.04">UTF-16LE</charset>
+      <charset toolname="file utility" toolversion="5.43">UTF-16LE</charset>
       <standard>
         <textMD:textMD xmlns:textMD="info:lc/xmlns/textMD-v3">
           <textMD:character_info>
@@ -29,22 +29,21 @@
       </standard>
     </text>
   </metadata>
-  <statistics fitsExecutionTime="524">
-    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
+  <statistics fitsExecutionTime="285">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.1.5" executionTime="24" />
-    <tool toolname="Jhove" toolversion="1.11" executionTime="205" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="142" />
-    <tool toolname="Exiftool" toolversion="10.00" executionTime="278" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="90" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="279" />
-    <tool toolname="Tika" toolversion="1.10" executionTime="172" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="28" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="112" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="128" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="278" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="44" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="57" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="61" />
   </statistics>
 </fits>
-

--- a/testfiles/output/valid.xls_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/valid.xls_XmlUnitExpectedOutput.xml
@@ -1,52 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.5.0" timestamp="8/11/21, 9:58 AM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.0-SNAPSHOT" timestamp="1/10/23, 10:02 AM">
   <identification>
-    <identity format="Microsoft Excel" mimetype="application/vnd.ms-excel" toolname="FITS" toolversion="1.5.0">
-      <tool toolname="Droid" toolversion="6.5" />
-      <tool toolname="file utility" toolversion="5.39" />
-      <tool toolname="Exiftool" toolversion="12.29" />
+    <identity format="Microsoft Excel" mimetype="application/vnd.ms-excel" toolname="FITS" toolversion="1.6.0-SNAPSHOT">
+      <tool toolname="Droid" toolversion="6.5.2" />
+      <tool toolname="file utility" toolversion="5.43" />
+      <tool toolname="Exiftool" toolversion="12.50" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="2.0.0" />
-      <version toolname="Droid" toolversion="6.5">8</version>
-      <externalIdentifier toolname="Droid" toolversion="6.5" type="puid">fmt/61</externalIdentifier>
+      <tool toolname="Tika" toolversion="2.6.0" />
+      <version toolname="Droid" toolversion="6.5.2">8</version>
+      <externalIdentifier toolname="Droid" toolversion="6.5.2" type="puid">fmt/61</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <created toolname="Exiftool" toolversion="12.29" status="CONFLICT">1998:12:08 14:22:55</created>
-    <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">1998-12-08T14:22:55Z</created>
-    <creatingApplicationName toolname="Tika" toolversion="2.0.0" status="SINGLE_RESULT">Microsoft Excel</creatingApplicationName>
-    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/home/winckles/workspace/3rd-party/fits/testfiles/valid.xls</filepath>
+    <created toolname="Exiftool" toolversion="12.50" status="CONFLICT">1998-12-08T14:22:55</created>
+    <created toolname="Tika" toolversion="2.6.0" status="CONFLICT">1998-12-08T14:22:55Z</created>
+    <creatingApplicationName toolname="Tika" toolversion="2.6.0" status="SINGLE_RESULT">Microsoft Excel</creatingApplicationName>
+    <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/fits/testfiles/input/valid.xls</filepath>
     <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">valid.xls</filename>
     <size toolname="OIS File Information" toolversion="1.0">270336</size>
     <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">fa11d8719f82d99f034a9ab2e52ac446</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1628692993248</fslastmodified>
+    <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1673358187398</fslastmodified>
   </fileinfo>
   <filestatus />
   <metadata>
     <document>
-      <title toolname="Exiftool" toolversion="12.29">Validatie 1</title>
-      <author toolname="Exiftool" toolversion="12.29">Johan van der Knijff</author>
+      <title toolname="Exiftool" toolversion="12.50">Validatie 1</title>
+      <author toolname="Exiftool" toolversion="12.50">Johan van der Knijff</author>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd" />
       </standard>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="1165">
-    <tool toolname="MediaInfo" toolversion="21.03" status="did not run" />
+  <statistics fitsExecutionTime="692">
+    <tool toolname="MediaInfo" toolversion="22.09" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
     <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Droid" toolversion="6.5" executionTime="412" />
-    <tool toolname="Jhove" toolversion="1.24.0" executionTime="1116" />
-    <tool toolname="embARC" toolversion="0.2" status="did not run" />
-    <tool toolname="file utility" toolversion="5.39" executionTime="1138" />
-    <tool toolname="Exiftool" toolversion="12.29" executionTime="1106" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
-    <tool toolname="OIS File Information" toolversion="1.0" executionTime="362" />
-    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="1064" />
-    <tool toolname="Tika" toolversion="2.0.0" executionTime="780" />
+    <tool toolname="Droid" toolversion="6.5.2" executionTime="90" />
     <tool toolname="jpylyzer" toolversion="2.1.0" status="did not run" />
+    <tool toolname="Jhove" toolversion="1.26.1" executionTime="456" />
+    <tool toolname="embARC" toolversion="0.2" status="did not run" />
+    <tool toolname="file utility" toolversion="5.43" executionTime="236" />
+    <tool toolname="Exiftool" toolversion="12.50" executionTime="664" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="did not run" />
+    <tool toolname="OIS File Information" toolversion="1.0" executionTime="40" />
+    <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="71" />
+    <tool toolname="Tika" toolversion="2.6.0" executionTime="472" />
   </statistics>
 </fits>
-

--- a/testfiles/properties/fits-full-with-tool-output.xml
+++ b/testfiles/properties/fits-full-with-tool-output.xml
@@ -11,6 +11,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.ADLTool" include-exts="adl" classpath-dirs="lib/adltool" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.VTTTool" include-exts="vtt" />
         <tool class="edu.harvard.hul.ois.fits.tools.droid.Droid"  exclude-exts="odm,m4a,mpg" classpath-dirs="lib/droid" />
+        <tool class="edu.harvard.hul.ois.fits.tools.jpylyzer.Jpylyzer" include-exts="jp2" />
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.embarc.EmbARC" include-exts="dpx" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,csv,m4a" classpath-dirs="lib/fileutility" />
@@ -20,7 +21,6 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />
         <tool class="edu.harvard.hul.ois.fits.tools.ffident.FFIdent" exclude-exts="dng,wps,vsd,jar,ppt,rtf" classpath-dirs="lib/ffident" />
         <tool class="edu.harvard.hul.ois.fits.tools.tika.TikaTool" exclude-exts="adl,vtt,csv,jar,avi,mov,mpg,mpeg,mkv,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv" classpath-dirs="lib/tika"/>
-        <tool class="edu.harvard.hul.ois.fits.tools.jpylyzer.Jpylyzer" include-exts="jp2" />
     </tools>
     
     <output>

--- a/testfiles/properties/fits-no-consolidation.xml
+++ b/testfiles/properties/fits-no-consolidation.xml
@@ -10,6 +10,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.ADLTool" include-exts="adl" classpath-dirs="lib/adltool" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.VTTTool" include-exts="vtt" />
         <tool class="edu.harvard.hul.ois.fits.tools.droid.Droid"  exclude-exts="odm,m4a,mpg" classpath-dirs="lib/droid" />
+        <tool class="edu.harvard.hul.ois.fits.tools.jpylyzer.Jpylyzer" include-exts="jp2" />
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,epub,csv,m4a" classpath-dirs="lib/fileutility" />
         <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
@@ -18,7 +19,6 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />
         <tool class="edu.harvard.hul.ois.fits.tools.ffident.FFIdent" exclude-exts="dng,wps,vsd,jar,ppt,rtf" classpath-dirs="lib/ffident" />
         <tool class="edu.harvard.hul.ois.fits.tools.tika.TikaTool" exclude-exts="adl,vtt,csv,jar,avi,mov,mpg,mpeg,mkv,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv" classpath-dirs="lib/tika"/>
-        <tool class="edu.harvard.hul.ois.fits.tools.jpylyzer.Jpylyzer" include-exts="jp2" />
     </tools>
     
     <output>

--- a/testfiles/properties/fits_no_md5_audio.xml
+++ b/testfiles/properties/fits_no_md5_audio.xml
@@ -7,6 +7,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.AudioInfo" include-exts="wav" classpath-dirs="lib/audioinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.ADLTool" include-exts="adl" classpath-dirs="lib/adltool" />
         <tool class="edu.harvard.hul.ois.fits.tools.droid.Droid"  exclude-exts="odm,m4a" classpath-dirs="lib/droid" />
+        <tool class="edu.harvard.hul.ois.fits.tools.jpylyzer.Jpylyzer" include-exts="jp2" />
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.embarc.EmbARC" include-exts="dpx" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,epub,csv,m4a" classpath-dirs="lib/fileutility" />
@@ -16,7 +17,6 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />
         <tool class="edu.harvard.hul.ois.fits.tools.ffident.FFIdent" exclude-exts="dng,wps,vsd,jar,ppt" classpath-dirs="lib/ffident" />
         <tool class="edu.harvard.hul.ois.fits.tools.tika.TikaTool" exclude-exts="jar" classpath-dirs="lib/tika"/>
-        <tool class="edu.harvard.hul.ois.fits.tools.jpylyzer.Jpylyzer" include-exts="jp2" />
     </tools>
     
     <output>

--- a/testfiles/properties/fits_no_md5_video.xml
+++ b/testfiles/properties/fits_no_md5_video.xml
@@ -7,6 +7,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.AudioInfo" include-exts="wav" classpath-dirs="lib/audioinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.ADLTool" include-exts="adl" classpath-dirs="lib/adltool" />
         <tool class="edu.harvard.hul.ois.fits.tools.droid.Droid"  exclude-exts="odm,m4a" classpath-dirs="lib/droid" />
+        <tool class="edu.harvard.hul.ois.fits.tools.jpylyzer.Jpylyzer" include-exts="jp2" />
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.embarc.EmbARC" include-exts="dpx" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,epub,csv,m4a" classpath-dirs="lib/fileutility" />
@@ -16,7 +17,6 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />
         <tool class="edu.harvard.hul.ois.fits.tools.ffident.FFIdent" exclude-exts="dng,wps,vsd,jar,ppt" classpath-dirs="lib/ffident" />
         <tool class="edu.harvard.hul.ois.fits.tools.tika.TikaTool" exclude-exts="jar" classpath-dirs="lib/tika"/>
-        <tool class="edu.harvard.hul.ois.fits.tools.jpylyzer.Jpylyzer" include-exts="jp2" />
     </tools>
     
     <output>

--- a/xml/fits.xml
+++ b/xml/fits.xml
@@ -10,6 +10,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.ADLTool" include-exts="adl" classpath-dirs="lib/adltool" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.VTTTool" include-exts="vtt" />
         <tool class="edu.harvard.hul.ois.fits.tools.droid.Droid"  exclude-exts="odm,m4a,mpg" classpath-dirs="lib/droid" />
+        <tool class="edu.harvard.hul.ois.fits.tools.jpylyzer.Jpylyzer" include-exts="jp2" />
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip,ai" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.embarc.EmbARC" include-exts="dpx" classpath-dirs="lib/embarc" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,csv,m4a,dpx" classpath-dirs="lib/fileutility" />
@@ -19,7 +20,6 @@
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />
         <tool class="edu.harvard.hul.ois.fits.tools.ffident.FFIdent" exclude-exts="dng,wps,vsd,jar,ppt,rtf" classpath-dirs="lib/ffident" />
         <tool class="edu.harvard.hul.ois.fits.tools.tika.TikaTool" exclude-exts="adl,vtt,csv,jar,avi,mov,mpg,mpeg,mkv,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,ai" classpath-dirs="lib/tika"/>
-        <tool class="edu.harvard.hul.ois.fits.tools.jpylyzer.Jpylyzer" include-exts="jp2" />
     </tools>
     
     <output>


### PR DESCRIPTION
**Resolves Issue**: [LIBDRS-9064](https://jira.huit.harvard.edu/browse/LIBDRS-9064)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
In the fits.xml configuration file(s) the jypylyzer tool has been moved above the JHOVE tool so that jpylyzer output for JPEG 2000 (jp2) files takes precedence. Expected output files for tests have been updated to reflect this change.

# How should this be tested?
Run the test suite from a Docker container as described in README.md.
- build FITS without running tests - `mvn clean package -DskipTests`
- build a Docker container - `docker build -f docker/Dockerfile-test -t fits-test .`
- Run the test suite - `docker run --rm -v `pwd`:/fits -v ~/.m2:/root/.m2 fits-test mvn clean test`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? yes
- integration tests? yes

# Interested parties
@pwinckles @awoods @cvicary 