### PR TITLE
Fix Github pages relative paths

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,7 +22,7 @@ title: File Information Tool Set (FITS)
 email: fits-users@googlegroups.com
 description: >- # this means to ignore newlines until "baseurl:"
   Documentation and official code release of the FITS and the FITS Web Service projects
-baseurl: "/fits" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://www.fitstool.org" # the base hostname & protocol for your site, e.g. http://example.com
 github_reponame_fits:  FITS
 github_url_fits: "https://github.com/fitstool/fits"

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -11,7 +11,7 @@
             {%- if site.email -%}
             <li><a class="u-email" href="mailto:{{ site.email }}">{{ site.email }}</a></li>
             {%- endif -%}
-            <li><a class="page-link" href="/fits/news">Archived News & Sprint Recaps</a></li>
+            <li><a class="page-link" href="/news">Archived News & Sprint Recaps</a></li>
         </ul>
         
       </div>
@@ -21,7 +21,7 @@
           {% if site.github_url_fits %}
           <li>
             <a href={{site.github_url_fits}}>
-              <svg class="svg-icon"><use xlink:href="/fits/assets/minima-social-icons.svg#github"></use></svg> 
+              <svg class="svg-icon"><use xlink:href="/assets/minima-social-icons.svg#github"></use></svg> 
               <span class="username">{{ site.github_reponame_fits }}</span>
             </a>
           </li>
@@ -29,7 +29,7 @@
           {% if site.github_url_fits-servlet %}
           <li>
             <a href={{site.github_url_fits-servlet}}>
-              <svg class="svg-icon"><use xlink:href="/fits/assets/minima-social-icons.svg#github"></use></svg> 
+              <svg class="svg-icon"><use xlink:href="/assets/minima-social-icons.svg#github"></use></svg> 
               <span class="username">{{ site.github_reponame_fits-servlet }}</span>
             </a>
           </li>

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
-  <link rel="stylesheet" href="/fits/css/main.css">
+  <link rel="stylesheet" href="/css/main.css">
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -20,11 +20,11 @@
         </label>
 
         <div class="trigger">
-          <a class="page-link" href="/fits/about">About</a>
-          <a class="page-link" href="/fits/connect">Connect</a>
+          <a class="page-link" href="/about">About</a>
+          <a class="page-link" href="/connect">Connect</a>
           <a class="page-link" href="https://github.com/fitstool/fits/wiki/Developer-Manual">Developer manual</a>
-          <a class="page-link" href="/fits/user-manual">User manual</a>
-          <a class="page-link" href="/fits/quick-start">Quick start</a>
+          <a class="page-link" href="/user-manual">User manual</a>
+          <a class="page-link" href="/quick-start">Quick start</a>
         </div>
       </nav>
     {%- endif -%}

--- a/docs/about.md
+++ b/docs/about.md
@@ -11,7 +11,7 @@ The File Information Tool Set (FITS) identifies, validates and extracts technica
 
 Note: FITS is written in Java and is **compatible with Java 1.8 or higher**.
 
-<p><a class="page-link" href="https://github.com/fitstool/fits/releases"><svg class="svg-icon"><use xlink:href="/fits/assets/minima-social-icons.svg#github"></use></svg>Release Notes & Source Code</a></p>
+<p><a class="page-link" href="https://github.com/fitstool/fits/releases"><svg class="svg-icon"><use xlink:href="/assets/minima-social-icons.svg#github"></use></svg>Release Notes & Source Code</a></p>
 </div>
 
 ---
@@ -23,5 +23,5 @@ The FITS Web Service is a project that allows FITS to be deployed as a service o
 
 Note: The latest and future versions of this project are built and tested using Java 8. 
 
-<p><a class="page-link" href="https://github.com/fitstool/FITSservlet/releases"><svg class="svg-icon"><use xlink:href="/fits/assets/minima-social-icons.svg#github"></use></svg>Release Notes & Source Code</a></p>
+<p><a class="page-link" href="https://github.com/fitstool/FITSservlet/releases"><svg class="svg-icon"><use xlink:href="/assets/minima-social-icons.svg#github"></use></svg>Release Notes & Source Code</a></p>
 </div>

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -19,6 +19,6 @@ Preservationists and digital curators who are concerned with long-term access an
 
 ### Installing FITS
 
-See our <a href="/fits/quick-start">Quick Start guide</a> to get started. Then, come back here to learn more about using FITS.
+See our <a href="/quick-start">Quick Start guide</a> to get started. Then, come back here to learn more about using FITS.
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,13 +10,13 @@ layout: home
 <!-- <p>A combination of tools that reliably extracts technical metadata and compares the results of their output, saving time and effort.</p> -->
 
 <div class="quick-cards">
-  <a href="/fits/quick-start">
+  <a href="/quick-start">
     <div>
       <h2>Quick Start</h2>
       <p>Install & run FITS for the first time</p>
     </div>
   </a>
-  <a href="/fits/user-manual">
+  <a href="/user-manual">
     <div>
       <h2>User manual</h2>
       <p>How to get the most out of using FITS</p>
@@ -37,7 +37,7 @@ layout: home
 </div>
 
 <div>
-  <a class="alert-box" href="/fits/blog/2022/03/28/community-sprint.html">
+  <a class="alert-box" href="/blog/2022/03/28/community-sprint.html">
     <span><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18" height="21" viewBox="0 0 18 21"><g><g transform="translate(-37 47)"><path id="qy38a" d="M52.88-32.18V-38a6.87 6.87 0 0 0-5.29-6.69v-.72a1.59 1.59 0 1 0-3.18 0v.72A6.87 6.87 0 0 0 39.12-38v5.82L37-30.06V-29h18v-1.06l-2.12-2.12zM44-28a2 2 0 1 0 4 0h-4z"></path></g></g></svg></span>
     <span>FITS Community Sprint Recap, Winter 2022</span>
   </a>

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -70,6 +70,6 @@ See the [Developer Manual](https://github.com/fitstool/fits/wiki/Developer-Manua
 
 ## 6. Next steps
 
-After you are up and running see the [User Manual](/fits/user-manual) for more documentation. 
+After you are up and running see the [User Manual](/user-manual) for more documentation. 
 
 </div>


### PR DESCRIPTION
**Fix relative paths for Github pages documents**
* * *

# What does this Pull Request do?
Modify the relative paths to resources under docs (Github pages) to remove `/fits` from the beginning of the path, as the `fitstool.org` domain now points to the `fits` repo Github pages as its root.

# How should this be tested?

1. Clone the repo in an environment that also has a GUI with a browser.
2. Checkout the branch "fix_rel_paths".
3. Change to the `docs/` directory.
4. If necessary, run `bundle install` to install all the jekyll dependencies.  If running Ruby 3.4+ also run `bundle add bigdecimal`.
5. Launch the test webserver: `bundle exec jekyll serve`
6. In your browser,go to http://127.0.0.1:4000/ (as shown in the output of the `bundle exec jekyll serve` command)
7. Confirm that the github pages display properly, and that the links work. 

# Interested parties
@awoods @aurora-charlow @ebenenglish 
