### PR TITLE
Revert "Update build.yml"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on:
-      group: huit-arc
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Build image


### PR DESCRIPTION
Reverts harvard-lts/fits#404 due to Harvard internal github runners' limitation of not running on public repositories.