### PR TITLE
Update harvard-lts links to fitstool org after repo migration

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,11 +23,11 @@ email: fits-users@googlegroups.com
 description: >- # this means to ignore newlines until "baseurl:"
   Documentation and official code release of the FITS and the FITS Web Service projects
 baseurl: "/fits" # the subpath of your site, e.g. /blog
-url: "https://harvard-lts.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://www.fitstool.org" # the base hostname & protocol for your site, e.g. http://example.com
 github_reponame_fits:  FITS
-github_url_fits: "https://github.com/harvard-lts/fits"
+github_url_fits: "https://github.com/fitstool/fits"
 github_reponame_fits-servlet: FITSservlet
-github_url_fits-servlet: "https://github.com/harvard-lts/FITSservlet"
+github_url_fits-servlet: "https://github.com/fitstool/FITSservlet"
 
 # Build settings
 theme: minima

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -22,7 +22,7 @@
         <div class="trigger">
           <a class="page-link" href="/fits/about">About</a>
           <a class="page-link" href="/fits/connect">Connect</a>
-          <a class="page-link" href="https://github.com/harvard-lts/fits/wiki/Developer-Manual">Developer manual</a>
+          <a class="page-link" href="https://github.com/fitstool/fits/wiki/Developer-Manual">Developer manual</a>
           <a class="page-link" href="/fits/user-manual">User manual</a>
           <a class="page-link" href="/fits/quick-start">Quick start</a>
         </div>

