### PR TITLE
add flag for overwriting test expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,18 @@ To run the formatter:
 
 When the project builds, it checks the formatting and will fail if there are any files that are not formatted per the standard.
 
+### Overwriting test expectations
+
+The test expectation xml files can be overwritten with the current FITS output by running the tests with the
+`-Doverwrite=true` flag. For example:
+
+```shell
+docker run --rm -v `pwd`:/fits -v ~/.m2:/root/.m2 fits-test mvn -Doverwrite=true clean test
+```
+
+However, generally speaking, test expectation files should be changed as little as possible so that the diffs are
+as clear as possible.
+
 ### Tools
 
 Some of the tools that FITS is distributed with are not bundled in the source tree. Instead, they are pulled in when
@@ -227,6 +239,7 @@ Available recipes:
     run +ARGS           # Executes FITS within a Docker container. This requires that the image has already been built (just build-image).
     test                # Runs the tests within a Docker container. Requires the image to already exist (just build-test-image). The image does NOT need to be rebuilt between runs.
     test-filter PATTERN # Runs the tests that match the pattern within a Docker container. Requires the image to already exist (just build-test-image). The image does NOT need to be rebuilt between runs.
+    test-overwrite      # Overwrites all of the test expecation xmls with the current FITS output
     update-droid-sigs   # Update DROID signature files
 ```
 

--- a/justfile
+++ b/justfile
@@ -34,6 +34,10 @@ test:
 test-filter PATTERN:
     docker run --rm -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test mvn clean test -Dtest={{PATTERN}}
 
+# Overwrites all of the test expecation xmls with the current FITS output
+test-overwrite:
+    docker run --rm -v `pwd`:/fits:z -v ~/.m2:/root/.m2:z fits-test mvn -Doverwrite=true clean test
+
 # Applies the code formatter
 format:
     mvn spotless:apply

--- a/src/test/java/edu/harvard/hul/ois/fits/tests/AbstractXmlUnitTest.java
+++ b/src/test/java/edu/harvard/hul/ois/fits/tests/AbstractXmlUnitTest.java
@@ -35,6 +35,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.custommonkey.xmlunit.DetailedDiff;
@@ -87,10 +90,17 @@ public class AbstractXmlUnitTest extends AbstractLoggingTest {
      */
     protected static Fits fits;
 
+    /**
+     * true if the expected test result xml files should be overwritten with the current results. This is useful for
+     * doing a bulk expectation update.
+     */
+    private static boolean overwrite;
+
     @BeforeClass
     public static void abstractClassSetup() throws FitsConfigurationException {
         // Set up XMLUnit for all classes.
         logger = LoggerFactory.getLogger(AbstractXmlUnitTest.class);
+        overwrite = Boolean.parseBoolean(System.getProperty("overwrite", "false"));
     }
 
     @AfterClass
@@ -194,7 +204,12 @@ public class AbstractXmlUnitTest extends AbstractLoggingTest {
         String expectedFile = OUTPUT_DIR + inputFilename + namePart + EXPECTED_OUTPUT_FILE_SUFFIX;
         String expectedXmlStr = FileUtils.readFileToString(new File(expectedFile), StandardCharsets.UTF_8);
 
-        testActualAgainstExpected(actualXmlStr, expectedXmlStr, actualFile, expectedFile);
+        if (overwrite) {
+            System.out.println("Overwriting test expectations at: " + expectedFile);
+            Files.copy(Paths.get(actualFile), Paths.get(expectedFile), StandardCopyOption.REPLACE_EXISTING);
+        } else {
+            testActualAgainstExpected(actualXmlStr, expectedXmlStr, actualFile, expectedFile);
+        }
     }
 
     /**


### PR DESCRIPTION
This adds a flag, `-Doverwrite=true`, that can be used to update the test expectation xml files in bulk.