### PR TITLE
Update pom.xml to target huit.artifactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,14 +152,14 @@
     <distributionManagement>
         <!-- repository URL and credentials set up in local .m2/settings.xml -->
         <repository>
-            <id>harvard-lts-internal-release-repository</id>
-            <name>Harvard LTS internal Release Repository</name>
-            <url>${lts-artifactory-url}/lts-libs-release-local</url>
+            <id>lts-maven</id>
+            <name>Harvard LTS Dependency Repository</name>
+            <url>https://artifactory.huit.harvard.edu/artifactory/lts-maven</url>
         </repository>
         <snapshotRepository>
-            <id>harvard-lts-internal-snapshot-repository</id>
-            <name>Harvard LTS internal Snapshot Repository</name>
-            <url>${lts-artifactory-url}/lts-libs-snapshot-local</url>
+            <id>lts-maven</id>
+            <name>Harvard LTS Dependency Repository</name>
+            <url>https://artifactory.huit.harvard.edu/artifactory/lts-maven</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
- instead of lts.artifactory

Resolves: https://at-harvard.atlassian.net/browse/LTSK8S-1144

# What does this Pull Request do?
Update pom.xml to target huit.artifactory instead of lts.artifactory

# How should this be tested?
- Ensure local ~/.m2/settings.xml has entry for huit.artifactory:
   ```
    <server>
       <id>lts-maven</id>
       <username>[net-id, such as: anw822]</username>
       <password>[from-huit.artifactory-profile]</password>
    </server>
   ```
- Build and see reference to huit.artifactory in terminal output
   ```
   mvn clean install
   ```

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? - no change
- integration tests? - no change

# Interested parties
@cvicary 