--- a/docs/_posts/2022-03-20-ffident.md
+++ b/docs/_posts/2022-03-20-ffident.md
@@ -4,7 +4,7 @@ categories: tools
 title:  ffident ([archived site](http://web.archive.org/web/20061106114156/http://schmidt.devlib.org/ffident/index.html))
 maintenance-organization: no longer maintained
 capabilities: Identifies file formats.
-formats: Listed in the configuration file [tools/ffident/formats.txt](https://github.com/harvard-lts/fits/blob/dev/tools/ffident/formats.txt)
+formats: Listed in the configuration file [tools/ffident/formats.txt](https://github.com/fitstool/fits/blob/dev/tools/ffident/formats.txt)
 description: FFIdent is written in Java. 
 usage-note: The FITS tool wrapper uses the provided API. Output is converted into a simple XML document and then converted to FITS XML using xml/ffident/ffident_to_fits.xslt.
 # more-info-url: more information at website

--- a/docs/_posts/2022-03-28-community-sprint.md
+++ b/docs/_posts/2022-03-28-community-sprint.md
@@ -14,4 +14,4 @@ author: author
 
 <hr>
 
-For more details, visit our [GitHub project board](https://github.com/orgs/harvard-lts/projects/3/views/1)
+For more details, visit our [GitHub project board](https://github.com/orgs/fitstool/projects/3/views/1)

--- a/docs/about.md
+++ b/docs/about.md
@@ -11,7 +11,7 @@ The File Information Tool Set (FITS) identifies, validates and extracts technica
 
 Note: FITS is written in Java and is **compatible with Java 1.8 or higher**.
 
-<p><a class="page-link" href="https://github.com/harvard-lts/fits/releases"><svg class="svg-icon"><use xlink:href="/fits/assets/minima-social-icons.svg#github"></use></svg>Release Notes & Source Code</a></p>
+<p><a class="page-link" href="https://github.com/fitstool/fits/releases"><svg class="svg-icon"><use xlink:href="/fits/assets/minima-social-icons.svg#github"></use></svg>Release Notes & Source Code</a></p>
 </div>
 
 ---
@@ -23,5 +23,5 @@ The FITS Web Service is a project that allows FITS to be deployed as a service o
 
 Note: The latest and future versions of this project are built and tested using Java 8. 
 
-<p><a class="page-link" href="https://github.com/harvard-lts/FITSservlet/releases"><svg class="svg-icon"><use xlink:href="/fits/assets/minima-social-icons.svg#github"></use></svg>Release Notes & Source Code</a></p>
+<p><a class="page-link" href="https://github.com/fitstool/FITSservlet/releases"><svg class="svg-icon"><use xlink:href="/fits/assets/minima-social-icons.svg#github"></use></svg>Release Notes & Source Code</a></p>
 </div>

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -19,7 +19,7 @@ permalink: /connect
     <p>Get involved the community's next 2-week sprint (date TBD). Sign up for the FITS Google Group to learn when the next sprint will be.</p>
   </div>
   <div>
-    <h2><a href="https://github.com/harvard-lts/fits/issues">Discuss on GitHub</a></h2>
+    <h2><a href="https://github.com/fitstool/fits/issues">Discuss on GitHub</a></h2>
     <p>Report bugs, suggest feature enhancements, or request documentation updates by creating an issue on FITS's GitHub issue tracker.</p>
   </div>
 </div>

--- a/docs/guides/fits-configuration-files.md
+++ b/docs/guides/fits-configuration-files.md
@@ -1,10 +1,10 @@
 ### FITS configuration files
 
-The FITS configuration files are located in the [xml directory](https://github.com/harvard-lts/fits/tree/dev/xml).
+The FITS configuration files are located in the [xml directory](https://github.com/fitstool/fits/tree/dev/xml).
 
 **The FITS XML output is highly affected by how FITS is configured. In particular, the order of tools near the top of the fits.xml configuration file specifies which tools FITS should prefer when they give conflicting information and if FITS should ignore tool output for particular formats. FITS comes pre-configured based on testing different tools with different formats and the default configuration should only be changed with a great deal of care and testing.**
 
-#### [fits.xml](https://github.com/harvard-lts/fits/blob/dev/xml/fits.xml)
+#### [fits.xml](https://github.com/fitstool/fits/blob/dev/xml/fits.xml)
 This is the main configuration file for FITS. The key pieces are described here:
 
 ##### tool element
@@ -52,7 +52,7 @@ The signature file to use with the Droid tool. [Get the list of all previously r
 This allows for limiting the amount of a file (from its beginning) that is to be examined by the DROID tool (in order to increase processing speed). For example, for some types of large video and audio files, only the first 64K bytes need to be examined to extract relevant metadata. The attribute **include-exts** sets the file extension that this limiter should be applied to, and the attribute **read-limit-kb** sets the limit, in kilobytes, of how much of the beginning of the designated file types should be examined. The default behavior (when this element remains commented-out) is for DROID to examine all files in their entirety. 
 
 
-#### [fits_format_tree.xml](https://github.com/harvard-lts/fits/blob/dev/xml/fits_format_tree.xml)
+#### [fits_format_tree.xml](https://github.com/fitstool/fits/blob/dev/xml/fits_format_tree.xml)
 Certain formats are a more specific subset of a more general format. The format tree in this file specifies these relationships. Nested formats are more specific versions of the formats they are nested under. FITS uses this to know when to report format conflicts and when it should report a more specific format. 
 
 During output consolidation the format tree is consulted, and any less specific format identities are thrown out. For example, OpenOffice text document formats are ZIP-based. Some tools identify these files as ZIP, and others as ODT. Any tools identifying the file as a ZIP would be discarded according to the rules set by the format tree. 
@@ -71,33 +71,33 @@ An example follows using a snippet of the format tree:
 The above snippet of the format tree should be interpreted as: JPEG 2000 JP2 and JPEG 2000 JPX are more specific forms of the JPEG 2000 format. If one FITS-wrapped tool were to report the format of a file as JPEG 2000 and another reported it as JPEG 2000 JP2, FITS would report the more specific format (JPEG 2000 JP2) and would not report that there was a format conflict (because both tools were technically correct). 
 
 
-#### [fits_output.xsd](https://github.com/harvard-lts/fits/blob/dev/xml/fits_output.xsd)
+#### [fits_output.xsd](https://github.com/fitstool/fits/blob/dev/xml/fits_output.xsd)
 Schema for the output of FITS XML files.
 
 
-#### [fits_xml_map.xml](https://github.com/harvard-lts/fits/blob/dev/xml/fits_xml_map.xml)
+#### [fits_xml_map.xml](https://github.com/fitstool/fits/blob/dev/xml/fits_xml_map.xml)
 This mapping file is used to normalize the values output by some of the tools that FITS wraps, for example to change Jhove's Greyscale value to Grayscale. It allows substitution of one value for another on a tool by tool, element by element basis.
 
 For example, if a tool outputs the value "2" as the sampling frequency unit for an image, but you want to use the text string "inches" instead, you could add an entry to fits_xml_map.xml. Mappings are applied automatically when a tool creates its FITS output, prior to output consolidation. You must specify the tool name, version, and element name that you want mapped. Currently all mapping-related needs are handled in the tool's XSLT. 
 
 
-#### [format_map.txt](https://github.com/harvard-lts/fits/blob/dev/xml/format_map.txt)
+#### [format_map.txt](https://github.com/fitstool/fits/blob/dev/xml/format_map.txt)
 The file is used to normalize format names output by some of the tools that FITS wraps. 
 
 
-#### [mime_map.txt](https://github.com/harvard-lts/fits/blob/dev/xml/mime_map.txt)
+#### [mime_map.txt](https://github.com/fitstool/fits/blob/dev/xml/mime_map.txt)
 The file is used to normalize MIME media type values output by some of the tools that FITS wraps.
 
 
-#### [mime_to_format_map.txt](https://github.com/harvard-lts/fits/blob/dev/xml/mime_to_format_map.txt)
+#### [mime_to_format_map.txt](https://github.com/fitstool/fits/blob/dev/xml/mime_to_format_map.txt)
 Used to map format names to MIME media types for some of the tools that FITS wraps.
 
 
-#### [prettyprint.xslt](https://github.com/harvard-lts/fits/blob/dev/xml/prettyprint.xslt)
+#### [prettyprint.xslt](https://github.com/fitstool/fits/blob/dev/xml/prettyprint.xslt)
 Transforms the standard FITS output into “pretty print” XML formatting for easier human readability.
 
 
-#### [xslt_map.xsd](https://github.com/harvard-lts/fits/blob/dev/xml/xslt_map.xsd)
+#### [xslt_map.xsd](https://github.com/fitstool/fits/blob/dev/xml/xslt_map.xsd)
 Schema for transformation maps for these tools: exiftool_xslt_map.xml, jhove_xslt_map.xml, nlnx_xslt_map.xml.
 
 ---

--- a/docs/guides/overview-of-fits-processing.md
+++ b/docs/guides/overview-of-fits-processing.md
@@ -11,6 +11,6 @@ The steps are described in more detail here.
 3. All of the FITS XML is consolidated into a single instance of FITS XML.
 4. The FITS XML is converted to standard XML (e.g. MIX) (if this option was requested for example by using the -x parameter on the command line).
 
-For a more technical description of FITS processing - see the [Developer Manual](https://github.com/harvard-lts/fits/wiki/Developer-Manual#fits-processing).
+For a more technical description of FITS processing - see the [Developer Manual](https://github.com/fitstool/fits/wiki/Developer-Manual#fits-processing).
 
 ---

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -1,6 +1,6 @@
 ### Tools & Libraries
 
-The latest version of FITS is configured to a number of open source projects. [All project licenses are available in our GitHub repository](https://github.com/harvard-lts/fits/tree/dev/Licenses).
+The latest version of FITS is configured to a number of open source projects. [All project licenses are available in our GitHub repository](https://github.com/fitstool/fits/tree/dev/Licenses).
 
 {% include tool.md %}
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,13 +22,13 @@ layout: home
       <p>How to get the most out of using FITS</p>
     </div>
   </a>
-  <a href="https://github.com/harvard-lts/fits/wiki/Developer-Manual">
+  <a href="https://github.com/fitstool/fits/wiki/Developer-Manual">
     <div>
       <h2>Developer manual</h2>
       <p>Developer-focused software documentation</p>
     </div>
   </a>
-  <a href="https://github.com/harvard-lts/fits/releases">
+  <a href="https://github.com/fitstool/fits/releases">
     <div>
       <h2>Code releases</h2>
       <p>Download the latest FITS code</p>

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -18,7 +18,7 @@ FITS is a Java program and requires Java version 1.8 or higher. To find out your
 
 ## 2. Installation
 
-Download the [latest release](https://github.com/harvard-lts/fits/releases). If this is your first time downloading FITS, create a directory for FITS:
+Download the [latest release](https://github.com/fitstool/fits/releases). If this is your first time downloading FITS, create a directory for FITS:
 
 - On Windows: C:\Program Files\Fits 
 - On Mac OS X: /Applications/Fits 
@@ -66,7 +66,7 @@ Here are a couple examples of running FITS to get you started. These are relativ
 
 ## 5. Using FITS' Java API
 
-See the [Developer Manual](https://github.com/harvard-lts/fits/wiki/Developer-Manual).
+See the [Developer Manual](https://github.com/fitstool/fits/wiki/Developer-Manual).
 
 ## 6. Next steps
 

--- a/docs_readme.md
+++ b/docs_readme.md
@@ -1,6 +1,6 @@
 # FITS Documentation
 
-The docs directory contains the Jekyll-based documentation website for the File Information Tool Set (FITS) project. The documentation is automatically published to [https://harvard-lts.github.io/fits](https://harvard-lts.github.io/fits) via GitHub Pages.
+The docs directory contains the Jekyll-based documentation website for the File Information Tool Set (FITS) project. The documentation is automatically published to [https://www.fitstool.org](https://www.fitstool.org) via GitHub Pages.
 
 ## Prerequisites
 
@@ -187,7 +187,7 @@ Key configuration options in `_config.yml`:
 
 - Check the [Jekyll documentation](https://jekyllrb.com/docs/)
 - Review [GitHub Pages documentation](https://docs.github.com/en/pages)
-- Search existing [FITS GitHub issues](https://github.com/harvard-lts/fits/issues)
+- Search existing [FITS GitHub issues](https://github.com/fitstool/fits/issues)
 
 ## Deployment
 


### PR DESCRIPTION
Point all github.com/harvard-lts links to the new github.com/fitstool org, and update the Jekyll site url and published-docs URL to the www.fitstool.org custom domain.
