### PR TITLE
Add mediainfo and libmediainfo-dev to Dockerfile for FITS

### DIFF
--- a/docker/Dockerfile-release
+++ b/docker/Dockerfile-release
@@ -47,6 +47,7 @@ RUN apt-get update && \
     # mediainfo dependencies
     libmms0 \
     libcurl3-gnutls \
+    mediainfo libmediainfo-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install file https://github.com/file/file


### PR DESCRIPTION
**Resolves Issue**: (link)

* Other Relevant Links: N/A

# What does this Pull Request do?

This Pull Request adds the mediainfo and libmediainfo-dev packages to the Dockerfile used for building the FITS Docker image. This addition resolves the error 'Unable to load library 'mediainfo'' which was encountered when running FITS in a Docker container. The inclusion of these packages ensures that FITS can properly utilize the mediainfo library for media file analysis, enhancing its functionality within the Dockerized environment.

# How should this be tested?

To test this Pull Request:

1. Build the Docker image using the updated Dockerfile: `docker build -f Dockerfile -t fits .`
1. Run FITS on a sample file in the Docker container: `docker run --rm -v pwd:/work fits -i sample_file.txt`
1. Observe that the 'Unable to load library 'mediainfo'' error does not occur and that FITS successfully analyzes the media file.
1. (Optional) Compare the output with previous runs of FITS to ensure consistency.

# Test coverage

No: The changes in this pull-request are not covered by unit tests or integration tests. The change is specific to the Docker build process and can be verified through the steps mentioned in the testing section.

# Interested parties

N/A
