### PR TITLE
update to exiftool 12.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased (TBD)
 
 - Tool upgrades
-  - ExifTool 12.60
+  - ExifTool 12.76
   - Jhove 1.28.0
   - MediaInfo 23.07
   - Tika 2.8.0

--- a/fits-pom.xml
+++ b/fits-pom.xml
@@ -103,7 +103,7 @@
                         <importOrder />
                         <removeUnusedImports />
                         <palantirJavaFormat>
-                            <version>2.27.0</version>
+                            <version>2.46.0</version>
                         </palantirJavaFormat>
                     </java>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>2.27.2</version>
+                    <version>2.43.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/testfiles/output/Winnie-the-Pooh-protected.epub_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/Winnie-the-Pooh-protected.epub_XmlUnitExpectedOutput.xml
@@ -19,11 +19,11 @@
   <filestatus />
   <metadata>
     <document>
-      <title toolname="Exiftool" toolversion="12.50">Winnie-the-Pooh</title>
-      <author toolname="Exiftool" toolversion="12.50">A. A. Milne</author>
-      <isRightsManaged toolname="Exiftool" toolversion="12.50">yes</isRightsManaged>
-      <identifier toolname="Exiftool" toolversion="12.50">1-101-15893-X</identifier>
-      <language toolname="Exiftool" toolversion="12.50">en</language>
+      <isRightsManaged toolname="Tika" toolversion="2.8.0" status="SINGLE_RESULT">yes</isRightsManaged>
+      <identifier toolname="Tika" toolversion="2.8.0" status="SINGLE_RESULT">1-101-15893-X</identifier>
+      <language toolname="Tika" toolversion="2.8.0" status="SINGLE_RESULT">en</language>
+      <author toolname="Tika" toolversion="2.8.0" status="SINGLE_RESULT">A. A. Milne</author>
+      <title toolname="Tika" toolversion="2.8.0" status="SINGLE_RESULT">Winnie-the-Pooh</title>
       <standard>
         <docmd:document xmlns:docmd="http://www.fcla.edu/docmd">
           <docmd:Language>en</docmd:Language>

--- a/testfiles/output/WordPerfect4_2.wp_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPerfect4_2.wp_XmlUnitExpectedOutput.xml
@@ -28,7 +28,7 @@
     <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.43" executionTime="172" />
-    <tool toolname="Exiftool" toolversion="12.50" executionTime="479" />
+    <tool toolname="Exiftool" toolversion="12.76" status="did not run" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="617" />
     <tool toolname="OIS File Information" toolversion="1.0" executionTime="88" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />

--- a/testfiles/output/WordPerfect5_0.wp_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPerfect5_0.wp_XmlUnitExpectedOutput.xml
@@ -38,7 +38,7 @@
     <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.43" executionTime="136" />
-    <tool toolname="Exiftool" toolversion="12.50" executionTime="376" />
+    <tool toolname="Exiftool" toolversion="12.76" status="did not run" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="134" />
     <tool toolname="OIS File Information" toolversion="1.0" executionTime="54" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />

--- a/testfiles/output/WordPerfect5_2.wp_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPerfect5_2.wp_XmlUnitExpectedOutput.xml
@@ -38,7 +38,7 @@
     <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.43" executionTime="126" />
-    <tool toolname="Exiftool" toolversion="12.50" executionTime="339" />
+    <tool toolname="Exiftool" toolversion="12.76" status="did not run" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="122" />
     <tool toolname="OIS File Information" toolversion="1.0" executionTime="42" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />

--- a/testfiles/output/WordPerfect6-7.wpd_XmlUnitExpectedOutput.xml
+++ b/testfiles/output/WordPerfect6-7.wpd_XmlUnitExpectedOutput.xml
@@ -32,7 +32,7 @@
     <tool toolname="Jhove" toolversion="1.26.1" status="did not run" />
     <tool toolname="embARC" toolversion="0.2" status="did not run" />
     <tool toolname="file utility" toolversion="5.43" executionTime="198" />
-    <tool toolname="Exiftool" toolversion="12.50" executionTime="388" />
+    <tool toolname="Exiftool" toolversion="12.76" status="did not run" />
     <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="143" />
     <tool toolname="OIS File Information" toolversion="1.0" executionTime="31" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />

--- a/testfiles/properties/fits-full-with-tool-output.xml
+++ b/testfiles/properties/fits-full-with-tool-output.xml
@@ -15,7 +15,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.embarc.EmbARC" include-exts="dpx" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,csv,m4a" classpath-dirs="lib/fileutility" />
-        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
+        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,wpd,wp,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
         <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" include-exts="wp,wpd,odt,doc,pdf,mp3,bfw,flac,html,xml,arc" classpath-dirs="lib/nzmetool,xml/nlnz"/>
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />

--- a/testfiles/properties/fits-no-consolidation.xml
+++ b/testfiles/properties/fits-no-consolidation.xml
@@ -13,7 +13,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.jpylyzer.Jpylyzer" include-exts="jp2" />
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,epub,csv,m4a" classpath-dirs="lib/fileutility" />
-        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
+        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,wpd,wp,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
         <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" include-exts="wp,wpd,odt,doc,pdf,mp3,bfw,flac,html,xml,arc" classpath-dirs="lib/nzmetool,xml/nlnz"/>
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />

--- a/testfiles/properties/fits_no_md5_audio.xml
+++ b/testfiles/properties/fits_no_md5_audio.xml
@@ -11,7 +11,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.embarc.EmbARC" include-exts="dpx" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,epub,csv,m4a" classpath-dirs="lib/fileutility" />
-        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="txt,wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv" classpath-dirs="lib/exiftool" />      
+        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="txt,wps,wpd,wp,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv" classpath-dirs="lib/exiftool" />
         <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" exclude-exts="dng,zip,odb,ott,odg,otg,odp,otp,ods,ots,odc,otc,odi,oti,odf,otf,odm,oth,tif,tiff,wav" classpath-dirs="lib/nzmetool,xml/nlnz"/>
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />

--- a/testfiles/properties/fits_no_md5_video.xml
+++ b/testfiles/properties/fits_no_md5_video.xml
@@ -11,7 +11,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.embarc.EmbARC" include-exts="dpx" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,epub,csv,m4a" classpath-dirs="lib/fileutility" />
-        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="txt,wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv" classpath-dirs="lib/exiftool" />      
+        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="txt,wps,wpd,wp,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv" classpath-dirs="lib/exiftool" />
         <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" exclude-exts="dng,zip,odb,ott,odg,otg,odp,otp,ods,ots,odc,otc,odi,oti,odf,otf,odm,oth,tif,tiff,wav" classpath-dirs="lib/nzmetool,xml/nlnz"/>
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />

--- a/tools.properties
+++ b/tools.properties
@@ -1,11 +1,11 @@
 # exiftool
 # When upgrading exiftool, be sure to select a *production release* version (https://www.exiftool.org/history.html).
 # None production releases are not available for download long-term.
-exiftool.version=12.60
-exiftool.unix.url=https://exiftool.org/Image-ExifTool-12.60.tar.gz
-exiftool.unix.md5=ab1b5d756aaa8188890afa5a16563f57
-exiftool.windows.url=https://exiftool.org/exiftool-12.60.zip
-exiftool.windows.md5=a020948fd8d1a8c891266bebee65792a
+exiftool.version=12.76
+exiftool.unix.url=https://exiftool.org/Image-ExifTool-12.76.tar.gz
+exiftool.unix.md5=685dd43e540a651efaae5af6730d6893
+exiftool.windows.url=https://exiftool.org/exiftool-12.76.zip
+exiftool.windows.md5=b57ce8a4df80763489cd1bd7ab616994
 
 # MediaInfo
 # https://mediaarea.net/en/MediaInfo/Download

--- a/xml/fits.xml
+++ b/xml/fits.xml
@@ -14,7 +14,7 @@
         <tool class="edu.harvard.hul.ois.fits.tools.jhove.Jhove" exclude-exts="dng,mbx,mbox,arw,adl,eml,java,doc,docx,docm,odt,rtf,pages,wpd,wp,epub,csv,avi,mov,mpg,mpeg,mkv,mp3,mp4,mpeg4,m2ts,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,pcd,zip,ai" classpath-dirs="lib/jhove" />
         <tool class="edu.harvard.hul.ois.fits.tools.embarc.EmbARC" include-exts="dpx" classpath-dirs="lib/embarc" />
         <tool class="edu.harvard.hul.ois.fits.tools.fileutility.FileUtility" exclude-exts="dng,wps,adl,jar,csv,m4a,dpx" classpath-dirs="lib/fileutility" />
-        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
+        <tool class="edu.harvard.hul.ois.fits.tools.exiftool.Exiftool" exclude-exts="wps,wpd,wp,vsd,jar,avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4,rmvb,rm,wmv,vtt,adl" classpath-dirs="lib/exiftool" />
         <tool class="edu.harvard.hul.ois.fits.tools.nlnz.MetadataExtractor" include-exts="wp,wpd,odt,doc,mp3,bfw,flac,html,xml,arc" classpath-dirs="lib/nzmetool,xml/nlnz"/>
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.FileInfo" classpath-dirs="lib/fileinfo" />
         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.XmlMetadata" include-exts="xml" classpath-dirs="lib/xmlmetadata" />


### PR DESCRIPTION
Upgrades the version of exiftool to 12.76, which is currently the most recent production release.

Unfortunately, exiftool now appears to try to identify WordPerfect documents and does so badly. They come back as `image/x-wpg`. So, I updated `fits.xml` to exclude exiftool from running on `.wpd` and `.wp` extensions.

Additionally, exiftool is now no longer reporting some metadata protected epubs. This is no big loss because other tools are able still able to get the info.

This fixes the main build as the old version of exitool is no longer available on the exiftool website for some reason.

@awoods requesting a review (I can't tag reviewers on the side anymore as I no longer have perms).